### PR TITLE
add additional fields to seqinfo.ini for mot utils

### DIFF
--- a/sahi/utils/mot.py
+++ b/sahi/utils/mot.py
@@ -224,8 +224,11 @@ class MotVideo:
         filepath.parent.mkdir(exist_ok=True)
         # create seqinfo.ini file with seqLength
         with open(str(filepath), "w") as file:
-            file.write(f"seqLength={seq_length}\n")
+            file.write("[Sequence]\n")
+            file.write(f"name={self.name}\n")
+            file.write(f"imDir=img1\n")
             file.write(f"frameRate={self.frame_rate}\n")
+            file.write(f"seqLength={seq_length}\n")
             file.write(f"imWidth={self.image_width}\n")
             file.write(f"imHeight={self.image_height}")
 


### PR DESCRIPTION
[https://github.com/open-mmlab/mmtracking/blob/master/tools/convert_datasets/mot2coco.py](url)  script throws AssertionError because there is no field indicating video name on seqinfo.ini files produced by the current _create_info_file method in the mot class. 
<img width="364" alt="Ekran görüntüsü 2021-08-13 121425" src="https://user-images.githubusercontent.com/68073829/129335471-32b1e32f-2ba8-44bc-854f-6216be6046d8.png">
![MicrosoftTeams-image](https://user-images.githubusercontent.com/68073829/129335509-f859598a-7f6f-4f3c-95f0-6142b96381ec.png).
