### PR TITLE
fix NMS bug

### DIFF
--- a/sahi/predict.py
+++ b/sahi/predict.py
@@ -286,7 +286,7 @@ def get_sliced_prediction(
         )
 
     # merge matching predictions
-    if len(object_prediction_list) > 0:
+    if len(object_prediction_list) > 1:
         object_prediction_list = postprocess(object_prediction_list)
 
     return PredictionResult(


### PR DESCRIPTION
If the model returns only one prediction, the NMS postprocessing fails with the following error.
```
Traceback (most recent call last):
  File "/home/tureckova/Code/TACR_TREND/sahi/sahi_predict-folder.py", line 29, in <module>
    predict(
  File "/home/tureckova/.local/lib/python3.8/site-packages/sahi/predict.py", line 477, in predict
    prediction_result = get_sliced_prediction(
  File "/home/tureckova/.local/lib/python3.8/site-packages/sahi/predict.py", line 290, in get_sliced_prediction
    object_prediction_list = postprocess(object_prediction_list)
  File "/home/tureckova/.local/lib/python3.8/site-packages/sahi/postprocess/combine.py", line 480, in __call__
    keep = batched_nms(
  File "/home/tureckova/.local/lib/python3.8/site-packages/sahi/postprocess/combine.py", line 34, in batched_nms
    keep_mask[curr_indices[curr_keep_indices]] = True
IndexError: too many indices for tensor of dimension 0
```
I think that if there is only one prediction, no postprocessing is needed - I made the appropriate change.