### PR TITLE
update predict script arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,94 +2,107 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8]
-        mmdet-version : [2.8.0, 2.9.0]
+        mmdet-version: [2.8.0, 2.9.0]
       fail-fast: false
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Restore Ubuntu cache
-      uses: actions/cache@v1
-      if: matrix.operating-system == 'ubuntu-latest'
-      with:
-        path: ~/.cache/pip
-        key: ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')}}
-        restore-keys: ${{ matrix.os }}-${{ matrix.python-version }}-
-    - name: Restore MacOS cache
-      uses: actions/cache@v1
-      if:  matrix.operating-system == 'macos-latest'
-      with:
-        path: ~/Library/Caches/pip
-        key: ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')}}
-        restore-keys: ${{ matrix.os }}-${{ matrix.python-version }}-
-    - name: Restore Windows cache
-      uses: actions/cache@v1
-      if: matrix.operating-system == 'windows-latest'
-      with:
-        path: ~\AppData\Local\pip\Cache
-        key: ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')}}
-        restore-keys: ${{ matrix.os }}-${{ matrix.python-version }}-
-    - name: Update pip
-      run: python -m pip install --upgrade pip
-    - name: Install dependencies
-      run: >
-        pip install -r requirements.txt
-    - name: Install PyTorch on Linux and Windows
-      if: >
-        matrix.operating-system == 'ubuntu-latest' ||
-        matrix.operating-system == 'windows-latest'
-      run: >
-        pip install torch==1.7.1+cpu torchvision==0.8.2+cpu
-        -f https://download.pytorch.org/whl/torch_stable.html
-    - name: Install PyTorch on MacOS
-      if: matrix.operating-system == 'macos-latest'
-      run: pip install torch==1.7.1 torchvision==0.8.2
-    - name: Install MMDetection
-      run: >
-        pip install mmcv-full==1.2.5 mmdet==${{ matrix.mmdet-version }}
-    - name: Lint with flake8
-      run: |
-        pip install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with unittest
-      run: |
-        pip install pytest
-        python -m unittest
-    - name: Install SAHI package from local setup.py
-      run: >
-        pip install -e .
-    - name: Test SAHI scripts for mmdet < 2.9.0
-      if: matrix.mmdet-version == '2.8.0'
-      run: |
-        # predict
-        python scripts/predict.py --source tests/data/ --visual --model_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_2x_coco_20200131-fdb43119.pth --config_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_1x_coco.py
-        python scripts/predict.py --source tests/data/coco_utils/terrain1.jpg --pickle --crop --model_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_2x_coco_20200131-fdb43119.pth --config_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_1x_coco.py
-        python scripts/predict.py --source tests/data/coco_utils/ --coco_file tests/data/coco_utils/combined_coco.json --model_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_2x_coco_20200131-fdb43119.pth --config_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_1x_coco.py
-    - name: Test SAHI scripts for mmdet == 2.9.0
-      if: matrix.mmdet-version == '2.9.0'
-      run: |
-        # predict
-        python scripts/predict.py --source tests/data/ --visual --model_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_2x_coco_20200131-fdb43119.pth --config_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_1x_coco_v290.py
-        python scripts/predict.py --source tests/data/coco_utils/terrain1.jpg --pickle --crop --model_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_2x_coco_20200131-fdb43119.pth --config_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_1x_coco_v290.py
-        python scripts/predict.py --source tests/data/coco_utils/ --coco_file tests/data/coco_utils/combined_coco.json --model_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_2x_coco_20200131-fdb43119.pth --config_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_1x_coco_v290.py
-        # coco2yolov5
-        python scripts/coco2yolov5.py --source tests/data/coco_utils/ --coco_file tests/data/coco_utils/combined_coco.json --train_split 0.9
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Restore Ubuntu cache
+        uses: actions/cache@v1
+        if: matrix.operating-system == 'ubuntu-latest'
+        with:
+          path: ~/.cache/pip
+          key: ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')}}
+          restore-keys: ${{ matrix.os }}-${{ matrix.python-version }}-
+
+      - name: Restore MacOS cache
+        uses: actions/cache@v1
+        if: matrix.operating-system == 'macos-latest'
+        with:
+          path: ~/Library/Caches/pip
+          key: ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')}}
+          restore-keys: ${{ matrix.os }}-${{ matrix.python-version }}-
+
+      - name: Restore Windows cache
+        uses: actions/cache@v1
+        if: matrix.operating-system == 'windows-latest'
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')}}
+          restore-keys: ${{ matrix.os }}-${{ matrix.python-version }}-
+
+      - name: Update pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install dependencies
+        run: >
+          pip install -r requirements.txt
+
+      - name: Install PyTorch on Linux and Windows
+        if: >
+          matrix.operating-system == 'ubuntu-latest' ||
+          matrix.operating-system == 'windows-latest'
+        run: >
+          pip install torch==1.7.1+cpu torchvision==0.8.2+cpu
+          -f https://download.pytorch.org/whl/torch_stable.html
+
+      - name: Install PyTorch on MacOS
+        if: matrix.operating-system == 'macos-latest'
+        run: pip install torch==1.7.1 torchvision==0.8.2
+
+      - name: Install MMDetection
+        run: >
+          pip install mmcv-full==1.2.5 mmdet==${{ matrix.mmdet-version }}
+
+      - name: Lint with flake8
+        run: |
+          pip install flake8
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+      - name: Test with unittest
+        run: |
+          pip install pytest
+          python -m unittest
+
+      - name: Install SAHI package from local setup.py
+        run: >
+          pip install -e .
+
+      - name: Test SAHI scripts for mmdet < 2.9.0
+        if: matrix.mmdet-version == '2.8.0'
+        run: |
+          # predict
+          python scripts/predict.py --source tests/data/ --model_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_2x_coco_20200131-fdb43119.pth --config_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_1x_coco.py
+          python scripts/predict.py --source tests/data/coco_utils/terrain1.jpg --novisual --pickle --crop --model_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_2x_coco_20200131-fdb43119.pth --config_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_1x_coco.py
+          python scripts/predict.py --source tests/data/coco_utils/ --coco_file tests/data/coco_utils/combined_coco.json --model_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_2x_coco_20200131-fdb43119.pth --config_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_1x_coco.py
+
+      - name: Test SAHI scripts for mmdet == 2.9.0
+        if: matrix.mmdet-version == '2.9.0'
+        run: |
+          # predict
+          python scripts/predict.py --source tests/data/ --model_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_2x_coco_20200131-fdb43119.pth --config_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_1x_coco_v290.py
+          python scripts/predict.py --source tests/data/coco_utils/terrain1.jpg --novisual --pickle --crop --model_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_2x_coco_20200131-fdb43119.pth --config_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_1x_coco_v290.py
+          python scripts/predict.py --source tests/data/coco_utils/ --coco_file tests/data/coco_utils/combined_coco.json --model_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_2x_coco_20200131-fdb43119.pth --config_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_1x_coco_v290.py
+          # coco2yolov5
+          python scripts/coco2yolov5.py --source tests/data/coco_utils/ --coco_file tests/data/coco_utils/combined_coco.json --train_split 0.9

--- a/.github/workflows/package_testing.yml
+++ b/.github/workflows/package_testing.yml
@@ -2,82 +2,94 @@ name: Package Testing
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Runs at 00:00 UTC every day
+    - cron: '0 0 * * *' # Runs at 00:00 UTC every day
 
 jobs:
   build:
     runs-on: ubuntu-latest
-  
+
     strategy:
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8]
-        mmdet-version : [2.8.0, 2.9.0]
+        mmdet-version: [2.8.0, 2.9.0]
       fail-fast: false
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Restore Ubuntu cache
-      uses: actions/cache@v1
-      if: matrix.operating-system == 'ubuntu-latest'
-      with:
-        path: ~/.cache/pip
-        key: ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')}}
-        restore-keys: ${{ matrix.os }}-${{ matrix.python-version }}-
-    - name: Restore MacOS cache
-      uses: actions/cache@v1
-      if:  matrix.operating-system == 'macos-latest'
-      with:
-        path: ~/Library/Caches/pip
-        key: ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')}}
-        restore-keys: ${{ matrix.os }}-${{ matrix.python-version }}-
-    - name: Restore Windows cache
-      uses: actions/cache@v1
-      if: matrix.operating-system == 'windows-latest'
-      with:
-        path: ~\AppData\Local\pip\Cache
-        key: ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')}}
-        restore-keys: ${{ matrix.os }}-${{ matrix.python-version }}-
-    - name: Update pip
-      run: python -m pip install --upgrade pip
-    - name: Install latest SAHI package
-      run: >
-        pip install --upgrade --force-reinstall sahi
-    - name: Install PyTorch on Linux and Windows
-      if: >
-        matrix.operating-system == 'ubuntu-latest' ||
-        matrix.operating-system == 'windows-latest'
-      run: >
-        pip install torch==1.7.1+cpu torchvision==0.8.2+cpu
-        -f https://download.pytorch.org/whl/torch_stable.html
-    - name: Install PyTorch on MacOS
-      if: matrix.operating-system == 'macos-latest'
-      run: pip install torch==1.7.1 torchvision==0.8.2
-    - name: Install MMDetection
-      run: >
-        pip install mmcv-full==1.2.5 mmdet==${{ matrix.mmdet-version }}
-    - name: Test with unittest
-      run: |
-        pip install pytest
-        python -m unittest
-    - name: Test SAHI scripts for mmdet < 2.9.0
-      if: matrix.mmdet-version == '2.8.0'
-      run: |
-        # predict
-        python scripts/predict.py --source tests/data/ --visual --model_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_2x_coco_20200131-fdb43119.pth --config_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_1x_coco.py
-        python scripts/predict.py --source tests/data/coco_utils/terrain1.jpg --pickle --crop --model_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_2x_coco_20200131-fdb43119.pth --config_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_1x_coco.py
-        python scripts/predict.py --source tests/data/coco_utils/ --coco_file tests/data/coco_utils/combined_coco.json --model_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_2x_coco_20200131-fdb43119.pth --config_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_1x_coco.py
-    - name: Test SAHI scripts for mmdet == 2.9.0
-      if: matrix.mmdet-version == '2.9.0'
-      run: |
-        # predict
-        python scripts/predict.py --source tests/data/ --visual --model_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_2x_coco_20200131-fdb43119.pth --config_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_1x_coco_v290.py
-        python scripts/predict.py --source tests/data/coco_utils/terrain1.jpg --pickle --crop --model_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_2x_coco_20200131-fdb43119.pth --config_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_1x_coco_v290.py
-        python scripts/predict.py --source tests/data/coco_utils/ --coco_file tests/data/coco_utils/combined_coco.json --model_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_2x_coco_20200131-fdb43119.pth --config_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_1x_coco_v290.py
-        # coco2yolov5
-        python scripts/coco2yolov5.py --source tests/data/coco_utils/ --coco_file tests/data/coco_utils/combined_coco.json --train_split 0.9
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Restore Ubuntu cache
+        uses: actions/cache@v1
+        if: matrix.operating-system == 'ubuntu-latest'
+        with:
+          path: ~/.cache/pip
+          key: ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')}}
+          restore-keys: ${{ matrix.os }}-${{ matrix.python-version }}-
+
+      - name: Restore MacOS cache
+        uses: actions/cache@v1
+        if: matrix.operating-system == 'macos-latest'
+        with:
+          path: ~/Library/Caches/pip
+          key: ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')}}
+          restore-keys: ${{ matrix.os }}-${{ matrix.python-version }}-
+
+      - name: Restore Windows cache
+        uses: actions/cache@v1
+        if: matrix.operating-system == 'windows-latest'
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')}}
+          restore-keys: ${{ matrix.os }}-${{ matrix.python-version }}-
+
+      - name: Update pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install latest SAHI package
+        run: >
+          pip install --upgrade --force-reinstall sahi
+
+      - name: Install PyTorch on Linux and Windows
+        if: >
+          matrix.operating-system == 'ubuntu-latest' ||
+          matrix.operating-system == 'windows-latest'
+        run: >
+          pip install torch==1.7.1+cpu torchvision==0.8.2+cpu
+          -f https://download.pytorch.org/whl/torch_stable.html
+
+      - name: Install PyTorch on MacOS
+        if: matrix.operating-system == 'macos-latest'
+        run: pip install torch==1.7.1 torchvision==0.8.2
+
+      - name: Install MMDetection
+        run: >
+          pip install mmcv-full==1.2.5 mmdet==${{ matrix.mmdet-version }}
+
+      - name: Test with unittest
+        run: |
+          pip install pytest
+          python -m unittest
+
+      - name: Test SAHI scripts for mmdet < 2.9.0
+        if: matrix.mmdet-version == '2.8.0'
+        run: |
+          # predict
+          python scripts/predict.py --source tests/data/--model_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_2x_coco_20200131-fdb43119.pth --config_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_1x_coco.py
+          python scripts/predict.py --source tests/data/coco_utils/terrain1.jpg --novisual --pickle --crop --model_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_2x_coco_20200131-fdb43119.pth --config_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_1x_coco.py
+          python scripts/predict.py --source tests/data/coco_utils/ --coco_file tests/data/coco_utils/combined_coco.json --model_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_2x_coco_20200131-fdb43119.pth --config_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_1x_coco.py
+
+      - name: Test SAHI scripts for mmdet == 2.9.0
+        if: matrix.mmdet-version == '2.9.0'
+        run: |
+          # predict
+          python scripts/predict.py --source tests/data/--model_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_2x_coco_20200131-fdb43119.pth --config_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_1x_coco_v290.py
+          python scripts/predict.py --source tests/data/coco_utils/terrain1.jpg --novisual --pickle --crop --model_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_2x_coco_20200131-fdb43119.pth --config_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_1x_coco_v290.py
+          python scripts/predict.py --source tests/data/coco_utils/ --coco_file tests/data/coco_utils/combined_coco.json --model_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_2x_coco_20200131-fdb43119.pth --config_path tests/data/models/mmdet_retinanet/retinanet_r50_fpn_1x_coco_v290.py
+          # coco2yolov5
+          python scripts/coco2yolov5.py --source tests/data/coco_utils/ --coco_file tests/data/coco_utils/combined_coco.json --train_split 0.9

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Object detection and instance segmentation are by far the most important fields 
 
 Check the [official SAHI blog post](https://medium.com/codable/sahi-a-vision-library-for-performing-sliced-inference-on-large-images-small-objects-c8b086af3b80).
 
-
 ### Installation
 
 - Install sahi using conda:
@@ -34,11 +33,13 @@ pip install sahi
 ```
 
 - Install your desired version of pytorch and torchvision:
+
 ```console
 pip install torch torchvision
 ```
 
 - Install your desired detection framework (such as mmdet):
+
 ```console
 pip install mmdet
 ```
@@ -46,6 +47,7 @@ pip install mmdet
 ## Usage
 
 - Sliced inference:
+
 ```python
 result = get_sliced_prediction(
     image,
@@ -57,9 +59,11 @@ result = get_sliced_prediction(
 )
 
 ```
+
 Refer to [inference notebook](demo/inference.ipynb) for detailed usage.
 
 - Slice an image:
+
 ```python
 from sahi.slicing import slice_image
 
@@ -75,6 +79,7 @@ slice_image_result, num_total_invalid_segmentation = slice_image(
 ```
 
 - Slice a coco formatted dataset:
+
 ```python
 from sahi.slicing import slice_coco
 
@@ -88,14 +93,48 @@ coco_dict, coco_path = slice_coco(
 )
 ```
 
+- `predict.py` script usage:
+
+```bash
+python scripts/predict.py --source image/file/or/folder --model_path path/to/model --config_path path/to/config
+```
+
+will perform sliced inference on default parameters and export the prediction visuals to runs/predict/exp folder.
+
+You can specify sliced inference parameters as:
+
+```bash
+python scripts/predict.py --slice_width 256 --slice_height 256 --overlap_height_ratio 0.1 --overlap_width_ratio 0.1 --iou_thresh 0.25 --source image/file/or/folder --model_path path/to/model --config_path path/to/config
+```
+
+If you want to export prediction pickles and cropped predictions add `--pickle` and `--crop` arguments. If you want to change crop extension type, set it as `--visual_export_format JPG`.
+
+If you want to perform standard prediction instead of sliced prediction, add `--standard_pred` argument.
+
+```bash
+python scripts/predict.py --coco_file path/to/coco/file --source coco/images/directory --model_path path/to/model --config_path path/to/config
+```
+
+will perform inference using provided coco file, then export results as a coco json file to runs/predict/exp/results.json
+
+If you don't want to export prediction visuals, add `--novisual` argument.
+
+- `coco2yolov5.py` script usage:
+
+```bash
+python scripts/coco2yolov5.py --coco_file path/to/coco/file --source coco/images/directory --train_split 0.9
+```
+
+will convert given coco dataset to yolov5 format and export to runs/coco2yolov5/exp folder .
+
 ## Adding new detection framework support
 
 sahi library currently only supports [MMDetection models](https://github.com/open-mmlab/mmdetection/blob/master/docs/model_zoo.md). However it is easy to add new frameworks.
 
 All you need to do is, creating a new class in [model.py](sahi/model.py) that implements [DetectionModel class](https://github.com/obss/sahi/blob/651f8e6cdb20467815748764bb198dd50241ab2b/sahi/model.py#L10). You can take the [MMDetection wrapper](https://github.com/obss/sahi/blob/651f8e6cdb20467815748764bb198dd50241ab2b/sahi/model.py#L164) as a reference.
 
-
 ## Contributers
+
 - [Fatih Cagatay Akyon](https://github.com/fcakyon)
 - [Cemil Cengiz](https://github.com/cemilcengiz)
 - [Sinan Onur Altinuc](https://github.com/sinanonur)

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
         help="perform detection from coco file and export results in coco json format",
     )
     parser.add_argument(
-        "--standard_pred", action="store_false", help="dont apply sliced prediction"
+        "--standard_pred", action="store_true", help="dont apply sliced prediction"
     )
     parser.add_argument("--slice_height", type=int, default=512)
     parser.add_argument("--slice_width", type=int, default=512)

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--name", default="exp", help="save results to project/name")
     parser.add_argument(
-        "--visual", action="store_true", help="export prediction visualizations"
+        "--novisual", action="store_true", help="export prediction visualizations"
     )
     parser.add_argument(
         "--pickle", action="store_true", help="export predictions as .pickle"
@@ -67,7 +67,7 @@ if __name__ == "__main__":
         help="perform detection from coco file and export results in coco json format",
     )
     parser.add_argument(
-        "--sliced_pred", action="store_false", help="apply sliced prediction"
+        "--standard_pred", action="store_false", help="dont apply sliced prediction"
     )
     parser.add_argument("--slice_height", type=int, default=512)
     parser.add_argument("--slice_width", type=int, default=512)
@@ -92,11 +92,11 @@ if __name__ == "__main__":
         source=opt.source,
         project=opt.project,
         name=opt.name,
-        export_visual=opt.visual,
+        export_visual=not (opt.novisual),
         export_pickle=opt.pickle,
         export_crop=opt.crop,
         coco_file_path=opt.coco_file,
-        apply_sliced_prediction=opt.sliced_pred,
+        apply_sliced_prediction=not (opt.standard_pred),
         slice_height=opt.slice_height,
         slice_width=opt.slice_width,
         overlap_height_ratio=opt.overlap_height_ratio,


### PR DESCRIPTION
- `predict.py` script usage:

```bash
python scripts/predict.py --source image/file/or/folder --model_path path/to/model --config_path path/to/config
```

will perform sliced inference on default parameters and export the prediction visuals to runs/predict/exp folder.

You can specify sliced inference parameters as:

```bash
python scripts/predict.py --slice_width 256 --slice_height 256 --overlap_height_ratio 0.1 --overlap_width_ratio 0.1 --iou_thresh 0.25 --source image/file/or/folder --model_path path/to/model --config_path path/to/config
```

If you want to export prediction pickles and cropped predictions add `--pickle` and `--crop` arguments. If you want to change crop extension type, set it as `--visual_export_format JPG`.

If you want to perform standard prediction instead of sliced prediction, add `--standard_pred` argument.

```bash
python scripts/predict.py --coco_file path/to/coco/file --source coco/images/directory --model_path path/to/model --config_path path/to/config
```

will perform inference using provided coco file, then export results as a coco json file to runs/predict/exp/results.json

If you don't want to export prediction visuals, add `--novisual` argument.

- `coco2yolov5.py` script usage:

```bash
python scripts/coco2yolov5.py --coco_file path/to/coco/file --source coco/images/directory --train_split 0.9
```

will convert given coco dataset to yolov5 format and export to runs/coco2yolov5/exp folder .