### PR TITLE
minor refactorization, export visuals with gt

### DIFF
--- a/sahi/annotation.py
+++ b/sahi/annotation.py
@@ -20,12 +20,12 @@ class BoundingBox:
     Bounding box of the annotation.
     """
 
-    def __init__(self, box: list, shift_amount: list = [0, 0]):
+    def __init__(self, box: List[int], shift_amount: List[int] = [0, 0]):
         """
         Args:
-            box: List
+            box: List[int]
                 [minx, miny, maxx, maxy]
-            shift_amount: List
+            shift_amount: List[int]
                 To shift the box and mask predictions from sliced image
                 to full sized image, should be in the form of [shift_x, shift_y]
         """
@@ -162,9 +162,7 @@ class Mask:
         # confirm full_shape is given
         assert full_shape is not None, "full_shape must be provided"
 
-        bool_mask = get_bool_mask_from_coco_segmentation(
-            segmentation, height=full_shape[0], width=full_shape[1]
-        )
+        bool_mask = get_bool_mask_from_coco_segmentation(segmentation, height=full_shape[0], width=full_shape[1])
         return cls(
             bool_mask=bool_mask,
             shift_amount=shift_amount,
@@ -234,9 +232,7 @@ class Mask:
 
     def get_shifted_mask(self):
         # Confirm full_shape is specified
-        assert (self.full_shape_height is not None) and (
-            self.full_shape_width is not None
-        ), "full_shape is None"
+        assert (self.full_shape_height is not None) and (self.full_shape_width is not None), "full_shape is None"
         # init full mask
         mask_fullsized = np.full(
             (
@@ -255,9 +251,7 @@ class Mask:
         ]
 
         # convert sliced mask to full mask
-        mask_fullsized[
-            starting_pixel[1] : ending_pixel[1], starting_pixel[0] : ending_pixel[0]
-        ] = self.bool_mask[
+        mask_fullsized[starting_pixel[1] : ending_pixel[1], starting_pixel[0] : ending_pixel[0]] = self.bool_mask[
             : ending_pixel[1] - starting_pixel[1], : ending_pixel[0] - starting_pixel[0]
         ]
 
@@ -423,9 +417,7 @@ class ObjectAnnotation:
                 To shift the box and mask predictions from sliced image to full
                 sized image, should be in the form of [shift_x, shift_y]
         """
-        bool_mask = get_bool_mask_from_coco_segmentation(
-            annotation.to_coco_segmentation()
-        )
+        bool_mask = get_bool_mask_from_coco_segmentation(annotation.to_coco_segmentation())
         return cls(
             category_id=category_id,
             bool_mask=bool_mask,
@@ -487,9 +479,7 @@ class ObjectAnnotation:
                 the form of [height, width]
         """
         assert isinstance(category_id, int), "category_id must be an integer"
-        assert (bbox is not None) or (
-            bool_mask is not None
-        ), "you must provide a bbox or bool_mask"
+        assert (bbox is not None) or (bool_mask is not None), "you must provide a bbox or bool_mask"
 
         if bool_mask is None:
             self.mask = None
@@ -570,13 +560,10 @@ class ObjectAnnotation:
             import imantics
         except ImportError:
             raise ImportError(
-                'Please run "pip install -U imantics" '
-                "to install imantics first for imantics conversion."
+                'Please run "pip install -U imantics" ' "to install imantics first for imantics conversion."
             )
 
-        imantics_category = imantics.Category(
-            id=self.category.id, name=self.category.name
-        )
+        imantics_category = imantics.Category(id=self.category.id, name=self.category.name)
         if self.mask is not None:
             imantics_mask = imantics.Mask.create(self.mask.bool_mask)
             imantics_annotation = imantics.annotation.Annotation.from_mask(

--- a/sahi/annotation.py
+++ b/sahi/annotation.py
@@ -2,7 +2,7 @@
 # Code written by Fatih C Akyon, 2020.
 
 import copy
-from typing import Dict, List
+from typing import List, Optional
 
 import numpy as np
 
@@ -283,10 +283,10 @@ class ObjectAnnotation:
     def from_bool_mask(
         cls,
         bool_mask,
-        category_id=None,
-        category_name=None,
-        shift_amount: list = [0, 0],
-        full_shape=None,
+        category_id: Optional[int] = None,
+        category_name: Optional[str] = None,
+        shift_amount: Optional[List[int]] = [0, 0],
+        full_shape: Optional[List[int]] = None,
     ):
         """
         Creates ObjectAnnotation from bool_mask (2D np.ndarray)
@@ -308,7 +308,7 @@ class ObjectAnnotation:
             category_id=category_id,
             bool_mask=bool_mask,
             category_name=category_name,
-            shift_amount=[0, 0],
+            shift_amount=shift_amount,
             full_shape=full_shape,
         )
 
@@ -316,10 +316,10 @@ class ObjectAnnotation:
     def from_coco_segmentation(
         cls,
         segmentation,
-        category_id=None,
-        category_name=None,
-        shift_amount: list = [0, 0],
-        full_shape=None,
+        category_id: Optional[int] = None,
+        category_name: Optional[str] = None,
+        shift_amount: Optional[List[int]] = [0, 0],
+        full_shape: Optional[List[int]] = None,
     ):
         """
         Creates ObjectAnnotation from coco segmentation:
@@ -351,18 +351,18 @@ class ObjectAnnotation:
             category_id=category_id,
             bool_mask=bool_mask,
             category_name=category_name,
-            shift_amount=[0, 0],
+            shift_amount=shift_amount,
             full_shape=full_shape,
         )
 
     @classmethod
     def from_coco_bbox(
         cls,
-        bbox,
-        category_id=None,
-        category_name=None,
-        shift_amount: list = [0, 0],
-        full_shape=None,
+        bbox: List[int],
+        category_id: Optional[int] = None,
+        category_name: Optional[str] = None,
+        shift_amount: Optional[List[int]] = [0, 0],
+        full_shape: Optional[List[int]] = None,
     ):
         """
         Creates ObjectAnnotation from coco bbox [minx, miny, width, height]
@@ -389,7 +389,7 @@ class ObjectAnnotation:
             category_id=category_id,
             bbox=bbox,
             category_name=category_name,
-            shift_amount=[0, 0],
+            shift_amount=shift_amount,
             full_shape=full_shape,
         )
 
@@ -397,10 +397,10 @@ class ObjectAnnotation:
     def from_shapely_annotation(
         cls,
         annotation,
-        category_id=None,
-        category_name=None,
-        shift_amount: list = [0, 0],
-        full_shape=None,
+        category_id: Optional[int] = None,
+        category_name: Optional[str] = None,
+        shift_amount: Optional[List[int]] = [0, 0],
+        full_shape: Optional[List[int]] = None,
     ):
         """
         Creates ObjectAnnotation from shapely_utils.ShapelyAnnotation
@@ -422,7 +422,7 @@ class ObjectAnnotation:
             category_id=category_id,
             bool_mask=bool_mask,
             category_name=category_name,
-            shift_amount=[0, 0],
+            shift_amount=shift_amount,
             full_shape=full_shape,
         )
 
@@ -430,8 +430,8 @@ class ObjectAnnotation:
     def from_imantics_annotation(
         cls,
         annotation,
-        shift_amount: list = [0, 0],
-        full_shape=None,
+        shift_amount: Optional[List[int]] = [0, 0],
+        full_shape: Optional[List[int]] = None,
     ):
         """
         Creates ObjectAnnotation from imantics.annotation.Annotation
@@ -448,18 +448,18 @@ class ObjectAnnotation:
             category_id=annotation.category.id,
             bool_mask=annotation.mask.array,
             category_name=annotation.category.name,
-            shift_amount=[0, 0],
+            shift_amount=shift_amount,
             full_shape=full_shape,
         )
 
     def __init__(
         self,
-        bbox=None,
-        bool_mask=None,
-        category_id=None,
-        category_name=None,
-        shift_amount: list = [0, 0],
-        full_shape=None,
+        bbox: Optional[List[int]] = None,
+        bool_mask: Optional[np.ndarray] = None,
+        category_id: Optional[int] = None,
+        category_name: Optional[str] = None,
+        shift_amount: Optional[List[int]] = [0, 0],
+        full_shape: Optional[List[int]] = None,
     ):
         """
         Args:

--- a/sahi/annotation.py
+++ b/sahi/annotation.py
@@ -527,14 +527,14 @@ class ObjectAnnotation:
                 segmentation=self.mask.to_coco_segmentation(),
                 category_id=self.category.id,
                 category_name=self.category.name,
-                score=self.score.score,
+                score=self.score.value,
             )
         else:
             coco_prediction = CocoPrediction.from_coco_bbox(
                 bbox=self.bbox.to_coco_bbox(),
                 category_id=self.category.id,
                 category_name=self.category.name,
-                score=self.score.score,
+                score=self.score.value,
             )
         return coco_prediction
 

--- a/sahi/model.py
+++ b/sahi/model.py
@@ -109,9 +109,7 @@ class DetectionModel:
         Applies category remapping based on mapping given in self.category_remapping
         """
         # confirm self.category_remapping is not None
-        assert (
-            self.category_remapping is not None
-        ), "self.category_remapping cannot be None"
+        assert self.category_remapping is not None, "self.category_remapping cannot be None"
         # remap categories
         for object_prediction in self._object_prediction_list:
             old_category_id_str = str(object_prediction.category.id)
@@ -173,8 +171,7 @@ class MmdetDetectionModel(DetectionModel):
             import mmdet
         except ImportError:
             raise ImportError(
-                'Please run "pip install -U mmcv mmdet" '
-                "to install MMDetection first for MMDetection inference."
+                'Please run "pip install -U mmcv mmdet" ' "to install MMDetection first for MMDetection inference."
             )
 
         from mmdet.apis import init_detector
@@ -189,10 +186,7 @@ class MmdetDetectionModel(DetectionModel):
 
         # set category_mapping
         if not self.category_mapping:
-            category_mapping = {
-                str(ind): category_name
-                for ind, category_name in enumerate(self.category_names)
-            }
+            category_mapping = {str(ind): category_name for ind, category_name in enumerate(self.category_names)}
             self.category_mapping = category_mapping
 
     def perform_inference(self, image: np.ndarray):
@@ -207,14 +201,11 @@ class MmdetDetectionModel(DetectionModel):
             import mmdet
         except ImportError:
             raise ImportError(
-                'Please run "pip install -U mmcv mmdet" '
-                "to install MMDetection first for MMDetection inference."
+                'Please run "pip install -U mmcv mmdet" ' "to install MMDetection first for MMDetection inference."
             )
 
         # Confirm model is loaded
-        assert (
-            self.model is not None
-        ), "Model is not loaded, load it by calling .load_model()"
+        assert self.model is not None, "Model is not loaded, load it by calling .load_model()"
 
         # Supports only batch of 1
         from mmdet.apis import inference_detector
@@ -333,7 +324,7 @@ class MmdetDetectionModel(DetectionModel):
             category_id = object_prediction.category.id
             # form bbox as 1x5 list [xmin, ymin, xmax, ymax, score]
             bbox = object_prediction.bbox.to_voc_bbox()
-            bbox.extend([object_prediction.score.score])
+            bbox.extend([object_prediction.score.value])
             category_id_to_bbox[category_id].append(np.array(bbox, dtype=np.float32))
             # form 2d bool mask
             if self.has_mask:
@@ -368,10 +359,7 @@ class Yolov5DetectionModel(DetectionModel):
         try:
             import yolov5
         except ImportError:
-            raise ImportError(
-                'Please run "pip install -U yolov5" '
-                "to install YOLOv5 first for YOLOv5 inference."
-            )
+            raise ImportError('Please run "pip install -U yolov5" ' "to install YOLOv5 first for YOLOv5 inference.")
 
         # set model
         try:
@@ -382,10 +370,7 @@ class Yolov5DetectionModel(DetectionModel):
 
         # set category_mapping
         if not self.category_mapping:
-            category_mapping = {
-                str(ind): category_name
-                for ind, category_name in enumerate(self.category_names)
-            }
+            category_mapping = {str(ind): category_name for ind, category_name in enumerate(self.category_names)}
             self.category_mapping = category_mapping
 
     def perform_inference(self, image: np.ndarray):
@@ -399,15 +384,10 @@ class Yolov5DetectionModel(DetectionModel):
         try:
             import yolov5
         except ImportError:
-            raise ImportError(
-                'Please run "pip install -U yolov5" '
-                "to install YOLOv5 first for YOLOv5 inference."
-            )
+            raise ImportError('Please run "pip install -U yolov5" ' "to install YOLOv5 first for YOLOv5 inference.")
 
         # Confirm model is loaded
-        assert (
-            self.model is not None
-        ), "Model is not loaded, load it by calling .load_model()"
+        assert self.model is not None, "Model is not loaded, load it by calling .load_model()"
 
         prediction_result = self.model(image)
 
@@ -493,8 +473,7 @@ class Yolov5DetectionModel(DetectionModel):
             original_predictions: a list of converted predictions in models original output format
         """
         assert self.original_predictions is not None, (
-            "self.original_predictions"
-            " cannot be empty, call .perform_inference() first"
+            "self.original_predictions" " cannot be empty, call .perform_inference() first"
         )
         # TODO: implement object_prediction_list to yolov5 format conversion
         NotImplementedError()

--- a/sahi/postprocess/combine.py
+++ b/sahi/postprocess/combine.py
@@ -67,7 +67,7 @@ class PostprocessPredictions:
     @staticmethod
     def get_score_func(object_prediction: ObjectPrediction):
         """Used for sorting predictions"""
-        return object_prediction.score.score
+        return object_prediction.score.value
 
     @staticmethod
     def has_same_category_id(pred1: ObjectPrediction, pred2: ObjectPrediction) -> bool:
@@ -178,7 +178,7 @@ class UnionMergePostprocess(PostprocessPredictions):
 
     @staticmethod
     def _get_merged_category(pred1: ObjectPrediction, pred2: ObjectPrediction) -> Category:
-        if pred1.score.score > pred2.score.score:
+        if pred1.score.value > pred2.score.value:
             return pred1.category
         else:
             return pred2.category
@@ -195,7 +195,7 @@ class UnionMergePostprocess(PostprocessPredictions):
         pred1: ObjectPrediction,
         pred2: ObjectPrediction,
     ) -> float:
-        scores: List[float] = [pred.score.score for pred in (pred1, pred2)]
+        scores: List[float] = [pred.score.value for pred in (pred1, pred2)]
         return max(scores)
 
     @staticmethod

--- a/sahi/postprocess/legacy/merge.py
+++ b/sahi/postprocess/legacy/merge.py
@@ -146,7 +146,7 @@ class PredictionMerger:
 
     @staticmethod
     def _merge_label(pred1: ObjectPrediction, pred2: ObjectPrediction):
-        if pred1.score.score > pred2.score.score:
+        if pred1.score.value > pred2.score.value:
             return pred1.category
         else:
             return pred2.category
@@ -164,7 +164,7 @@ class PredictionMerger:
         pred1: ObjectPrediction,
         pred2: ObjectPrediction,
     ) -> float:
-        scores = [pred.score.score for pred in (pred1, pred2)]
+        scores = [pred.score.value for pred in (pred1, pred2)]
         policy = self._score_merging_method
         if policy == ScoreMergingPolicy.SMALLER_SCORE:
             return min(scores)

--- a/sahi/predict.py
+++ b/sahi/predict.py
@@ -401,7 +401,9 @@ def predict(
     durations_in_seconds["slice"] = 0
     for ind, image_path in enumerate(tqdm(image_path_list)):
         # get filename
-        filename_without_extension = str(Path(image_path).stem)
+        relative_filepath = image_path.split(source)[-1]
+        relative_filepath = relative_filepath[1:] if relative_filepath[0] == os.sep else relative_filepath
+        filename_without_extension = Path(relative_filepath).stem
         # load image
         image = read_image(image_path)
 
@@ -448,26 +450,28 @@ def predict(
         time_start = time.time()
         # export prediction boxes
         if export_crop:
+            output_dir = str(crop_dir / Path(relative_filepath).parent)
             crop_object_predictions(
                 image=image,
                 object_prediction_list=object_prediction_list,
-                output_dir=str(crop_dir),
+                output_dir=output_dir,
                 file_name=filename_without_extension,
                 export_format=visual_export_format,
             )
         # export prediction list as pickle
         if export_pickle:
-            save_path = str(pickle_dir / (filename_without_extension + ".pickle"))
+            save_path = str(pickle_dir / Path(relative_filepath).parent / (filename_without_extension + ".pickle"))
             save_pickle(data=object_prediction_list, save_path=save_path)
         # export visualization
         if export_visual:
+            output_dir = str(visual_dir / Path(relative_filepath).parent)
             visualize_object_predictions(
                 image,
                 object_prediction_list=object_prediction_list,
                 rect_th=visual_bbox_thickness,
                 text_size=visual_text_size,
                 text_th=visual_text_thickness,
-                output_dir=str(visual_dir),
+                output_dir=output_dir,
                 file_name=filename_without_extension,
                 export_format=visual_export_format,
             )

--- a/sahi/predict.py
+++ b/sahi/predict.py
@@ -5,11 +5,12 @@ import os
 import time
 
 from tqdm import tqdm
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 
+from sahi.prediction import ObjectPrediction
 from sahi.postprocess.combine import UnionMergePostprocess, PostprocessPredictions, NMSPostprocess
 from sahi.slicing import slice_image
-from sahi.utils.coco import Coco
+from sahi.utils.coco import Coco, CocoImage
 from sahi.utils.cv import (
     crop_object_predictions,
     read_image,
@@ -73,12 +74,12 @@ def get_prediction(
         shift_amount=shift_amount,
         full_shape=full_shape,
     )
-    object_prediction_list = detection_model.object_prediction_list
+    object_prediction_list: List[ObjectPrediction] = detection_model.object_prediction_list
     # filter out predictions with lower score
     filtered_object_prediction_list = [
         object_prediction
         for object_prediction in object_prediction_list
-        if object_prediction.score.score > detection_model.prediction_score_threshold
+        if object_prediction.score.value > detection_model.prediction_score_threshold
     ]
     # postprocess matching predictions
     if postprocess is not None:
@@ -356,9 +357,8 @@ def predict(
 
     # list image files in directory
     if coco_file_path:
-        coco = Coco.from_coco_dict_or_path(coco_file_path)
+        coco: Coco = Coco.from_coco_dict_or_path(coco_file_path)
         image_path_list = [str(Path(source) / Path(coco_image.file_name)) for coco_image in coco.images]
-        image_id_list = [coco_image.id for coco_image in coco.images]
         coco_json = []
     elif os.path.isdir(source):
         time_start = time.time()
@@ -377,6 +377,7 @@ def predict(
     save_dir = Path(increment_path(Path(project) / name, exist_ok=False))  # increment run
     crop_dir = save_dir / "crops"
     visual_dir = save_dir / "visuals"
+    visual_with_gt_dir = save_dir / "visuals_with_gt"
     pickle_dir = save_dir / "pickles"
     save_dir.mkdir(parents=True, exist_ok=True)  # make dir
 
@@ -386,7 +387,7 @@ def predict(
     detection_model = DetectionModel(
         model_path=model_parameters["model_path"],
         config_path=model_parameters.get("config_path", None),
-        prediction_score_threshold=model_parameters["prediction_score_threshold"],
+        prediction_score_threshold=model_parameters.get("prediction_score_threshold", 0.25),
         device=model_parameters.get("device", None),
         category_mapping=model_parameters.get("category_mapping", None),
         category_remapping=model_parameters.get("category_remapping", None),
@@ -403,11 +404,7 @@ def predict(
         # get filename
         if os.path.isdir(source):  # preserve source folder structure in export
             relative_filepath = image_path.split(source)[-1]
-            relative_filepath = (
-                relative_filepath[1:]
-                if relative_filepath[0] == os.sep
-                else relative_filepath
-            )
+            relative_filepath = relative_filepath[1:] if relative_filepath[0] == os.sep else relative_filepath
         else:  # no process if source is single file
             relative_filepath = image_path
         filename_without_extension = Path(relative_filepath).stem
@@ -447,12 +444,50 @@ def predict(
         durations_in_seconds["prediction"] += prediction_result["durations_in_seconds"]["prediction"]
 
         if coco_file_path:
-            image_id = image_id_list[ind]
+            image_id = ind + 1
+            # append predictions in coco format
             for object_prediction in object_prediction_list:
                 coco_prediction = object_prediction.to_coco_prediction()
                 coco_prediction.image_id = image_id
                 coco_prediction_json = coco_prediction.json
                 coco_json.append(coco_prediction_json)
+            # convert ground truth annotations to object_prediction_list
+            coco_image: CocoImage = coco.images[ind]
+            object_prediction_gt_list: List[ObjectPrediction] = []
+            for coco_annotation in coco_image.annotations:
+                coco_annotation_dict = coco_annotation.json
+                category_name = coco_annotation.category_name
+                full_shape = [coco_image.height, coco_image.width]
+                object_prediction_gt = ObjectPrediction.from_coco_annotation_dict(
+                    annotation_dict=coco_annotation_dict, category_name=category_name, full_shape=full_shape
+                )
+                object_prediction_gt_list.append(object_prediction_gt)
+            # export visualizations with ground truths
+            output_dir = str(visual_with_gt_dir / Path(relative_filepath).parent)
+            color = (0, 255, 0)  # original annotations in green
+            result = visualize_object_predictions(
+                image,
+                object_prediction_list=object_prediction_gt_list,
+                rect_th=visual_bbox_thickness,
+                text_size=visual_text_size,
+                text_th=visual_text_thickness,
+                color=color,
+                output_dir=None,
+                file_name=None,
+                export_format=None,
+            )
+            color = (255, 0, 0)  # model predictions in red
+            _ = visualize_object_predictions(
+                result["image"],
+                object_prediction_list=object_prediction_list,
+                rect_th=visual_bbox_thickness,
+                text_size=visual_text_size,
+                text_th=visual_text_thickness,
+                color=color,
+                output_dir=output_dir,
+                file_name=filename_without_extension,
+                export_format=visual_export_format,
+            )
 
         time_start = time.time()
         # export prediction boxes
@@ -467,11 +502,7 @@ def predict(
             )
         # export prediction list as pickle
         if export_pickle:
-            save_path = str(
-                pickle_dir
-                / Path(relative_filepath).parent
-                / (filename_without_extension + ".pickle")
-            )
+            save_path = str(pickle_dir / Path(relative_filepath).parent / (filename_without_extension + ".pickle"))
             save_pickle(data=object_prediction_list, save_path=save_path)
         # export visualization
         if export_visual:

--- a/sahi/predict.py
+++ b/sahi/predict.py
@@ -401,8 +401,15 @@ def predict(
     durations_in_seconds["slice"] = 0
     for ind, image_path in enumerate(tqdm(image_path_list)):
         # get filename
-        relative_filepath = image_path.split(source)[-1]
-        relative_filepath = relative_filepath[1:] if relative_filepath[0] == os.sep else relative_filepath
+        if os.path.isdir(source):  # preserve source folder structure in export
+            relative_filepath = image_path.split(source)[-1]
+            relative_filepath = (
+                relative_filepath[1:]
+                if relative_filepath[0] == os.sep
+                else relative_filepath
+            )
+        else:  # no process if source is single file
+            relative_filepath = image_path
         filename_without_extension = Path(relative_filepath).stem
         # load image
         image = read_image(image_path)
@@ -460,7 +467,11 @@ def predict(
             )
         # export prediction list as pickle
         if export_pickle:
-            save_path = str(pickle_dir / Path(relative_filepath).parent / (filename_without_extension + ".pickle"))
+            save_path = str(
+                pickle_dir
+                / Path(relative_filepath).parent
+                / (filename_without_extension + ".pickle")
+            )
             save_pickle(data=object_prediction_list, save_path=save_path)
         # export visualization
         if export_visual:

--- a/sahi/prediction.py
+++ b/sahi/prediction.py
@@ -2,11 +2,10 @@
 # Code written by Fatih C Akyon, 2020.
 
 import copy
-
+from typing import List, Optional
 import numpy as np
 
 from sahi.annotation import ObjectAnnotation
-from sahi.utils.torch import to_float_tensor, torch_stack
 
 
 class PredictionScore:
@@ -38,13 +37,13 @@ class ObjectPrediction(ObjectAnnotation):
 
     def __init__(
         self,
-        bbox: list,
-        score: float,
-        category_id: int,
-        category_name=None,
-        bool_mask=None,
-        shift_amount: list = [0, 0],
-        full_shape: list = [1024, 1024],
+        bbox: Optional[List[int]] = None,
+        category_id: Optional[int] = None,
+        category_name: Optional[str] = None,
+        bool_mask: Optional[np.ndarray] = None,
+        score: Optional[float] = 0,
+        shift_amount: Optional[List[int]] = [0, 0],
+        full_shape: Optional[List[int]] = None,
     ):
         """
         Creates ObjectPrediction from bbox, score, category_id, category_name, bool_mask.

--- a/sahi/prediction.py
+++ b/sahi/prediction.py
@@ -110,36 +110,3 @@ class ObjectPrediction(ObjectAnnotation):
     mask: {self.mask},
     score: {self.score},
     category: {self.category}>"""
-
-
-class PredictionInput:
-    def __init__(
-        self,
-        image_list,
-        shift_amount_list=None,
-        full_shape=None,
-    ):
-        """
-        Arguments:
-            image_list: list of images to be predicted
-            shift_amount_list: To shift the box and mask predictions from sliced image to full sized image, should be in the form of [shift_x, shift_y]
-            full_shape: Size of the full image after shifting, should be in the form of [height, width]
-
-        image_list and shift_amount_list should have same length
-        """
-        self.image_list = image_list
-        image_tensor_list = []
-        for image in image_list:
-            # normalize image
-            image = image / np.max(image)
-            # convert numpy image to tensor
-            image_tensor_list.append(to_float_tensor(image))
-        # create batch tensor
-        batch_image_tensor = torch_stack(tuple(image_tensor_list), dim=0)
-        self.batch_image_tensor = batch_image_tensor
-        # set other properties
-        if shift_amount_list:
-            self.shift_amount_list = shift_amount_list
-        else:
-            self.shift_amount_list = [[0, 0] for ind in range(len(image_list))]
-        self.full_shape = full_shape

--- a/sahi/prediction.py
+++ b/sahi/prediction.py
@@ -10,25 +10,25 @@ from sahi.utils.torch import to_float_tensor, torch_stack
 
 
 class PredictionScore:
-    def __init__(self, score: float):
+    def __init__(self, value: float):
         """
         Arguments:
             score: prediction score between 0 and 1
         """
         # if score is a numpy object, convert it to python variable
-        if type(score).__module__ == "numpy":
-            score = copy.deepcopy(score).tolist()
+        if type(value).__module__ == "numpy":
+            value = copy.deepcopy(value).tolist()
         # set score
-        self.score = score
+        self.value = value
 
     def is_greater_than_threshold(self, threshold):
         """
         Check if score is greater than threshold
         """
-        return self.score > threshold
+        return self.value > threshold
 
     def __repr__(self):
-        return f"PredictionScore: <score: {self.score}>"
+        return f"PredictionScore: <value: {self.value}>"
 
 
 class ObjectPrediction(ObjectAnnotation):
@@ -87,7 +87,7 @@ class ObjectPrediction(ObjectAnnotation):
             return ObjectPrediction(
                 bbox=self.bbox.get_shifted_box().to_voc_bbox(),
                 category_id=self.category.id,
-                score=self.score.score,
+                score=self.score.value,
                 bool_mask=self.mask.get_shifted_mask().bool_mask,
                 category_name=self.category.name,
                 shift_amount=[0, 0],
@@ -97,7 +97,7 @@ class ObjectPrediction(ObjectAnnotation):
             return ObjectPrediction(
                 bbox=self.bbox.get_shifted_box().to_voc_bbox(),
                 category_id=self.category.id,
-                score=self.score.score,
+                score=self.score.value,
                 bool_mask=None,
                 category_name=self.category.name,
                 shift_amount=[0, 0],

--- a/sahi/slicing.py
+++ b/sahi/slicing.py
@@ -59,9 +59,7 @@ def get_slice_bboxes(
             if y_max > image_height or x_max > image_width:
                 ymax = min(image_height, y_max)
                 xmax = min(image_width, x_max)
-                slice_bboxes.append(
-                    [xmax - slice_width, ymax - slice_height, xmax, ymax]
-                )
+                slice_bboxes.append([xmax - slice_width, ymax - slice_height, xmax, ymax])
             else:
                 slice_bboxes.append([x_min, y_min, x_max, y_max])
             x_min = x_max - x_overlap
@@ -97,9 +95,7 @@ def annotation_inside_slice(annotation: Dict, slice_bbox: List[int]) -> bool:
     return True
 
 
-def process_coco_annotations(
-    coco_annotation_list: List[CocoAnnotation], slice_bbox: List[int], min_area_ratio
-) -> bool:
+def process_coco_annotations(coco_annotation_list: List[CocoAnnotation], slice_bbox: List[int], min_area_ratio) -> bool:
     """Slices and filters given list of CocoAnnotation objects with given
     'slice_bbox' and 'min_area_ratio'.
 
@@ -118,9 +114,7 @@ def process_coco_annotations(
     sliced_coco_annotation_list: List[CocoAnnotation] = []
     for coco_annotation in coco_annotation_list:
         if annotation_inside_slice(coco_annotation.json, slice_bbox):
-            sliced_coco_annotation = coco_annotation.get_sliced_coco_annotation(
-                slice_bbox
-            )
+            sliced_coco_annotation = coco_annotation.get_sliced_coco_annotation(slice_bbox)
             if sliced_coco_annotation.area / coco_annotation.area >= min_area_ratio:
                 sliced_coco_annotation_list.append(sliced_coco_annotation)
     return sliced_coco_annotation_list
@@ -156,9 +150,7 @@ class SliceImageResult:
         self.image_dir = image_dir
 
     def add_sliced_image(self, sliced_image: SlicedImage):
-        assert (
-            type(sliced_image) == SlicedImage
-        ), "sliced_image must be a SlicedImage instance"
+        assert type(sliced_image) == SlicedImage, "sliced_image must be a SlicedImage instance"
         self._sliced_image_list.append(sliced_image)
 
     @property
@@ -215,7 +207,6 @@ def slice_image(
     overlap_height_ratio: float = 0.2,
     overlap_width_ratio: float = 0.2,
     min_area_ratio: float = 0.1,
-    slice_sep: str = "_",
     out_ext: Optional[str] = None,
     verbose: bool = False,
 ) -> SliceImageResult:
@@ -239,8 +230,6 @@ def slice_image(
             overlap of 20 pixels). Default 0.2.
         min_area_ratio (float): If the cropped annotation area to original annotation
             ratio is smaller than this value, the annotation is filtered out. Default 0.1.
-        slice_sep (str, optional): Character used to separate outname from
-            coordinates in the saved windows. Default '_'.
         out_ext (str, optional): Extension of saved images. Default is the
             original suffix.
         verbose (bool, optional): Switch to print relevant values to screen.
@@ -282,9 +271,7 @@ def slice_image(
     n_ims = 0
 
     # init images and annotations lists
-    sliced_image_result = SliceImageResult(
-        original_image_size=[image_height, image_width], image_dir=output_dir
-    )
+    sliced_image_result = SliceImageResult(original_image_size=[image_height, image_width], image_dir=output_dir)
 
     # iterate over slices
     for slice_bbox in slice_bboxes:
@@ -295,9 +282,7 @@ def slice_image(
 
         # process annotations if coco_annotations is given
         if coco_annotation_list is not None:
-            sliced_coco_annotation_list = process_coco_annotations(
-                coco_annotation_list, slice_bbox, min_area_ratio
-            )
+            sliced_coco_annotation_list = process_coco_annotations(coco_annotation_list, slice_bbox, min_area_ratio)
 
         # set image file suffixes
         slice_suffixes = "_".join(map(str, slice_bbox))
@@ -319,9 +304,7 @@ def slice_image(
             verboseprint("sliced image path:", slice_file_path)
 
         # create coco image
-        coco_image = CocoImage(
-            file_name=slice_file_name, height=slice_height, width=slice_width
-        )
+        coco_image = CocoImage(file_name=slice_file_name, height=slice_height, width=slice_width)
 
         # append coco annotations (if present) to coco image
         if coco_annotation_list:
@@ -438,9 +421,7 @@ def slice_coco(
     )
     save_path = ""
     if output_coco_annotation_file_name and output_dir:
-        save_path = os.path.join(
-            output_dir, output_coco_annotation_file_name + "_coco.json"
-        )
+        save_path = os.path.join(output_dir, output_coco_annotation_file_name + "_coco.json")
         save_json(coco_dict, save_path)
 
     return coco_dict, save_path

--- a/sahi/slicing.py
+++ b/sahi/slicing.py
@@ -343,7 +343,6 @@ def slice_coco(
     overlap_height_ratio: float = 0.2,
     overlap_width_ratio: float = 0.2,
     min_area_ratio: float = 0.1,
-    slice_sep: str = "_",
     out_ext: Optional[str] = None,
     verbose: bool = False,
 ) -> List[Union[Dict, str]]:
@@ -369,8 +368,6 @@ def slice_coco(
             overlap of 20 pixels). Default 0.2.
         min_area_ratio (float): If the cropped annotation area to original annotation
             ratio is smaller than this value, the annotation is filtered out. Default 0.1.
-        slice_sep (str, optional): Character used to separate outname from
-            coordinates in the saved windows. Default '_'.
         out_ext (str, optional): Extension of saved images. Default is the
             original suffix.
         verbose (bool, optional): Switch to print relevant values to screen.
@@ -406,7 +403,6 @@ def slice_coco(
             overlap_height_ratio=overlap_height_ratio,
             overlap_width_ratio=overlap_width_ratio,
             min_area_ratio=min_area_ratio,
-            slice_sep=slice_sep,
             out_ext=out_ext,
             verbose=False,
         )

--- a/sahi/utils/coco.py
+++ b/sahi/utils/coco.py
@@ -4,7 +4,7 @@
 
 import copy
 import os
-from collections import Counter, OrderedDict, defaultdict
+from collections import Counter, defaultdict
 from dataclasses import dataclass
 from multiprocessing import Pool
 from pathlib import Path

--- a/sahi/utils/cv.py
+++ b/sahi/utils/cv.py
@@ -46,13 +46,7 @@ def crop_object_predictions(
         )
         save_path = os.path.join(
             output_dir,
-            file_name
-            + "_box"
-            + str(ind)
-            + "_class"
-            + str(category_id)
-            + "."
-            + export_format,
+            file_name + "_box" + str(ind) + "_class" + str(category_id) + "." + export_format,
         )
         cv2.imwrite(save_path, cv2.cvtColor(cropped_img, cv2.COLOR_RGB2BGR))
 
@@ -82,8 +76,7 @@ def read_large_image(image_path: str):
             import skimage.io
         except ImportError:
             raise ImportError(
-                'Please run "pip install -U scikit-image" '
-                "to install scikit-image first for large image handling."
+                'Please run "pip install -U scikit-image" ' "to install scikit-image first for large image handling."
             )
         image0 = skimage.io.imread(image_path, as_grey=False).astype(np.uint8)  # [::-1]
         use_cv2 = False
@@ -260,7 +253,7 @@ def visualize_object_predictions(
 
         bbox = object_prediction.bbox.to_voc_bbox()
         category_name = object_prediction.category.name
-        score = object_prediction.score.score
+        score = object_prediction.score.value
 
         # visualize masks if present
         if object_prediction.mask is not None:
@@ -316,9 +309,7 @@ def get_coco_segmentation_from_bool_mask(bool_mask):
     mask = np.squeeze(bool_mask)
     mask = mask.astype(np.uint8)
     mask = cv2.copyMakeBorder(mask, 1, 1, 1, 1, cv2.BORDER_CONSTANT, value=0)
-    polygons = cv2.findContours(
-        mask, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE, offset=(-1, -1)
-    )
+    polygons = cv2.findContours(mask, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE, offset=(-1, -1))
     polygons = polygons[0] if len(polygons) == 2 else polygons[1]
     # Convert polygon to coco segmentation
     coco_segmentation = [polygon.flatten().tolist() for polygon in polygons]
@@ -330,10 +321,7 @@ def get_bool_mask_from_coco_segmentation(coco_segmentation, width, height):
     Convert coco segmentation to 2D boolean mask of given height and width
     """
     size = [height, width]
-    points = [
-        np.array(point).reshape(-1, 2).round().astype(int)
-        for point in coco_segmentation
-    ]
+    points = [np.array(point).reshape(-1, 2).round().astype(int) for point in coco_segmentation]
     bool_mask = np.zeros(size)
     bool_mask = cv2.fillPoly(bool_mask, points, 1)
     bool_mask.astype(bool)

--- a/scripts/slice_coco.py
+++ b/scripts/slice_coco.py
@@ -21,9 +21,7 @@ if __name__ == "__main__":
 
     # slice train-val coco dataset images
     print("Slicing step is starting...")
-    sliced_output_dir = coco_annotation_file_path.replace(
-        "coco.json", "sliced_input_" + str(slice_size) + "/"
-    )
+    sliced_output_dir = coco_annotation_file_path.replace("coco.json", "sliced_input_" + str(slice_size) + "/")
     for split_type in coco_dict_paths.keys():
         coco_annotation_file_path = coco_dict_paths[split_type]
         sliced_coco_name = get_base_filename(coco_annotation_file_path)[0].replace(
@@ -40,7 +38,6 @@ if __name__ == "__main__":
             max_allowed_zeros_ratio=0.2,
             overlap_height_ratio=0.2,
             overlap_width_ratio=0.2,
-            slice_sep="_",
             out_ext=".png",
             verbose=True,
         )

--- a/tests/data/models/mmdet_cascade_mask_rcnn/coco_instance.py
+++ b/tests/data/models/mmdet_cascade_mask_rcnn/coco_instance.py
@@ -24,7 +24,7 @@ test_pipeline = [
             dict(type="RandomFlip"),
             dict(type="Normalize", **img_norm_cfg),
             dict(type="Pad", size_divisor=32),
-            dict(type="ImageToTensor", keys=["img"]),
+            dict(type="DefaultFormatBundle"),
             dict(type="Collect", keys=["img"]),
         ],
     ),

--- a/tests/data/models/mmdet_retinanet/coco_detection.py
+++ b/tests/data/models/mmdet_retinanet/coco_detection.py
@@ -24,7 +24,7 @@ test_pipeline = [
             dict(type="RandomFlip"),
             dict(type="Normalize", **img_norm_cfg),
             dict(type="Pad", size_divisor=32),
-            dict(type="ImageToTensor", keys=["img"]),
+            dict(type="DefaultFormatBundle"),
             dict(type="Collect", keys=["img"]),
         ],
     ),

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -14,7 +14,7 @@ class TestPredict(unittest.TestCase):
         from sahi.prediction import PredictionScore
 
         prediction_score = PredictionScore(np.array(0.6))
-        self.assertEqual(type(prediction_score.score), float)
+        self.assertEqual(type(prediction_score.value), float)
         self.assertEqual(prediction_score.is_greater_than_threshold(0.5), True)
         self.assertEqual(prediction_score.is_greater_than_threshold(0.7), False)
 

--- a/tests/test_slicing.py
+++ b/tests/test_slicing.py
@@ -29,7 +29,6 @@ class TestSlicing(unittest.TestCase):
             overlap_height_ratio=0.1,
             overlap_width_ratio=0.4,
             min_area_ratio=0.1,
-            slice_sep="_",
             out_ext=".png",
             verbose=False,
         )
@@ -54,7 +53,6 @@ class TestSlicing(unittest.TestCase):
             overlap_height_ratio=0.1,
             overlap_width_ratio=0.4,
             min_area_ratio=0.1,
-            slice_sep="_",
             out_ext=".png",
             verbose=False,
         )
@@ -79,7 +77,6 @@ class TestSlicing(unittest.TestCase):
             overlap_height_ratio=0.1,
             overlap_width_ratio=0.4,
             min_area_ratio=0.1,
-            slice_sep="_",
             out_ext=".png",
             verbose=False,
         )
@@ -112,7 +109,6 @@ class TestSlicing(unittest.TestCase):
             overlap_height_ratio=0.1,
             overlap_width_ratio=0.4,
             min_area_ratio=0.1,
-            slice_sep="_",
             out_ext=".png",
             verbose=False,
         )
@@ -148,7 +144,6 @@ class TestSlicing(unittest.TestCase):
             overlap_height_ratio=0.1,
             overlap_width_ratio=0.4,
             min_area_ratio=0.1,
-            slice_sep="|",
             out_ext=".png",
             verbose=False,
         )


### PR DESCRIPTION
- export visuals with predicted + gt annotations into `visuals_with_gt` folder when `coco_file_path` is provided
- keep source folder structure when exporting results
- add `from_coco_annotation_dict` classmethod to `ObjectAnnotation`
- remove unused imports/classes/parameters
- better typing hints