### PR TITLE
utilize ignore_negative_samples property

### DIFF
--- a/docs/COCO.md
+++ b/docs/COCO.md
@@ -147,6 +147,16 @@ area_filtered_coco = coco.get_area_filtered_coco(intervals_per_category=interval
 save_json(area_filtered_coco.json, "area_filtered_coco.json")
 ```
 
+## Filter out images that does not contain any annotation
+
+```python
+from sahi.utils.coco import Coco
+
+# set ignore_negative_samples as False if you want images without annotations present in json and yolov5 exports
+coco = Coco.from_coco_dict_or_path("coco.json", ignore_negative_samples=True)
+
+```
+
 ## Merge COCO dataset files:
 
 ```python

--- a/sahi/utils/coco.py
+++ b/sahi/utils/coco.py
@@ -737,7 +737,7 @@ class CocoVideo:
 
 
 class Coco:
-    def __init__(self, name=None, image_dir=None, remapping_dict=None, ignore_negative_samples=True):
+    def __init__(self, name=None, image_dir=None, remapping_dict=None, ignore_negative_samples=False):
         """
         Creates Coco object.
 
@@ -919,7 +919,7 @@ class Coco:
             )
 
     @classmethod
-    def from_coco_dict_or_path(cls, coco_dict_or_path, desired_name2id=None, image_dir=None, remapping_dict=None, ignore_negative_samples=True, mp=False):
+    def from_coco_dict_or_path(cls, coco_dict_or_path, desired_name2id=None, image_dir=None, remapping_dict=None, ignore_negative_samples=False, mp=False):
         """
         Creates coco object from COCO formatted dict or COCO dataset file path.
 
@@ -1288,7 +1288,7 @@ class Coco:
 
 
 def export_yolov5_images_and_txts_from_coco_object(
-    output_dir, coco, ignore_negative_samples=True, mp=False
+    output_dir, coco, ignore_negative_samples=False, mp=False
 ):
     """
     Creates image symlinks and annotation txts in yolo format from coco dataset.
@@ -1314,7 +1314,7 @@ def export_yolov5_images_and_txts_from_coco_object(
         for coco_image in tqdm(coco.images):
             export_single_yolov5_image_and_corresponding_txt(coco_image, coco.image_dir, output_dir, ignore_negative_samples)
 
-def export_single_yolov5_image_and_corresponding_txt(coco_image, coco_image_dir, output_dir, ignore_negative_samples=True):
+def export_single_yolov5_image_and_corresponding_txt(coco_image, coco_image_dir, output_dir, ignore_negative_samples=False):
     """
     Generates yolov5 formatted image symlink and annotation txt file.
 
@@ -1655,7 +1655,7 @@ def get_imageid2annotationlist_mapping(coco_dict: dict) -> dict:
     return imageid2annotationlist_mapping
 
 
-def create_coco_dict(images, categories, ignore_negative_samples=True):
+def create_coco_dict(images, categories, ignore_negative_samples=False):
     """
     Creates COCO dict with fields "images", "annotations", "categories".
 

--- a/sahi/utils/coco.py
+++ b/sahi/utils/coco.py
@@ -919,7 +919,7 @@ class Coco:
             )
 
     @classmethod
-    def from_coco_dict_or_path(cls, coco_dict_or_path, desired_name2id=None, image_dir=None, remapping_dict=None, mp=False):
+    def from_coco_dict_or_path(cls, coco_dict_or_path, desired_name2id=None, image_dir=None, remapping_dict=None, ignore_negative_samples=True, mp=False):
         """
         Creates coco object from COCO formatted dict or COCO dataset file path.
 
@@ -933,6 +933,8 @@ class Coco:
                 Base file directory that contains dataset images. Required for merging and yolov5 conversion.
             remapping_dict: dict
                 {1:0, 2:1} maps category id 1 to 0 and category id 2 to 1
+            ignore_negative_samples: bool
+                If True ignores images without annotations in all operations.
             mp: bool
                 If True, multiprocess mode is on.
                 Should be called in 'if __name__ == __main__:' block.

--- a/tests/test_cocoutils.py
+++ b/tests/test_cocoutils.py
@@ -665,6 +665,35 @@ class TestCocoUtils(unittest.TestCase):
         )
         self.assertEqual(area_filtered_coco.stats["num_images"], len(area_filtered_coco.images))
         self.assertEqual(area_filtered_coco.stats["num_annotations"], len(area_filtered_coco.json["annotations"]))
+        
+        intervals_per_category = {
+            "human": {"min": 20, "max": 10000},
+            "vehicle": {"min": 50, "max": 15000},
+            }
+        area_filtered_coco = coco.get_area_filtered_coco(intervals_per_category=intervals_per_category)
+
+        self.assertEqual(
+            len(coco.json["images"]),
+            50,
+        )
+        self.assertEqual(
+            len(area_filtered_coco.json["images"]),
+            22,
+        )
+        self.assertGreater(
+            area_filtered_coco.stats["min_annotation_area"],
+            min(intervals_per_category["human"]["min"], intervals_per_category["vehicle"]["min"]),
+        )
+        self.assertLess(
+            area_filtered_coco.stats["max_annotation_area"],
+            max(intervals_per_category["human"]["max"], intervals_per_category["vehicle"]["max"]),
+        )
+        self.assertEqual(
+            area_filtered_coco.image_dir,
+            image_dir,
+        )
+        self.assertEqual(area_filtered_coco.stats["num_images"], len(area_filtered_coco.images))
+        self.assertEqual(area_filtered_coco.stats["num_annotations"], len(area_filtered_coco.json["annotations"]))
 
     def test_cocovid(self):
         from sahi.utils.coco import CocoVid


### PR DESCRIPTION
```python
from sahi.utils.coco import Coco

# set ignore_negative_samples as True if you want to discard images without annotations in json and yolov5 exports
coco = Coco.from_coco_dict_or_path("coco.json", ignore_negative_samples=True)

```