### PR TITLE
print exports dirs after process finishes

### DIFF
--- a/sahi/model.py
+++ b/sahi/model.py
@@ -11,11 +11,6 @@ from sahi.prediction import ObjectPrediction
 from sahi.utils.torch import cuda_is_available, empty_cuda_cache
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    format="%(asctime)s - %(levelname)s - %(name)s -   %(message)s",
-    datefmt="%m/%d/%Y %H:%M:%S",
-    level=os.environ.get("LOGLEVEL", "INFO").upper(),
-)
 
 
 class DetectionModel:

--- a/sahi/predict.py
+++ b/sahi/predict.py
@@ -544,6 +544,9 @@ def predict(
         save_path = str(save_dir / "result.json")
         save_json(coco_json, save_path)
 
+    if export_visual or export_pickle or export_crop or dataset_json_path is not None:
+        print(f"Results are sucessfully exported to {save_dir}")
+
     # print prediction duration
     if verbose == 2:
         print(

--- a/sahi/predict.py
+++ b/sahi/predict.py
@@ -545,7 +545,7 @@ def predict(
         save_json(coco_json, save_path)
 
     if export_visual or export_pickle or export_crop or dataset_json_path is not None:
-        print(f"Results are sucessfully exported to {save_dir}")
+        print(f"Prediction results are sucessfully exported to {save_dir}")
 
     # print prediction duration
     if verbose == 2:

--- a/sahi/scripts/coco2yolov5.py
+++ b/sahi/scripts/coco2yolov5.py
@@ -38,6 +38,8 @@ def main(
         numpy_seed=seed,
     )
 
+    print(f"COCO to YOLOv5 conversion results are sucessfully exported to {save_dir}")
+
 
 if __name__ == "__main__":
     fire.Fire(main)

--- a/sahi/scripts/coco_error_analysis.py
+++ b/sahi/scripts/coco_error_analysis.py
@@ -261,7 +261,7 @@ def _analyze_results(
         ), "3 integers should be specified as areas, \
             representing 3 area regions"
 
-    if not out_dir:
+    if out_dir is None:
         out_dir = Path(res_file).parent
         out_dir = str(out_dir / "coco_error_analysis")
 
@@ -329,12 +329,13 @@ def _analyze_results(
             _makebarplot(recThrs, ps, res_out_dir, "allclass", iou_type)
             _make_gt_area_group_numbers_plot(cocoEval=cocoEval, outDir=res_out_dir, verbose=True)
             _make_gt_area_histogram_plot(cocoEval=cocoEval, outDir=res_out_dir)
+    print(f"Results are successfully exported to {out_dir}")
 
 
 def main(
     dataset_json_path: str,
     result_json_path: str,
-    out_dir: str,
+    out_dir: str = None,
     type: str = "bbox",
     extraplots: bool = False,
     areas: List[int] = [1024, 9216, 10000000000],

--- a/sahi/scripts/coco_error_analysis.py
+++ b/sahi/scripts/coco_error_analysis.py
@@ -329,7 +329,7 @@ def _analyze_results(
             _makebarplot(recThrs, ps, res_out_dir, "allclass", iou_type)
             _make_gt_area_group_numbers_plot(cocoEval=cocoEval, outDir=res_out_dir, verbose=True)
             _make_gt_area_histogram_plot(cocoEval=cocoEval, outDir=res_out_dir)
-    print(f"Results are successfully exported to {out_dir}")
+    print(f"COCO error analysis results are successfully exported to {out_dir}")
 
 
 def main(

--- a/sahi/scripts/coco_evaluation.py
+++ b/sahi/scripts/coco_evaluation.py
@@ -343,7 +343,7 @@ def evaluate_coco(
     # export as json
     with open(save_path, "w", encoding="utf-8") as outfile:
         json.dump(eval_results, outfile, indent=4, separators=(",", ":"))
-    print(f"Results are successfully exported to {save_path}")
+    print(f"COCO evaluation results are successfully exported to {save_path}")
     return eval_results
 
 

--- a/sahi/scripts/coco_evaluation.py
+++ b/sahi/scripts/coco_evaluation.py
@@ -343,6 +343,7 @@ def evaluate_coco(
     # export as json
     with open(save_path, "w", encoding="utf-8") as outfile:
         json.dump(eval_results, outfile, indent=4, separators=(",", ":"))
+    print(f"Results are successfully exported to {save_path}")
     return eval_results
 
 

--- a/sahi/scripts/slice_coco.py
+++ b/sahi/scripts/slice_coco.py
@@ -14,6 +14,7 @@ def main(
     ignore_negative_samples: bool = False,
     project: str = "runs/slice_coco",
     name: str = "exp",
+    min_area_ratio: float = 0.1,
 ):
     """
     Args:
@@ -24,6 +25,9 @@ def main(
         ignore_negative_samples (bool): ignore images without annotation
         project (str): save results to project/name
         name (str): save results to project/name
+        min_area_ratio (float): If the cropped annotation area to original
+            annotation ratio is smaller than this value, the annotation
+            is filtered out. Default 0.1.
     """
 
     # assure slice_size is list
@@ -56,10 +60,7 @@ def main(
         )
         output_coco_annotation_file_path = os.path.join(output_dir, sliced_coco_name + ".json")
         save_json(coco_dict, output_coco_annotation_file_path)
-        print(
-            f"Sliced 'slice_size: {slice_size}' coco file is saved to",
-            output_coco_annotation_file_path,
-        )
+        print(f"Sliced dataset for 'slice_size: {slice_size}' is exported to {output_dir}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
export directories are printed after process finishes for:
- predict
- coco error analysis
- coco evaluation
- slice coco
- coco to yolov5 converter

remove redundant logger lines in `model.py`

add `min_area_ratio` param to `sahi coco slice` cli.