### PR TITLE
Add export_file_name and export_format argument to export_visuals

### DIFF
--- a/sahi/prediction.py
+++ b/sahi/prediction.py
@@ -164,7 +164,7 @@ class PredictionResult:
         self.object_prediction_list: List[ObjectPrediction] = object_prediction_list
         self.durations_in_seconds = durations_in_seconds
 
-    def export_visuals(self, export_dir: str, text_size: float = None, rect_th: int = None):
+    def export_visuals(self, export_dir: str, export_file_name: str = "prediction_visual", export_format: str = "png", text_size: float = None, rect_th: int = None):
         Path(export_dir).mkdir(parents=True, exist_ok=True)
         visualize_object_predictions(
             image=np.ascontiguousarray(self.image),
@@ -174,8 +174,8 @@ class PredictionResult:
             text_th=None,
             color=None,
             output_dir=export_dir,
-            file_name="prediction_visual",
-            export_format="png",
+            file_name=export_file_name,
+            export_format=export_format,
         )
 
     def to_coco_annotations(self):


### PR DESCRIPTION
Add functionality to edit file name when exporting an annotated image with the export_visuals method.