### PR TITLE
Include requirements.txt in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 opencv-python>=4.2.0.32
 shapely>=1.7.0
 tqdm>=4.48.2
-dataclasses; python_version<"3.7"
 pillow>=8.2.0
 pyyaml
 fire

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def get_long_description():
 
 
 def get_requirements():
-    with open("requirements.txt") as f:
+    with open("requirements.txt", encoding="utf8") as f:
         return f.read().splitlines()
 
 


### PR DESCRIPTION
The `requirements.txt` file was not included in [sahi-0.8.0.tar.gz](https://files.pythonhosted.org/packages/8a/bb/b112407386621507892dcbd51d97cb4be1192fb0530a9da4988b40f604fe/sahi-0.8.0.tar.gz) on PyPI, which is causing the conda packaging to fail at https://github.com/conda-forge/staged-recipes/pull/16106/files#r703927160.

<details>

```python-traceback
Processing $SRC_DIR
  Created temporary directory: /tmp/pip-req-build-3127h4fo
  DEPRECATION: A future pip version will change local packages to be built in-place without first copying to a temporary directory. We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default.
   pip 21.3 will remove support for this functionality. You can find discussion regarding this at https://github.com/pypa/pip/issues/7555.
  Added file://$SRC_DIR to build tracker '/tmp/pip-req-tracker-feka46z1'
    Created temporary directory: /tmp/pip-modern-metadata-nwnw58gq
    Preparing wheel metadata: started
    Running command /home/conda/staged-recipes/build_artifacts/sahi_1631056185585/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/bin/python /home/conda/staged-recipes/build_artifacts/sahi_1631056185585/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py prepare_metadata_for_build_wheel /tmp/tmpalscc9fo
    Traceback (most recent call last):
      File "/home/conda/staged-recipes/build_artifacts/sahi_1631056185585/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 349, in <module>
        main()
      File "/home/conda/staged-recipes/build_artifacts/sahi_1631056185585/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 331, in main
        json_out['return_val'] = hook(**hook_input['kwargs'])
      File "/home/conda/staged-recipes/build_artifacts/sahi_1631056185585/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 151, in prepare_metadata_for_build_wheel
        return hook(metadata_directory, config_settings)
      File "/home/conda/staged-recipes/build_artifacts/sahi_1631056185585/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/lib/python3.9/site-packages/setuptools/build_meta.py", line 166, in prepare_metadata_for_build_wheel
        self.run_setup()
      File "/home/conda/staged-recipes/build_artifacts/sahi_1631056185585/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/lib/python3.9/site-packages/setuptools/build_meta.py", line 258, in run_setup
        super(_BuildMetaLegacyBackend,
      File "/home/conda/staged-recipes/build_artifacts/sahi_1631056185585/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/lib/python3.9/site-packages/setuptools/build_meta.py", line 150, in run_setup
        exec(compile(code, __file__, 'exec'), locals())
      File "setup.py", line 37, in <module>
        install_requires=get_requirements(),
      File "setup.py", line 15, in get_requirements
        with open("requirements.txt") as f:
    FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
```
</details>

So, this PR includes the `requirements.txt` file in the source distribution (sdist) by adding a MANIFEST.in file. See https://packaging.python.org/guides/using-manifest-in/. To test that this works, `git checkout` this branch, and run:

```
python setup.py sdist
```

Then, open the `dist/sahi-0.8.0.tar.gz` file. You should see the `requirements.txt` file inside. Confirm that things work by running:

```
pip install sahi-0.8.0.tar.gz
```
should report:
```bash
Processing ./sahi-0.8.0.tar.gz
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Requirement already satisfied: pyyaml in /srv/conda/lib/python3.7/site-packages (from sahi==0.8.0) (5.4.1)
Requirement already satisfied: shapely>=1.7.0 in /srv/conda/lib/python3.7/site-packages (from sahi==0.8.0) (1.7.1)
Requirement already satisfied: opencv-python>=4.2.0.32 in /srv/conda/lib/python3.7/site-packages (from sahi==0.8.0) (4.5.3.56)
Requirement already satisfied: pillow>=8.2.0 in /srv/conda/lib/python3.7/site-packages (from sahi==0.8.0) (8.3.2)
Requirement already satisfied: tqdm>=4.48.2 in /srv/conda/lib/python3.7/site-packages (from sahi==0.8.0) (4.62.2)
Requirement already satisfied: fire in /srv/conda/lib/python3.7/site-packages (from sahi==0.8.0) (0.4.0)
Requirement already satisfied: numpy>=1.14.5 in /srv/conda/lib/python3.7/site-packages (from opencv-python>=4.2.0.32->sahi==0.8.0) (1.21.2)
Requirement already satisfied: termcolor in /srv/conda/lib/python3.7/site-packages (from fire->sahi==0.8.0) (1.1.0)
Requirement already satisfied: six in /srv/conda/lib/python3.7/site-packages (from fire->sahi==0.8.0) (1.14.0)
Building wheels for collected packages: sahi
  Building wheel for sahi (PEP 517) ... done
  Created wheel for sahi: filename=sahi-0.8.0-py3-none-any.whl size=71487 sha256=12d159c7ddff62c91e8453cd8b6aa06624aac4096de4141117a7684b338dd8ec
  Stored in directory: /home/jovyan/.cache/pip/wheels/8e/a8/46/27171308dd72025e6acc9ad5dac5450671c072037bc48fad2c
Successfully built sahi
Installing collected packages: sahi
Successfully installed sahi-0.8.0
```

Also removing dataclasses since Python 3.7 and above is used now (#123), and setting the encoding for open() to UTF-8 per [PEP597](https://www.python.org/dev/peps/pep-0597).