### PR TITLE
add `coco_evaluation` script, refactor `coco_error_analysis` script

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -30,7 +30,7 @@ python scripts/predict.py --slice_width 256 --slice_height 256 --overlap_height_
 
 - By default, scripts apply both standard and sliced prediction (multi-stage inference). If you don't want to perform sliced prediction add `--no_sliced_pred` argument. If you don't want to perform standard prediction add `--no_standard_pred` argument.
 
-- If you want to perform prediction using a COCO annotation file, provide COCO json path as add `--coco_file path/to/coco/file` and coco image folder as `--source path/to/coco/image/folder`, predictions will be exported as a coco json file to runs/predict/exp/results.json. Then you can use coco_error_analysis.py script to calculate COCO evaluation results.
+- If you want to perform prediction using a COCO annotation file, provide COCO json path as add `--coco_file path/to/coco/file` and coco image folder as `--source path/to/coco/image/folder`, predictions will be exported as a coco json file to runs/predict/exp/results.json. Then you can use coco_evaluation.py script to calculate COCO evaluation results or coco_error_analysis.py script to calculate detailed COCO error plots.
 
 
 ## `coco2yolov5.py` script usage:
@@ -43,10 +43,28 @@ python scripts/coco2yolov5.py --coco_file path/to/coco/file --source coco/images
 
 will convert given coco dataset to yolov5 format and export to runs/coco2yolov5/exp folder.
 
+## `coco_evaluation.py` script usage:
+
+```bash
+python scripts/coco_evaluation.py dataset.json results.json
+```
+
+will calculate coco evaluation and export them to given output folder directory.
+
+If you want to specify mAP metric type, set it as `--metric bbox mask`.
+
+If you want to also calculate classwise scores add `--classwise` argument.
+
+If you want to specify max detections, set it as `--proposal_nums 10 100 500`.
+
+If you want to specify a psecific IOU threshold, set it as `--iou_thrs 0.5`. Default includes `0.50:0.95` and `0.5` scores.
+
+If you want to specify export directory, set it as `--out_dir output/folder/directory `.
+
 ## `coco_error_analysis.py` script usage:
 
 ```bash
-python scripts/coco_error_analysis.py results.json output/folder/directory --ann coco/annotation/path
+python scripts/coco_error_analysis.py dataset.json results.json
 ```
 
 will calculate coco error plots and export them to given output folder directory.
@@ -56,3 +74,5 @@ If you want to specify mAP result type, set it as `--types bbox mask`.
 If you want to export extra mAP bar plots and annotation area stats add `--extraplots` argument.
 
 If you want to specify area regions, set it as `--areas 1024 9216 10000000000`.
+
+If you want to specify export directory, set it as `--out_dir output/folder/directory `.

--- a/scripts/coco_error_analysis.py
+++ b/scripts/coco_error_analysis.py
@@ -2,6 +2,7 @@ import copy
 import os
 from argparse import ArgumentParser
 from multiprocessing import Pool
+from pathlib import Path
 
 import numpy as np
 
@@ -9,35 +10,31 @@ try:
     from pycocotools.coco import COCO
     from pycocotools.cocoeval import COCOeval
 except ImportError:
-    raise ImportError(
-        'Please run "pip install -U pycocotools" '
-        'to install pycocotools first for coco evaluation.')
+    raise ImportError('Please run "pip install -U pycocotools" ' "to install pycocotools first for coco evaluation.")
 try:
     import matplotlib.pyplot as plt
 except ImportError:
-    raise ImportError(
-        'Please run "pip install -U matplotlib" '
-        'to install matplotlib first for visualization.')
+    raise ImportError('Please run "pip install -U matplotlib" ' "to install matplotlib first for visualization.")
 
 
 def makeplot(rs, ps, outDir, class_name, iou_type):
-    cs = np.vstack([
-        np.ones((2, 3)),
-        np.array([0.31, 0.51, 0.74]),
-        np.array([0.75, 0.31, 0.30]),
-        np.array([0.36, 0.90, 0.38]),
-        np.array([0.50, 0.39, 0.64]),
-        np.array([1, 0.6, 0]),
-    ])
-    areaNames = ['allarea', 'small', 'medium', 'large']
-    types = ['C75', 'C50', 'Loc', 'Sim', 'Oth', 'BG', 'FN']
+    cs = np.vstack(
+        [
+            np.ones((2, 3)),
+            np.array([0.31, 0.51, 0.74]),
+            np.array([0.75, 0.31, 0.30]),
+            np.array([0.36, 0.90, 0.38]),
+            np.array([0.50, 0.39, 0.64]),
+            np.array([1, 0.6, 0]),
+        ]
+    )
+    areaNames = ["allarea", "small", "medium", "large"]
+    types = ["C75", "C50", "Loc", "Sim", "Oth", "BG", "FN"]
     for i in range(len(areaNames)):
         area_ps = ps[..., i, 0]
-        figure_title = iou_type + '-' + class_name + '-' + areaNames[i]
+        figure_title = iou_type + "-" + class_name + "-" + areaNames[i]
         aps = [ps_.mean() for ps_ in area_ps]
-        ps_curve = [
-            ps_.mean(axis=1) if ps_.ndim > 1 else ps_ for ps_ in area_ps
-        ]
+        ps_curve = [ps_.mean(axis=1) if ps_.ndim > 1 else ps_ for ps_ in area_ps]
         ps_curve.insert(0, np.zeros(ps_curve[0].shape))
         fig = plt.figure()
         ax = plt.subplot(111)
@@ -48,16 +45,16 @@ def makeplot(rs, ps, outDir, class_name, iou_type):
                 ps_curve[k],
                 ps_curve[k + 1],
                 color=cs[k],
-                label=str(f'[{aps[k]:.3f}]' + types[k]),
+                label=str(f"[{aps[k]:.3f}]" + types[k]),
             )
-        plt.xlabel('recall')
-        plt.ylabel('precision')
+        plt.xlabel("recall")
+        plt.ylabel("precision")
         plt.xlim(0, 1.0)
         plt.ylim(0, 1.0)
         plt.title(figure_title)
         plt.legend()
         # plt.show()
-        fig.savefig(outDir + f'/{figure_title}.png')
+        fig.savefig(outDir + f"/{figure_title}.png")
         plt.close(fig)
 
 
@@ -66,28 +63,28 @@ def autolabel(ax, rects):
     for rect in rects:
         height = rect.get_height()
         if height > 0 and height <= 1:  # for percent values
-            text_label = '{:2.0f}'.format(height * 100)
+            text_label = "{:2.0f}".format(height * 100)
         else:
-            text_label = '{:2.0f}'.format(height)
+            text_label = "{:2.0f}".format(height)
         ax.annotate(
             text_label,
             xy=(rect.get_x() + rect.get_width() / 2, height),
             xytext=(0, 3),  # 3 points vertical offset
-            textcoords='offset points',
-            ha='center',
-            va='bottom',
-            fontsize='x-small',
+            textcoords="offset points",
+            ha="center",
+            va="bottom",
+            fontsize="x-small",
         )
 
 
 def makebarplot(rs, ps, outDir, class_name, iou_type):
-    areaNames = ['allarea', 'small', 'medium', 'large']
-    types = ['C75', 'C50', 'Loc', 'Sim', 'Oth', 'BG', 'FN']
+    areaNames = ["allarea", "small", "medium", "large"]
+    types = ["C75", "C50", "Loc", "Sim", "Oth", "BG", "FN"]
     fig, ax = plt.subplots()
     x = np.arange(len(areaNames))  # the areaNames locations
     width = 0.60  # the width of the bars
     rects_list = []
-    figure_title = iou_type + '-' + class_name + '-' + 'ap bar plot'
+    figure_title = iou_type + "-" + class_name + "-" + "ap bar plot"
     for i in range(len(types) - 1):
         type_ps = ps[i, ..., 0]
         aps = [ps_.mean() for ps_ in type_ps.T]
@@ -97,10 +94,11 @@ def makebarplot(rs, ps, outDir, class_name, iou_type):
                 aps,
                 width / len(types),
                 label=types[i],
-            ))
+            )
+        )
 
     # Add some text for labels, title and custom x-axis tick labels, etc.
-    ax.set_ylabel('Mean Average Precision (mAP)')
+    ax.set_ylabel("Mean Average Precision (mAP)")
     ax.set_title(figure_title)
     ax.set_xticks(x)
     ax.set_xticklabels(areaNames)
@@ -111,7 +109,7 @@ def makebarplot(rs, ps, outDir, class_name, iou_type):
         autolabel(ax, rects)
 
     # Save plot
-    fig.savefig(outDir + f'/{figure_title}.png')
+    fig.savefig(outDir + f"/{figure_title}.png")
     plt.close(fig)
 
 
@@ -123,9 +121,9 @@ def get_gt_area_group_numbers(cocoEval):
     areaRngLbl2Number = dict.fromkeys(areaRngLbl, 0)
     for evalImg in cocoEval.evalImgs:
         if evalImg:
-            for gtIgnore in evalImg['gtIgnore']:
+            for gtIgnore in evalImg["gtIgnore"]:
                 if not gtIgnore:
-                    aRngLbl = areaRngStr2areaRngLbl[str(evalImg['aRng'])]
+                    aRngLbl = areaRngStr2areaRngLbl[str(evalImg["aRng"])]
                     areaRngLbl2Number[aRngLbl] += 1
     return areaRngLbl2Number
 
@@ -134,18 +132,18 @@ def make_gt_area_group_numbers_plot(cocoEval, outDir, verbose=True):
     areaRngLbl2Number = get_gt_area_group_numbers(cocoEval)
     areaRngLbl = areaRngLbl2Number.keys()
     if verbose:
-        print('number of annotations per area group:', areaRngLbl2Number)
+        print("number of annotations per area group:", areaRngLbl2Number)
 
     # Init figure
     fig, ax = plt.subplots()
     x = np.arange(len(areaRngLbl))  # the areaNames locations
     width = 0.60  # the width of the bars
-    figure_title = 'number of annotations per area group'
+    figure_title = "number of annotations per area group"
 
     rects = ax.bar(x, areaRngLbl2Number.values(), width)
 
     # Add some text for labels, title and custom x-axis tick labels, etc.
-    ax.set_ylabel('Number of annotations')
+    ax.set_ylabel("Number of annotations")
     ax.set_title(figure_title)
     ax.set_xticks(x)
     ax.set_xticklabels(areaRngLbl)
@@ -155,146 +153,151 @@ def make_gt_area_group_numbers_plot(cocoEval, outDir, verbose=True):
 
     # Save plot
     fig.tight_layout()
-    fig.savefig(outDir + f'/{figure_title}.png')
+    fig.savefig(outDir + f"/{figure_title}.png")
     plt.close(fig)
 
 
 def make_gt_area_histogram_plot(cocoEval, outDir):
     n_bins = 100
-    areas = [ann['area'] for ann in cocoEval.cocoGt.anns.values()]
+    areas = [ann["area"] for ann in cocoEval.cocoGt.anns.values()]
 
     # init figure
-    figure_title = 'gt annotation areas histogram plot'
+    figure_title = "gt annotation areas histogram plot"
     fig, ax = plt.subplots()
 
     # Set the number of bins
     ax.hist(np.sqrt(areas), bins=n_bins)
 
     # Add some text for labels, title and custom x-axis tick labels, etc.
-    ax.set_xlabel('Squareroot Area')
-    ax.set_ylabel('Number of annotations')
+    ax.set_xlabel("Squareroot Area")
+    ax.set_ylabel("Number of annotations")
     ax.set_title(figure_title)
 
     # Save plot
     fig.tight_layout()
-    fig.savefig(outDir + f'/{figure_title}.png')
+    fig.savefig(outDir + f"/{figure_title}.png")
     plt.close(fig)
 
 
-def analyze_individual_category(k,
-                                cocoDt,
-                                cocoGt,
-                                catId,
-                                iou_type,
-                                areas=None):
+def analyze_individual_category(k, cocoDt, cocoGt, catId, iou_type, areas=None):
     nm = cocoGt.loadCats(catId)[0]
     print(f'--------------analyzing {k + 1}-{nm["name"]}---------------')
     ps_ = {}
     dt = copy.deepcopy(cocoDt)
     nm = cocoGt.loadCats(catId)[0]
     imgIds = cocoGt.getImgIds()
-    dt_anns = dt.dataset['annotations']
+    dt_anns = dt.dataset["annotations"]
     select_dt_anns = []
     for ann in dt_anns:
-        if ann['category_id'] == catId:
+        if ann["category_id"] == catId:
             select_dt_anns.append(ann)
-    dt.dataset['annotations'] = select_dt_anns
+    dt.dataset["annotations"] = select_dt_anns
     dt.createIndex()
     # compute precision but ignore superclass confusion
     gt = copy.deepcopy(cocoGt)
-    child_catIds = gt.getCatIds(supNms=[nm['supercategory']])
-    for idx, ann in enumerate(gt.dataset['annotations']):
-        if ann['category_id'] in child_catIds and ann['category_id'] != catId:
-            gt.dataset['annotations'][idx]['ignore'] = 1
-            gt.dataset['annotations'][idx]['iscrowd'] = 1
-            gt.dataset['annotations'][idx]['category_id'] = catId
+    child_catIds = gt.getCatIds(supNms=[nm["supercategory"]])
+    for idx, ann in enumerate(gt.dataset["annotations"]):
+        if ann["category_id"] in child_catIds and ann["category_id"] != catId:
+            gt.dataset["annotations"][idx]["ignore"] = 1
+            gt.dataset["annotations"][idx]["iscrowd"] = 1
+            gt.dataset["annotations"][idx]["category_id"] = catId
     cocoEval = COCOeval(gt, copy.deepcopy(dt), iou_type)
     cocoEval.params.imgIds = imgIds
     cocoEval.params.maxDets = [100]
     cocoEval.params.iouThrs = [0.1]
     cocoEval.params.useCats = 1
     if areas:
-        cocoEval.params.areaRng = [[0**2, areas[2]], [0**2, areas[0]],
-                                   [areas[0], areas[1]], [areas[1], areas[2]]]
+        cocoEval.params.areaRng = [
+            [0 ** 2, areas[2]],
+            [0 ** 2, areas[0]],
+            [areas[0], areas[1]],
+            [areas[1], areas[2]],
+        ]
     cocoEval.evaluate()
     cocoEval.accumulate()
-    ps_supercategory = cocoEval.eval['precision'][0, :, k, :, :]
-    ps_['ps_supercategory'] = ps_supercategory
+    ps_supercategory = cocoEval.eval["precision"][0, :, k, :, :]
+    ps_["ps_supercategory"] = ps_supercategory
     # compute precision but ignore any class confusion
     gt = copy.deepcopy(cocoGt)
-    for idx, ann in enumerate(gt.dataset['annotations']):
-        if ann['category_id'] != catId:
-            gt.dataset['annotations'][idx]['ignore'] = 1
-            gt.dataset['annotations'][idx]['iscrowd'] = 1
-            gt.dataset['annotations'][idx]['category_id'] = catId
+    for idx, ann in enumerate(gt.dataset["annotations"]):
+        if ann["category_id"] != catId:
+            gt.dataset["annotations"][idx]["ignore"] = 1
+            gt.dataset["annotations"][idx]["iscrowd"] = 1
+            gt.dataset["annotations"][idx]["category_id"] = catId
     cocoEval = COCOeval(gt, copy.deepcopy(dt), iou_type)
     cocoEval.params.imgIds = imgIds
     cocoEval.params.maxDets = [100]
     cocoEval.params.iouThrs = [0.1]
     cocoEval.params.useCats = 1
     if areas:
-        cocoEval.params.areaRng = [[0**2, areas[2]], [0**2, areas[0]],
-                                   [areas[0], areas[1]], [areas[1], areas[2]]]
+        cocoEval.params.areaRng = [
+            [0 ** 2, areas[2]],
+            [0 ** 2, areas[0]],
+            [areas[0], areas[1]],
+            [areas[1], areas[2]],
+        ]
     cocoEval.evaluate()
     cocoEval.accumulate()
-    ps_allcategory = cocoEval.eval['precision'][0, :, k, :, :]
-    ps_['ps_allcategory'] = ps_allcategory
+    ps_allcategory = cocoEval.eval["precision"][0, :, k, :, :]
+    ps_["ps_allcategory"] = ps_allcategory
     return k, ps_
 
 
-def analyze_results(res_file,
-                    ann_file,
-                    res_types,
-                    out_dir,
-                    extraplots=None,
-                    areas=None):
+def analyze_results(res_file, ann_file, res_types, out_dir=None, extraplots=None, areas=None):
     for res_type in res_types:
-        assert res_type in ['bbox', 'segm']
+        assert res_type in ["bbox", "segm"]
     if areas:
-        assert len(areas) == 3, '3 integers should be specified as areas, \
-            representing 3 area regions'
+        assert (
+            len(areas) == 3
+        ), "3 integers should be specified as areas, \
+            representing 3 area regions"
 
-    directory = os.path.dirname(out_dir + '/')
+    if not out_dir:
+        out_dir = Path(res_file).parent
+        out_dir = str(out_dir / "coco_error_analysis")
+
+    directory = os.path.dirname(out_dir + "/")
     if not os.path.exists(directory):
-        print(f'-------------create {out_dir}-----------------')
+        print(f"-------------create {out_dir}-----------------")
         os.makedirs(directory)
 
     cocoGt = COCO(ann_file)
     cocoDt = cocoGt.loadRes(res_file)
     imgIds = cocoGt.getImgIds()
     for res_type in res_types:
-        res_out_dir = out_dir + '/' + res_type + '/'
+        res_out_dir = out_dir + "/" + res_type + "/"
         res_directory = os.path.dirname(res_out_dir)
         if not os.path.exists(res_directory):
-            print(f'-------------create {res_out_dir}-----------------')
+            print(f"-------------create {res_out_dir}-----------------")
             os.makedirs(res_directory)
         iou_type = res_type
-        cocoEval = COCOeval(
-            copy.deepcopy(cocoGt), copy.deepcopy(cocoDt), iou_type)
+        cocoEval = COCOeval(copy.deepcopy(cocoGt), copy.deepcopy(cocoDt), iou_type)
         cocoEval.params.imgIds = imgIds
         cocoEval.params.iouThrs = [0.75, 0.5, 0.1]
         cocoEval.params.maxDets = [100]
         if areas:
-            cocoEval.params.areaRng = [[0**2, areas[2]], [0**2, areas[0]],
-                                       [areas[0], areas[1]],
-                                       [areas[1], areas[2]]]
+            cocoEval.params.areaRng = [
+                [0 ** 2, areas[2]],
+                [0 ** 2, areas[0]],
+                [areas[0], areas[1]],
+                [areas[1], areas[2]],
+            ]
         cocoEval.evaluate()
         cocoEval.accumulate()
-        ps = cocoEval.eval['precision']
+        ps = cocoEval.eval["precision"]
         ps = np.vstack([ps, np.zeros((4, *ps.shape[1:]))])
         catIds = cocoGt.getCatIds()
         recThrs = cocoEval.params.recThrs
         with Pool(processes=48) as pool:
-            args = [(k, cocoDt, cocoGt, catId, iou_type, areas)
-                    for k, catId in enumerate(catIds)]
+            args = [(k, cocoDt, cocoGt, catId, iou_type, areas) for k, catId in enumerate(catIds)]
             analyze_results = pool.starmap(analyze_individual_category, args)
         for k, catId in enumerate(catIds):
             nm = cocoGt.loadCats(catId)[0]
             print(f'--------------saving {k + 1}-{nm["name"]}---------------')
             analyze_result = analyze_results[k]
             assert k == analyze_result[0]
-            ps_supercategory = analyze_result[1]['ps_supercategory']
-            ps_allcategory = analyze_result[1]['ps_allcategory']
+            ps_supercategory = analyze_result[1]["ps_supercategory"]
+            ps_allcategory = analyze_result[1]["ps_allcategory"]
             # compute precision but ignore superclass confusion
             ps[3, :, k, :, :] = ps_supercategory
             # compute precision but ignore any class confusion
@@ -303,47 +306,41 @@ def analyze_results(res_file,
             ps[ps == -1] = 0
             ps[5, :, k, :, :] = ps[4, :, k, :, :] > 0
             ps[6, :, k, :, :] = 1.0
-            makeplot(recThrs, ps[:, :, k], res_out_dir, nm['name'], iou_type)
+            makeplot(recThrs, ps[:, :, k], res_out_dir, nm["name"], iou_type)
             if extraplots:
-                makebarplot(recThrs, ps[:, :, k], res_out_dir, nm['name'],
-                            iou_type)
-        makeplot(recThrs, ps, res_out_dir, 'allclass', iou_type)
+                makebarplot(recThrs, ps[:, :, k], res_out_dir, nm["name"], iou_type)
+        makeplot(recThrs, ps, res_out_dir, "allclass", iou_type)
         if extraplots:
-            makebarplot(recThrs, ps, res_out_dir, 'allclass', iou_type)
-            make_gt_area_group_numbers_plot(
-                cocoEval=cocoEval, outDir=res_out_dir, verbose=True)
+            makebarplot(recThrs, ps, res_out_dir, "allclass", iou_type)
+            make_gt_area_group_numbers_plot(cocoEval=cocoEval, outDir=res_out_dir, verbose=True)
             make_gt_area_histogram_plot(cocoEval=cocoEval, outDir=res_out_dir)
 
 
 def main():
-    parser = ArgumentParser(description='COCO Error Analysis Tool')
-    parser.add_argument('result', help='result file (json format) path')
-    parser.add_argument('out_dir', help='dir to save analyze result images')
+    parser = ArgumentParser(description="COCO Error Analysis Tool")
+    parser.add_argument("dataset_path", type=str, help="COCO dataset (json file) path")
+    parser.add_argument("results_path", type=str, help="COCO results (json file) path")
+    parser.add_argument("--out_dir", help="dir to save analyze result images")
+    parser.add_argument("--types", type=str, nargs="+", default=["bbox"], help="result types")
+    parser.add_argument("--extraplots", action="store_true", help="export extra bar/stat plots")
     parser.add_argument(
-        '--ann',
-        default='data/coco/annotations/instances_val2017.json',
-        help='annotation file path')
-    parser.add_argument(
-        '--types', type=str, nargs='+', default=['bbox'], help='result types')
-    parser.add_argument(
-        '--extraplots',
-        action='store_true',
-        help='export extra bar/stat plots')
-    parser.add_argument(
-        '--areas',
+        "--areas",
         type=int,
-        nargs='+',
+        nargs="+",
         default=[1024, 9216, 10000000000],
-        help='area regions')
+        help="area regions",
+    )
     args = parser.parse_args()
+
     analyze_results(
-        args.result,
-        args.ann,
+        args.results_path,
+        args.dataset_path,
         args.types,
         out_dir=args.out_dir,
         extraplots=args.extraplots,
-        areas=args.areas)
+        areas=args.areas,
+    )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/coco_evaluation.py
+++ b/scripts/coco_evaluation.py
@@ -1,0 +1,361 @@
+from argparse import ArgumentParser
+from pathlib import Path
+import json
+import itertools
+import warnings
+from collections import OrderedDict
+from terminaltables import AsciiTable
+
+import numpy as np
+
+try:
+    from pycocotools.coco import COCO
+    from pycocotools.cocoeval import COCOeval
+except ImportError:
+    raise ImportError('Please run "pip install -U pycocotools" ' "to install pycocotools first for coco evaluation.")
+
+
+def _cocoeval_summarize(
+    cocoeval, ap=1, iouThr=None, catIdx=None, areaRng="all", maxDets=100, catName="", nameStrLen=None
+):
+    p = cocoeval.params
+    if catName:
+        iStr = " {:<18} {} {:<{nameStrLen}} @[ IoU={:<9} | area={:>6s} | maxDets={:>3d} ] = {:0.3f}"
+        nameStr = catName
+    else:
+        iStr = " {:<18} {} @[ IoU={:<9} | area={:>6s} | maxDets={:>3d} ] = {:0.3f}"
+    titleStr = "Average Precision" if ap == 1 else "Average Recall"
+    typeStr = "(AP)" if ap == 1 else "(AR)"
+    iouStr = "{:0.2f}:{:0.2f}".format(p.iouThrs[0], p.iouThrs[-1]) if iouThr is None else "{:0.2f}".format(iouThr)
+
+    aind = [i for i, aRng in enumerate(p.areaRngLbl) if aRng == areaRng]
+    mind = [i for i, mDet in enumerate(p.maxDets) if mDet == maxDets]
+    if ap == 1:
+        # dimension of precision: [TxRxKxAxM]
+        s = cocoeval.eval["precision"]
+        # IoU
+        if iouThr is not None:
+            t = np.where(iouThr == p.iouThrs)[0]
+            s = s[t]
+        if catIdx is not None:
+            s = s[:, :, catIdx, aind, mind]
+        else:
+            s = s[:, :, :, aind, mind]
+    else:
+        # dimension of recall: [TxKxAxM]
+        s = cocoeval.eval["recall"]
+        if iouThr is not None:
+            t = np.where(iouThr == p.iouThrs)[0]
+            s = s[t]
+        if catIdx is not None:
+            s = s[:, catIdx, aind, mind]
+        else:
+            s = s[:, :, aind, mind]
+    if len(s[s > -1]) == 0:
+        mean_s = -1
+    else:
+        mean_s = np.mean(s[s > -1])
+    if catName:
+        print(iStr.format(titleStr, typeStr, nameStr, iouStr, areaRng, maxDets, mean_s, nameStrLen=nameStrLen))
+    else:
+        print(iStr.format(titleStr, typeStr, iouStr, areaRng, maxDets, mean_s))
+    return mean_s
+
+
+def evaluate_coco(
+    dataset_path,
+    result_path,
+    metric="bbox",
+    classwise=False,
+    proposal_nums=(10, 100, 500),
+    iou_thrs=None,
+    metric_items=None,
+    out_dir=None,
+):
+    """Evaluation in COCO protocol.
+    Args:
+        dataset_path (str): COCO dataset json path.
+        result_path (str): COCO result json path.
+        metric (str | list[str]): Metrics to be evaluated. Options are
+            'bbox', 'segm', 'proposal'.
+        classwise (bool): Whether to evaluating the AP for each class.
+        proposal_nums (Sequence[int]): Proposal number used for evaluating
+            recalls, such as recall@100, recall@500.
+            Default: (10, 100, 500).
+        iou_thrs (Sequence[float], optional): IoU threshold used for
+            evaluating recalls/mAPs. If set to a list, the average of all
+            IoUs will also be computed. If not specified, [0.50, 0.55,
+            0.60, 0.65, 0.70, 0.75, 0.80, 0.85, 0.90, 0.95] will be used.
+            Default: None.
+        metric_items (list[str] | str, optional): Metric items that will
+            be returned. If not specified, ``['AR@10', 'AR@100',
+            'AR@500', 'AR_s@500', 'AR_m@500', 'AR_l@500' ]`` will be
+            used when ``metric=='proposal'``, ``['mAP', 'mAP50', 'mAP75',
+            'mAP_s', 'mAP_m', 'mAP_l', 'mAP50_s', 'mAP50_m', 'mAP50_l']``
+            will be used when ``metric=='bbox' or metric=='segm'``.
+        out_dir (str): Directory to save evaluation result json.
+    Returns:
+        dict[str, float]: COCO style evaluation metric.
+    """
+
+    metrics = metric if isinstance(metric, list) else [metric]
+    allowed_metrics = ["bbox", "segm", "proposal"]
+    for metric in metrics:
+        if metric not in allowed_metrics:
+            raise KeyError(f"metric {metric} is not supported")
+    if iou_thrs is None:
+        iou_thrs = np.linspace(0.5, 0.95, int(np.round((0.95 - 0.5) / 0.05)) + 1, endpoint=True)
+    if metric_items is not None:
+        if not isinstance(metric_items, list):
+            metric_items = [metric_items]
+
+    eval_results = OrderedDict()
+    cocoGt = COCO(dataset_path)
+    cat_ids = list(cocoGt.cats.keys())
+    for metric in metrics:
+        msg = f"Evaluating {metric}..."
+        msg = "\n" + msg
+        print(msg)
+
+        iou_type = metric
+        with open(result_path) as json_file:
+            results = json.load(json_file)
+        try:
+            if iou_type == "segm":
+                # Refer to https://github.com/cocodataset/cocoapi/blob/master/PythonAPI/pycocotools/coco.py#L331  # noqa
+                # When evaluating mask AP, if the results contain bbox,
+                # cocoapi will use the box area instead of the mask area
+                # for calculating the instance area. Though the overall AP
+                # is not affected, this leads to different
+                # small/medium/large mask AP results.
+                for x in results:
+                    x.pop("bbox")
+                warnings.simplefilter("once")
+                warnings.warn(
+                    'The key "bbox" is deleted for more accurate mask AP '
+                    "of small/medium/large instances since v2.12.0. This "
+                    "does not change the overall mAP calculation.",
+                    UserWarning,
+                )
+            cocoDt = cocoGt.loadRes(results)
+        except IndexError:
+            print("The testing results of the whole dataset is empty.")
+            break
+
+        cocoEval = COCOeval(cocoGt, cocoDt, iou_type)
+        cocoEval.params.catIds = cat_ids
+        cocoEval.params.maxDets = list(proposal_nums)
+        cocoEval.params.iouThrs = iou_thrs
+        # mapping of cocoEval.stats
+        coco_metric_names = {
+            "mAP": 0,
+            "mAP50": 1,
+            "mAP75": 2,
+            "mAP_s": 3,
+            "mAP_m": 4,
+            "mAP_l": 5,
+            "AR@10": 6,
+            "AR@100": 7,
+            "AR@500": 8,
+            "AR_s@500": 9,
+            "AR_m@500": 10,
+            "AR_l@500": 11,
+            "mAP50_s": 12,
+            "mAP50_m": 13,
+            "mAP50_l": 14,
+        }
+        if metric_items is not None:
+            for metric_item in metric_items:
+                if metric_item not in coco_metric_names:
+                    raise KeyError(f"metric item {metric_item} is not supported")
+        if metric == "proposal":
+            cocoEval.params.useCats = 0
+            cocoEval.evaluate()
+            cocoEval.accumulate()
+            cocoEval.summarize()
+            if metric_items is None:
+                metric_items = ["AR@10", "AR@100", "AR@500", "AR_s@500", "AR_m@500", "AR_l@500"]
+
+            for item in metric_items:
+                val = float(f"{cocoEval.stats[coco_metric_names[item]]:.3f}")
+                eval_results[item] = val
+        else:
+            cocoEval.evaluate()
+            cocoEval.accumulate()
+            cocoEval.summarize()
+            # calculate mAP50_s/m/l
+            mAP50_s = _cocoeval_summarize(
+                cocoEval, ap=1, iouThr=0.5, areaRng="small", maxDets=cocoEval.params.maxDets[-1]
+            )
+            mAP50_m = _cocoeval_summarize(
+                cocoEval, ap=1, iouThr=0.5, areaRng="medium", maxDets=cocoEval.params.maxDets[-1]
+            )
+            mAP50_l = _cocoeval_summarize(
+                cocoEval, ap=1, iouThr=0.5, areaRng="large", maxDets=cocoEval.params.maxDets[-1]
+            )
+            cocoEval.stats = np.append(cocoEval.stats, [mAP50_s, mAP50_m, mAP50_l], 0)
+
+            if classwise:  # Compute per-category AP
+                # Compute per-category AP
+                # from https://github.com/facebookresearch/detectron2/
+                precisions = cocoEval.eval["precision"]
+                # precision: (iou, recall, cls, area range, max dets)
+                assert len(cat_ids) == precisions.shape[2]
+
+                max_cat_name_len = 0
+                for idx, catId in enumerate(cat_ids):
+                    nm = cocoGt.loadCats(catId)[0]
+                    cat_name_len = len(nm["name"])
+                    max_cat_name_len = cat_name_len if cat_name_len > max_cat_name_len else max_cat_name_len
+
+                results_per_category = []
+                for idx, catId in enumerate(cat_ids):
+                    # area range index 0: all area ranges
+                    # max dets index -1: typically 100 per image
+                    nm = cocoGt.loadCats(catId)[0]
+                    ap = _cocoeval_summarize(
+                        cocoEval,
+                        ap=1,
+                        catIdx=idx,
+                        areaRng="all",
+                        maxDets=cocoEval.params.maxDets[-1],
+                        catName=nm["name"],
+                        nameStrLen=max_cat_name_len,
+                    )
+                    ap_s = _cocoeval_summarize(
+                        cocoEval,
+                        ap=1,
+                        catIdx=idx,
+                        areaRng="small",
+                        maxDets=cocoEval.params.maxDets[-1],
+                        catName=nm["name"],
+                        nameStrLen=max_cat_name_len,
+                    )
+                    ap_m = _cocoeval_summarize(
+                        cocoEval,
+                        ap=1,
+                        catIdx=idx,
+                        areaRng="medium",
+                        maxDets=cocoEval.params.maxDets[-1],
+                        catName=nm["name"],
+                        nameStrLen=max_cat_name_len,
+                    )
+                    ap_l = _cocoeval_summarize(
+                        cocoEval,
+                        ap=1,
+                        catIdx=idx,
+                        areaRng="large",
+                        maxDets=cocoEval.params.maxDets[-1],
+                        catName=nm["name"],
+                        nameStrLen=max_cat_name_len,
+                    )
+                    ap50 = _cocoeval_summarize(
+                        cocoEval,
+                        ap=1,
+                        iouThr=0.5,
+                        catIdx=idx,
+                        areaRng="all",
+                        maxDets=cocoEval.params.maxDets[-1],
+                        catName=nm["name"],
+                        nameStrLen=max_cat_name_len,
+                    )
+                    ap50_s = _cocoeval_summarize(
+                        cocoEval,
+                        ap=1,
+                        iouThr=0.5,
+                        catIdx=idx,
+                        areaRng="small",
+                        maxDets=cocoEval.params.maxDets[-1],
+                        catName=nm["name"],
+                        nameStrLen=max_cat_name_len,
+                    )
+                    ap50_m = _cocoeval_summarize(
+                        cocoEval,
+                        ap=1,
+                        iouThr=0.5,
+                        catIdx=idx,
+                        areaRng="medium",
+                        maxDets=cocoEval.params.maxDets[-1],
+                        catName=nm["name"],
+                        nameStrLen=max_cat_name_len,
+                    )
+                    ap50_l = _cocoeval_summarize(
+                        cocoEval,
+                        ap=1,
+                        iouThr=0.5,
+                        catIdx=idx,
+                        areaRng="large",
+                        maxDets=cocoEval.params.maxDets[-1],
+                        catName=nm["name"],
+                        nameStrLen=max_cat_name_len,
+                    )
+                    results_per_category.append((f'{metric}_{nm["name"]}_mAP', f"{float(ap):0.3f}"))
+                    results_per_category.append((f'{metric}_{nm["name"]}_mAP_s', f"{float(ap_s):0.3f}"))
+                    results_per_category.append((f'{metric}_{nm["name"]}_mAP_m', f"{float(ap_m):0.3f}"))
+                    results_per_category.append((f'{metric}_{nm["name"]}_mAP_l', f"{float(ap_l):0.3f}"))
+                    results_per_category.append((f'{metric}_{nm["name"]}_mAP50', f"{float(ap50):0.3f}"))
+                    results_per_category.append((f'{metric}_{nm["name"]}_mAP50_s', f"{float(ap50_s):0.3f}"))
+                    results_per_category.append((f'{metric}_{nm["name"]}_mAP50_m', f"{float(ap50_m):0.3f}"))
+                    results_per_category.append((f'{metric}_{nm["name"]}_mAP50_l', f"{float(ap50_l):0.3f}"))
+
+                num_columns = min(6, len(results_per_category) * 2)
+                results_flatten = list(itertools.chain(*results_per_category))
+                headers = ["category", "AP"] * (num_columns // 2)
+                results_2d = itertools.zip_longest(*[results_flatten[i::num_columns] for i in range(num_columns)])
+                table_data = [headers]
+                table_data += [result for result in results_2d]
+                table = AsciiTable(table_data)
+                print("\n" + table.table)
+
+            if metric_items is None:
+                metric_items = ["mAP", "mAP50", "mAP75", "mAP_s", "mAP_m", "mAP_l", "mAP50_s", "mAP50_m", "mAP50_l"]
+
+            for metric_item in metric_items:
+                key = f"{metric}_{metric_item}"
+                val = float(f"{cocoEval.stats[coco_metric_names[metric_item]]:.3f}")
+                eval_results[key] = val
+            ap = cocoEval.stats[:6]
+            eval_results[f"{metric}_mAP_copypaste"] = (
+                f"{ap[0]:.3f} {ap[1]:.3f} {ap[2]:.3f} {ap[3]:.3f} " f"{ap[4]:.3f} {ap[5]:.3f}"
+            )
+            eval_results["results_per_category"] = {key: value for key, value in results_per_category}
+    # set save path
+    if not out_dir:
+        out_dir = Path(result_path).parent
+    save_path = str(out_dir / "eval.json")
+    # export as json
+    with open(save_path, "w", encoding="utf-8") as outfile:
+        json.dump(eval_results, outfile, indent=4, separators=(",", ":"))
+    return eval_results
+
+
+def main():
+    parser = ArgumentParser(description="COCO Evaluation Tool")
+    parser.add_argument("dataset_path", type=str, help="COCO dataset (json file) path")
+    parser.add_argument("result_path", type=str, help="COCO result (json file) path")
+    parser.add_argument("--out_dir", type=str, default=None, help="dir to save evaluation result json")
+    parser.add_argument("--metric", type=str, nargs="+", default=["bbox"], help="metric types")
+    parser.add_argument("--classwise", action="store_true", help="whether to evaluate the AP for each class")
+    parser.add_argument(
+        "--proposal_nums",
+        type=int,
+        nargs="+",
+        default=[10, 100, 500],
+        help="Proposal number used for evaluating recalls, such as recall@100, recall@500",
+    )
+    parser.add_argument("--iou_thrs", type=float, default=None, help="IoU threshold used for evaluating recalls/mAPs")
+    args = parser.parse_args()
+    # perform coco eval
+    eval_results = evaluate_coco(
+        args.dataset_path,
+        args.result_path,
+        args.metric,
+        args.classwise,
+        args.proposal_nums,
+        args.iou_thrs,
+        args.out_dir,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## `coco_evaluation.py` script usage:

```bash
python scripts/coco_evaluation.py dataset.json results.json
```

will calculate coco evaluation and export them to given output folder directory.

If you want to specify mAP metric type, set it as `--metric bbox mask`.

If you want to also calculate classwise scores add `--classwise` argument.

If you want to specify max detections, set it as `--proposal_nums 10 100 500`.

If you want to specify a psecific IOU threshold, set it as `--iou_thrs 0.5`. Default includes `0.50:0.95` and `0.5` scores.

If you want to specify export directory, set it as `--out_dir output/folder/directory `.

## `coco_error_analysis.py` script usage:

```bash
python scripts/coco_error_analysis.py dataset.json results.json
```

will calculate coco error plots and export them to given output folder directory.

If you want to specify mAP result type, set it as `--types bbox mask`.

If you want to export extra mAP bar plots and annotation area stats add `--extraplots` argument.

If you want to specify area regions, set it as `--areas 1024 9216 10000000000`.

If you want to specify export directory, set it as `--out_dir output/folder/directory `.