### PR TITLE
add get_area_filtered_coco method to Coco class

### DIFF
--- a/docs/COCO.md
+++ b/docs/COCO.md
@@ -123,6 +123,24 @@ coco.update_categories(desired_name2id)
 save_json(coco.json, "updated_coco.json")
 ```
 
+## Filter COCO dataset by annotation area:
+
+```python
+from sahi.utils.coco import Coco
+from sahi.utils.file import save_json
+
+# init Coco objects by specifying coco dataset paths and image folder directories
+coco = Coco.from_coco_dict_or_path("coco.json")
+
+# filter out images that contain annotations with smaller area than 50
+area_filtered_coco = coco.get_area_filtered_coco(min=50)
+# filter out images that contain annotations with smaller area than 50 and larger area than 10000
+area_filtered_coco = coco.get_area_filtered_coco(min=50, max=10000)
+
+# export filtered COCO dataset
+save_json(area_filtered_coco.json, "area_filtered_coco.json")
+```
+
 ## Merge COCO dataset files:
 
 ```python

--- a/sahi/utils/coco.py
+++ b/sahi/utils/coco.py
@@ -1195,7 +1195,7 @@ class Coco:
         with open(yaml_path, "w") as outfile:
             yaml.dump(data, outfile, default_flow_style=None)
 
-    def get_subsampled_coco(self, subsample_ratio=10):
+    def get_subsampled_coco(self, subsample_ratio=2):
         """
         Subsamples images with subsample_ratio and returns as sahi.utils.coco.Coco object.
 
@@ -1211,7 +1211,7 @@ class Coco:
             remapping_dict=self.remapping_dict
         )
         subsampled_coco.add_categories_from_coco_category_list(self.json_categories)
-        for image_ind in tqdm(range(0, len(self.images), subsample_ratio)):
+        for image_ind in range(0, len(self.images), subsample_ratio):
             subsampled_coco.add_image(self.images[image_ind])
 
         return subsampled_coco
@@ -1230,6 +1230,7 @@ def export_yolov5_images_and_txts_from_coco_object(
             Initialized Coco object that contains images and categories.
     """
 
+    print('generating image symlinks and annotation files for yolov5...')
     for image in tqdm(coco.images):
         # set coco and yolo image paths
         if Path(image.file_name).is_file():
@@ -1694,7 +1695,7 @@ def split_coco_as_train_val(
     train_annotations = list()
     val_annotations = list()
     print("splitting coco dataset into train/val...")
-    for annotation in tqdm(coco_dict["annotations"]):
+    for annotation in coco_dict["annotations"]:
         image_index_for_annotation = image_id_2_idx[annotation["image_id"]]
         if image_index_for_annotation in train_indices:
             train_annotations.append(annotation)

--- a/tests/test_cocoutils.py
+++ b/tests/test_cocoutils.py
@@ -605,6 +605,38 @@ class TestCocoUtils(unittest.TestCase):
         self.assertEqual(subsampled_coco.stats["num_images"], len(subsampled_coco.images))
         self.assertEqual(subsampled_coco.stats["num_annotations"], len(subsampled_coco.json["annotations"]))
 
+    def test_get_area_filtered_coco(self):
+        from sahi.utils.coco import Coco
+
+        coco_path = "tests/data/coco_utils/visdrone2019-det-train-first50image.json"
+        image_dir = "tests/data/coco_utils/"
+        min_area = 50
+        max_area = 10000
+        coco = Coco.from_coco_dict_or_path(coco_path, image_dir=image_dir)
+        area_filtered_coco = coco.get_area_filtered_coco(min=min_area, max=max_area)
+        self.assertEqual(
+            len(coco.json["images"]),
+            50,
+        )
+        self.assertEqual(
+            len(area_filtered_coco.json["images"]),
+            15,
+        )
+        self.assertGreater(
+            area_filtered_coco.stats["min_annotation_area"],
+            min_area,
+        )
+        self.assertLess(
+            area_filtered_coco.stats["max_annotation_area"],
+            max_area,
+        )
+        self.assertEqual(
+            area_filtered_coco.image_dir,
+            image_dir,
+        )
+        self.assertEqual(area_filtered_coco.stats["num_images"], len(area_filtered_coco.images))
+        self.assertEqual(area_filtered_coco.stats["num_annotations"], len(area_filtered_coco.json["annotations"]))
+
     def test_cocovid(self):
         from sahi.utils.coco import CocoVid
 


### PR DESCRIPTION
## Filter COCO dataset by annotation area:

```python
from sahi.utils.coco import Coco
from sahi.utils.file import save_json

# init Coco objects by specifying coco dataset paths and image folder directories
coco = Coco.from_coco_dict_or_path("coco.json")

# filter out images that contain annotations with smaller area than 50
area_filtered_coco = coco.get_area_filtered_coco(min=50)
# filter out images that contain annotations with smaller area than 50 and larger area than 10000
area_filtered_coco = coco.get_area_filtered_coco(min=50, max=10000)

# export filtered COCO dataset
save_json(area_filtered_coco.json, "area_filtered_coco.json")
```