### PR TITLE
refactor fiftyone utils

### DIFF
--- a/sahi/scripts/coco2fiftyone.py
+++ b/sahi/scripts/coco2fiftyone.py
@@ -1,11 +1,9 @@
 import time
-from collections import defaultdict
 from pathlib import Path
 from typing import List
 
 import fire
 
-from sahi.utils.cv import read_image_as_pil
 from sahi.utils.file import load_json
 
 
@@ -23,20 +21,14 @@ def main(
         iou_thresh (float): iou threshold for coco evaluation
     """
 
-    from sahi.utils.fiftyone import create_fiftyone_dataset_from_coco_file, fo
+    from sahi.utils.fiftyone import add_coco_labels, create_fiftyone_dataset_from_coco_file, fo
 
     coco_result_list = []
-    image_id_to_coco_result_list = []
     result_name_list = []
     if result_json_paths:
-        for ind, result_json_path in enumerate(result_json_paths):
+        for result_json_path in result_json_paths:
             coco_result = load_json(result_json_path)
             coco_result_list.append(coco_result)
-
-            image_id_to_coco_result = defaultdict(list)
-            for result in coco_result:
-                image_id_to_coco_result[result["image_id"]].append(result)
-            image_id_to_coco_result_list.append(image_id_to_coco_result)
 
             # use file names as fiftyone name, create unique names if duplicate
             result_name_temp = Path(result_json_path).stem
@@ -51,32 +43,8 @@ def main(
 
     # submit detections if coco result is given
     if result_json_paths:
-        image_id = 1
-        with fo.ProgressBar() as pb:
-            for sample in pb(dataset):
-                image_pil = read_image_as_pil(sample.filepath)
-
-                # iterate over multiple coco results
-                for ind, image_id_to_coco_result in enumerate(image_id_to_coco_result_list):
-                    coco_result_list = image_id_to_coco_result[image_id]
-                    fo_detection_list: List[fo.Detection] = []
-
-                    for coco_result in coco_result_list:
-                        fo_x = coco_result["bbox"][0] / image_pil.width
-                        fo_y = coco_result["bbox"][1] / image_pil.height
-                        fo_w = coco_result["bbox"][2] / image_pil.width
-                        fo_h = coco_result["bbox"][3] / image_pil.height
-                        fo_bbox = [fo_x, fo_y, fo_w, fo_h]
-                        fo_label = dataset.default_classes[coco_result["category_id"]]
-                        fo_confidence = coco_result["score"]
-
-                        fo_detection_list.append(
-                            fo.Detection(label=fo_label, bounding_box=fo_bbox, confidence=fo_confidence)
-                        )
-
-                    sample[result_name_list[ind]] = fo.Detections(detections=fo_detection_list)
-                    sample.save()
-                image_id += 1
+        for result_name, coco_result in zip(result_name_list, coco_result_list):
+            add_coco_labels(dataset, result_name, coco_result, coco_id_field="gt_coco_id")
 
     # visualize results
     session = fo.launch_app()
@@ -88,20 +56,22 @@ def main(
         first_coco_result_name = result_name_list[0]
         results = dataset.evaluate_detections(
             first_coco_result_name,
-            gt_field="ground_truth",
+            gt_field="gt_detections",
             eval_key=f"{first_coco_result_name}_eval",
             iou=iou_thresh,
             compute_mAP=False,
         )
         # Get the 10 most common classes in the dataset
-        counts = dataset.count_values("ground_truth.detections.label")
-        classes_top10 = sorted(counts, key=counts.get, reverse=True)[:10]
+        # counts = dataset.count_values("gt_detections.detections.label")
+        # classes_top10 = sorted(counts, key=counts.get, reverse=True)[:10]
         # Print a classification report for the top-10 classes
-        results.print_report(classes=classes_top10)
+        # results.print_report(classes=classes_top10)
         # Load the view on which we ran the `eval` evaluation
         eval_view = dataset.load_evaluation_view(f"{first_coco_result_name}_eval")
         # Show samples with most false positives
         session.view = eval_view.sort_by(f"{first_coco_result_name}_eval_fp", reverse=True)
+
+        print("SAHI has successfully launched a Fiftyone app " f"at http://localhost:{fo.config.default_app_port}")
     while 1:
         time.sleep(3)
 

--- a/sahi/utils/fiftyone.py
+++ b/sahi/utils/fiftyone.py
@@ -1,9 +1,17 @@
 import os
+import subprocess
+import sys
 
 try:
+    # to fix https://github.com/voxel51/fiftyone/issues/845
+    if sys.platform == "win32":
+        _ = subprocess.run("tskill mongod", stderr=subprocess.DEVNULL)
+    else:
+        _ = subprocess.run(["pkill", "mongod"], stderr=subprocess.DEVNULL)
+    # import fo utilities
     import fiftyone as fo
     from fiftyone.utils.coco import COCODetectionDatasetImporter as BaseCOCODetectionDatasetImporter
-    from fiftyone.utils.coco import _get_matching_image_ids, load_coco_detection_annotations
+    from fiftyone.utils.coco import _get_matching_image_ids, add_coco_labels, load_coco_detection_annotations
 except ModuleNotFoundError:
     raise ModuleNotFoundError('Please run "pip install -U fiftyone" to install fiftyone first for fiftyone utilities.')
 
@@ -58,8 +66,8 @@ class COCODetectionDatasetImporter(BaseCOCODetectionDatasetImporter):
 
 
 def create_fiftyone_dataset_from_coco_file(coco_image_dir: str, coco_json_path: str):
-    coco_importer = COCODetectionDatasetImporter(data_path=coco_image_dir, labels_path=coco_json_path)
-    dataset = fo.Dataset.from_importer(coco_importer)
+    coco_importer = COCODetectionDatasetImporter(data_path=coco_image_dir, labels_path=coco_json_path, include_id=True)
+    dataset = fo.Dataset.from_importer(coco_importer, label_field="gt")
     return dataset
 
 


### PR DESCRIPTION
- utilize `add_coco_labels()` from fiftyone
- handle when coco image ids are not sequential
- handle fiftyone bug: https://github.com/voxel51/fiftyone/issues/845