### PR TITLE
improve coco to yolov5 export

### DIFF
--- a/docs/COCO.md
+++ b/docs/COCO.md
@@ -224,6 +224,28 @@ coco.export_as_yolov5(
 
 <details closed>
 <summary>
+<big><b>Convert train/val COCO dataset to ultralytics/yolov5 format:</b></big>
+</summary>
+
+```python
+from sahi.utils.coco import Coco, export_coco_as_yolov5
+
+# init Coco object
+train_coco = Coco.from_coco_dict_or_path("train_coco.json", image_dir="coco_images/")
+val_coco = Coco.from_coco_dict_or_path("val_coco.json", image_dir="coco_images/")
+
+# export converted YoloV5 formatted dataset into given output_dir with given train/val split
+data_yml_path = export_coco_as_yolov5(
+  output_dir="output/folder/dir",
+  train_coco=train_coco,
+  val_coco=val_coco
+)
+
+```
+</details>
+
+<details closed>
+<summary>
 <big><b>Subsample COCO dataset file:</b></big>
 </summary>
 

--- a/tests/test_cocoutils.py
+++ b/tests/test_cocoutils.py
@@ -781,6 +781,17 @@ class TestCocoUtils(unittest.TestCase):
             len(area_filtered_coco.json["annotations"]),
         )
 
+    def test_export_coco_as_yolov5(self):
+        from sahi.utils.coco import Coco, export_coco_as_yolov5
+
+        coco_dict_path = "tests/data/coco_utils/combined_coco.json"
+        image_dir = "tests/data/coco_utils/"
+        output_dir = "tests/data/export_coco_as_yolov5/"
+        if os.path.isdir(output_dir):
+            shutil.rmtree(output_dir)
+        coco = Coco.from_coco_dict_or_path(coco_dict_path, image_dir=image_dir)
+        export_coco_as_yolov5(output_dir=output_dir, train_coco=coco, val_coco=coco, numpy_seed=0)
+
     def test_cocovid(self):
         from sahi.utils.coco import CocoVid
 


### PR DESCRIPTION
```python
from sahi.utils.coco import Coco, export_coco_as_yolov5

# init Coco object
train_coco = Coco.from_coco_dict_or_path("train_coco.json", image_dir="coco_images/")
val_coco = Coco.from_coco_dict_or_path("val_coco.json", image_dir="coco_images/")

# export converted YoloV5 formatted dataset into given output_dir with given train/val split
data_yml_path = export_coco_as_yolov5(
  output_dir="output/folder/dir",
  train_coco=train_coco,
  val_coco=val_coco
)

```