### PR TITLE
improve .stats

### DIFF
--- a/docs/COCO.md
+++ b/docs/COCO.md
@@ -215,23 +215,20 @@ coco = Coco.from_coco_dict_or_path("coco.json")
 # get dataset stats
 coco.stats
 {
-    'avg_annotation_area': 2448.405738278109,
-    'avg_num_annotations_in_image': 53.037243084530985,
-    'max_annotation_area': 328640,
-    'max_num_annotations_in_image': 902,
-    'min_annotation_area': 3,
-    'min_num_annotations_in_image': 1,
-    'num_annotations': 343204,
-    'num_annotations_per_category': {
-        'human': 106396,
-        'vehicle': 236808
-    },
-    'num_categories': 2,
-    'num_images': 6471,
-    'num_images_per_category': {
-        'human': 5684,
-        'vehicle': 6323
-    }
+  'num_images': 6471,
+  'num_annotations': 343204,
+  'num_categories': 2,
+  'num_negative_images': 0,
+  'num_images_per_category': {'human': 5684, 'vehicle': 6323},
+  'num_annotations_per_category': {'human': 106396, 'vehicle': 236808},
+  'min_num_annotations_in_image': 1,
+  'max_num_annotations_in_image': 902,
+  'avg_num_annotations_in_image': 53.037243084530985,
+  'min_annotation_area': 3,
+  'max_annotation_area': 328640,
+  'avg_annotation_area': 2448.405738278109,
+  'min_annotation_area_per_category': {'human': 3, 'vehicle': 3},
+  'max_annotation_area_per_category': {'human': 72670, 'vehicle': 328640},
 }
 
 ```

--- a/sahi/utils/coco.py
+++ b/sahi/utils/coco.py
@@ -1044,10 +1044,10 @@ class Coco:
                     max_annotation_area = annotation_area
                 if annotation_area<min_annotation_area:
                     min_annotation_area = annotation_area
-                if annotation_area>max_area_per_category[annotation.category_name]:
-                    max_area_per_category[annotation.category_name] = annotation_area
-                if annotation_area<min_area_per_category[annotation.category_name]:
-                    min_area_per_category[annotation.category_name] = annotation_area
+                if annotation_area>max_annotation_area_per_category[annotation.category_name]:
+                    max_annotation_area_per_category[annotation.category_name] = annotation_area
+                if annotation_area<min_annotation_area_per_category[annotation.category_name]:
+                    min_annotation_area_per_category[annotation.category_name] = annotation_area
             # update num_negative_images
             if len(image.annotations) == 0:
                 num_negative_images += 1
@@ -1079,8 +1079,8 @@ class Coco:
             "min_annotation_area": min_annotation_area,
             "max_annotation_area": max_annotation_area,
             "avg_annotation_area": avg_annotation_area,
-            "min_area_per_category": min_area_per_category,
-            "max_area_per_category": max_area_per_category,
+            "min_annotation_area_per_category": min_annotation_area_per_category,
+            "max_annotation_area_per_category": max_annotation_area_per_category,
         }
 
     def split_coco_as_train_val(

--- a/sahi/utils/coco.py
+++ b/sahi/utils/coco.py
@@ -1016,15 +1016,17 @@ class Coco:
         """
         Iterates over all annotations and calculates total number of
         """
+        # init all stats
         num_annotations = 0
         num_images = len(self.images)
         num_negative_images = 0
         num_categories = len(self.json_categories)
         category_name_to_zero = {category["name"]:0 for category in self.json_categories}
+        category_name_to_inf = {category["name"]:float('inf') for category in self.json_categories}
         num_images_per_category = copy.deepcopy(category_name_to_zero)
         num_annotations_per_category = copy.deepcopy(category_name_to_zero)
-        min_area_per_category = copy.deepcopy(category_name_to_zero)
-        max_area_per_category = copy.deepcopy(category_name_to_zero)
+        min_annotation_area_per_category = copy.deepcopy(category_name_to_inf)
+        max_annotation_area_per_category = copy.deepcopy(category_name_to_zero)
         min_num_annotations_in_image = float('inf')
         max_num_annotations_in_image = 0
         total_annotation_area = 0
@@ -1061,7 +1063,7 @@ class Coco:
                 max_num_annotations_in_image = num_annotations_in_image
             if num_annotations_in_image<min_num_annotations_in_image:
                 min_num_annotations_in_image = num_annotations_in_image
-        avg_num_annotations_in_image = num_annotations/num_images
+        avg_num_annotations_in_image = num_annotations/(num_images-num_negative_images)
         avg_annotation_area = total_annotation_area/num_annotations
 
         self._stats = {

--- a/sahi/utils/coco.py
+++ b/sahi/utils/coco.py
@@ -1018,6 +1018,7 @@ class Coco:
         """
         num_annotations = 0
         num_images = len(self.images)
+        num_negative_images = 0
         num_categories = len(self.json_categories)
         category_name_to_zero = {category["name"]:0 for category in self.json_categories}
         num_images_per_category = copy.deepcopy(category_name_to_zero)
@@ -1039,6 +1040,9 @@ class Coco:
                     max_annotation_area = annotation_area
                 if annotation_area<min_annotation_area:
                     min_annotation_area = annotation_area
+            # update num_negative_images
+            if len(image.annotations) == 0:
+                num_negative_images += 1
             # update num_annotations
             num_annotations += len(image.annotations)
             # update num_images_per_category
@@ -1058,6 +1062,7 @@ class Coco:
             "num_images": num_images,
             "num_annotations": num_annotations,
             "num_categories": num_categories,
+            "num_negative_images": num_negative_images,
             "num_images_per_category": num_images_per_category,
             "num_annotations_per_category": num_annotations_per_category,
             "min_num_annotations_in_image": min_num_annotations_in_image,

--- a/sahi/utils/coco.py
+++ b/sahi/utils/coco.py
@@ -1023,6 +1023,8 @@ class Coco:
         category_name_to_zero = {category["name"]:0 for category in self.json_categories}
         num_images_per_category = copy.deepcopy(category_name_to_zero)
         num_annotations_per_category = copy.deepcopy(category_name_to_zero)
+        min_area_per_category = copy.deepcopy(category_name_to_zero)
+        max_area_per_category = copy.deepcopy(category_name_to_zero)
         min_num_annotations_in_image = float('inf')
         max_num_annotations_in_image = 0
         total_annotation_area = 0
@@ -1040,6 +1042,10 @@ class Coco:
                     max_annotation_area = annotation_area
                 if annotation_area<min_annotation_area:
                     min_annotation_area = annotation_area
+                if annotation_area>max_area_per_category[annotation.category_name]:
+                    max_area_per_category[annotation.category_name] = annotation_area
+                if annotation_area<min_area_per_category[annotation.category_name]:
+                    min_area_per_category[annotation.category_name] = annotation_area
             # update num_negative_images
             if len(image.annotations) == 0:
                 num_negative_images += 1
@@ -1070,7 +1076,9 @@ class Coco:
             "avg_num_annotations_in_image": avg_num_annotations_in_image,
             "min_annotation_area": min_annotation_area,
             "max_annotation_area": max_annotation_area,
-            "avg_annotation_area": avg_annotation_area
+            "avg_annotation_area": avg_annotation_area,
+            "min_area_per_category": min_area_per_category,
+            "max_area_per_category": max_area_per_category,
         }
 
     def split_coco_as_train_val(


### PR DESCRIPTION
fixes #81 

## Get dataset stats:

```python
from sahi.utils.coco import Coco

# init Coco object
coco = Coco.from_coco_dict_or_path("coco.json")

# get dataset stats
coco.stats
{
  'num_images': 6471,
  'num_annotations': 343204,
  'num_categories': 2,
  'num_negative_images': 0,
  'num_images_per_category': {'human': 5684, 'vehicle': 6323},
  'num_annotations_per_category': {'human': 106396, 'vehicle': 236808},
  'min_num_annotations_in_image': 1,
  'max_num_annotations_in_image': 902,
  'avg_num_annotations_in_image': 53.037243084530985,
  'min_annotation_area': 3,
  'max_annotation_area': 328640,
  'avg_annotation_area': 2448.405738278109,
  'min_annotation_area_per_category': {'human': 3, 'vehicle': 3},
  'max_annotation_area_per_category': {'human': 72670, 'vehicle': 328640},
}

```