### PR TITLE
add support for video prediction

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,37 +154,31 @@ Find detailed info on COCO utilities (yolov5 conversion, slicing, subsampling, f
 
 Find detailed info on MOT utilities (ground truth dataset creation, exporting tracker metrics in mot challenge format) at [mot.md](docs/mot.md).
 
+
 ### Input, Export Video Support 
 
-<<<<<<< HEAD
 A video can be given as input and the results can be exported as video. You can also see the SAHI predictions during inference on the interactive window where fast-forwarding or backwarding is also possible.
-=======
-As the input, the video can be given and the results can be exporting as video. It can also see the SAHI prediction result during inference on opened window, video can be skip or prev. However, it can be still predicted from the image.
->>>>>>> 100f6fdbdafae3ee67b2bd825c7c92aa0dadb4db
 
 One more thing added prediction time to terminal.
 
-For input, export video:
-` sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --export_video --video_path home/burak/video.mp4`   
+#### For input, export video:
+`sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --source home/user/video.mp4 --input_video --export_visual`   
 
-For view result of prediction during inference:
-` sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --export_video --video_path home/burak/video.mp4  --view_img` 
+#### For view result of prediction during inference:
+`sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --source /home/user/video.mp4 --input_video --export_visual --view_image `
 
-<<<<<<< HEAD
-For fast-forwarding or backwarding at result view of prediction during inference::
-=======
-For skip or prev view result of prediction during inference:
->>>>>>> 100f6fdbdafae3ee67b2bd825c7c92aa0dadb4db
-` sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --export_video --video_path /home/burak/video.mp4  --view_img --forward_backward` 
+#### For fast-forwarding at result view of prediction during inference:
+`sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --source /home/user/video.mp4 --input_video --export_visual --view_image --fast_forwarding` 
 
 * Skip 100 frames, on opened window  press key = d 
 * Prev 100 frames, on opened window press key = a
-* Skip 5 frames, on opened window press key = g
-* Prev 5 frames, on opened window press key = f
+* Skip 10 frames, on opened window press key = g
+* Prev 10 frames, on opened window press key = f
 * Exit,  on opened window press key = Esc
 
-For input, export image:
-` sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --source /home/burak/picture.png`
+#### For input, export image:
+`sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --source /home/user/picture.png --export_visual`
+
 
 ## <div align="center">Citation</div>
 

--- a/README.md
+++ b/README.md
@@ -165,16 +165,15 @@ One more thing added prediction time to terminal.
 `sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --source home/user/video.mp4 --export_visual`   
 
 #### For view result of prediction during inference:
-`sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --source /home/user/video.mp4 --export_visual --view_image `
-
-#### For fast-forwarding at result view of prediction during inference:
-`sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --source /home/user/video.mp4 --export_visual --view_image --fast_forwarding` 
+`sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --source /home/user/video.mp4 --view_image`
 
 * Skip 100 frames, on opened window  press key = d 
 * Prev 100 frames, on opened window press key = a
-* Skip 10 frames, on opened window press key = g
-* Prev 10 frames, on opened window press key = f
+* Skip 20 frames, on opened window press key = g
+* Prev 20 frames, on opened window press key = f
 * Exit,  on opened window press key = Esc
+
+Note: If view_image is slow, you can add `--time_interval=(your choice)` argument without brackets as int. If you want to export video during view_image, in addition you must use `--export_visual` and `--avarage_prediction_time=(your choice)`. Details in predict.py file.
 
 #### For input, export image:
 `sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --source /home/user/picture.png --export_visual`

--- a/README.md
+++ b/README.md
@@ -154,6 +154,30 @@ Find detailed info on COCO utilities (yolov5 conversion, slicing, subsampling, f
 
 Find detailed info on MOT utilities (ground truth dataset creation, exporting tracker metrics in mot challenge format) at [mot.md](docs/mot.md).
 
+### Input, Export Video Support 
+
+A video can be given as input and the results can be exported as video. You can also see the SAHI predictions during inference on the interactive window where fast-forwarding or backwarding is also possible.
+
+One more thing added prediction time to terminal.
+
+For input, export video:
+` sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --export_video --video_path home/burak/video.mp4`   
+
+For view result of prediction during inference:
+` sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --export_video --video_path home/burak/video.mp4  --view_img` 
+
+For fast-forwarding or backwarding at result view of prediction during inference::
+` sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --export_video --video_path /home/burak/video.mp4  --view_img --forward_backward` 
+
+* Skip 100 frames, on opened window  press key = d 
+* Prev 100 frames, on opened window press key = a
+* Skip 5 frames, on opened window press key = g
+* Prev 5 frames, on opened window press key = f
+* Exit,  on opened window press key = Esc
+
+For input, export image:
+` sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --source /home/burak/picture.png`
+
 ## <div align="center">Citation</div>
 
 If you use this package in your work, please cite it as:

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ One more thing added prediction time to terminal.
 * Prev 20 frames, on opened window press key = f
 * Exit,  on opened window press key = Esc
 
-Note: If view_image is slow, you can add `--time_interval=(your choice)` argument without brackets as int. If you want to export video during view_image, in addition you must use `--export_visual` and `--avarage_prediction_time=(your choice)`. Details in predict.py file.
+Note: If view_image is slow, you can add `--time_interval=(your choice)` argument without brackets as int. If you want to export video during view_image, in addition you must use `--export_visual`. Details in predict.py file.
 
 #### For input, export image:
 `sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --source /home/user/picture.png --export_visual`

--- a/README.md
+++ b/README.md
@@ -162,13 +162,13 @@ A video can be given as input and the results can be exported as video. You can 
 One more thing added prediction time to terminal.
 
 #### For input, export video:
-`sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --source home/user/video.mp4 --input_video --export_visual`   
+`sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --source home/user/video.mp4 --export_visual`   
 
 #### For view result of prediction during inference:
-`sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --source /home/user/video.mp4 --input_video --export_visual --view_image `
+`sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --source /home/user/video.mp4 --export_visual --view_image `
 
 #### For fast-forwarding at result view of prediction during inference:
-`sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --source /home/user/video.mp4 --input_video --export_visual --view_image --fast_forwarding` 
+`sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --source /home/user/video.mp4 --export_visual --view_image --fast_forwarding` 
 
 * Skip 100 frames, on opened window  press key = d 
 * Prev 100 frames, on opened window press key = a

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Object detection and instance segmentation are by far the most important fields 
 
 | Command  | Description  |
 |---|---|
-| [predict](https://github.com/obss/sahi/blob/main/docs/cli.md#predict-command-usage)  | perform sliced/standard prediction using any [yolov5](https://github.com/ultralytics/yolov5)/[mmdet](https://github.com/open-mmlab/mmdetection)/[detectron2](https://github.com/facebookresearch/detectron2) model |
+| [predict](https://github.com/obss/sahi/blob/main/docs/cli.md#predict-command-usage)  | perform sliced/standard video/image prediction using any [yolov5](https://github.com/ultralytics/yolov5)/[mmdet](https://github.com/open-mmlab/mmdetection)/[detectron2](https://github.com/facebookresearch/detectron2) model |
 | [predict-fiftyone](https://github.com/obss/sahi/blob/main/docs/cli.md#predict-fiftyone-command-usage)  | perform sliced/standard prediction using any [yolov5](https://github.com/ultralytics/yolov5)/[mmdet](https://github.com/open-mmlab/mmdetection)/[detectron2](https://github.com/facebookresearch/detectron2) model and explore results in [fiftyone app](https://github.com/voxel51/fiftyone) |
 | [coco slice](https://github.com/obss/sahi/blob/main/docs/cli.md#coco-slice-command-usage)  | automatically slice COCO annotation and image files |
 | [coco fiftyone](https://github.com/obss/sahi/blob/main/docs/cli.md#coco-fiftyone-command-usage)  | explore multiple prediction results on your COCO dataset with [fiftyone ui](https://github.com/voxel51/fiftyone) ordered by number of misdetections |
@@ -50,6 +50,8 @@ Object detection and instance segmentation are by far the most important fields 
 - [Introduction to SAHI](https://medium.com/codable/sahi-a-vision-library-for-performing-sliced-inference-on-large-images-small-objects-c8b086af3b80)
 
 - [Official paper](https://arxiv.org/abs/2202.06934) (NEW)
+
+- [Video inference support is live](https://github.com/obss/sahi/issues/457) (NEW)
 
 - [Kaggle notebook](https://www.kaggle.com/remekkinas/sahi-slicing-aided-hyper-inference-yv5-and-yx) (NEW)
 
@@ -134,6 +136,8 @@ pip install detectron2 -f https://dl.fbaipublicfiles.com/detectron2/wheels/cu113
 
 Find detailed info on `sahi predict` command at [cli.md](docs/cli.md#predict-command-usage).
 
+Find detailed info on video inference at [video inference tutorial](https://github.com/obss/sahi/issues/457).
+
 Find detailed info on image/dataset slicing utilities at [slicing.md](docs/slicing.md).
 
 ### Error Analysis Plots & Evaluation
@@ -153,31 +157,6 @@ Find detailed info at [Interactive Result Visualization and Inspection](https://
 Find detailed info on COCO utilities (yolov5 conversion, slicing, subsampling, filtering, merging, splitting) at [coco.md](docs/coco.md).
 
 Find detailed info on MOT utilities (ground truth dataset creation, exporting tracker metrics in mot challenge format) at [mot.md](docs/mot.md).
-
-
-### Input, Export Video Support 
-
-A video can be given as input and the results can be exported as video. You can also see the SAHI predictions during inference on the interactive window where fast-forwarding or backwarding is also possible.
-
-One more thing added prediction time to terminal.
-
-#### For input, export video:
-`sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --source home/user/video.mp4 --export_visual`   
-
-#### For view result of prediction during inference:
-`sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --source /home/user/video.mp4 --view_image`
-
-* Skip 100 frames, on opened window  press key = d 
-* Prev 100 frames, on opened window press key = a
-* Skip 20 frames, on opened window press key = g
-* Prev 20 frames, on opened window press key = f
-* Exit,  on opened window press key = Esc
-
-Note: If view_image is slow, you can add `--time_interval=(your choice)` argument without brackets as int. If you want to export video during view_image, in addition you must use `--export_visual`. Details in predict.py file.
-
-#### For input, export image:
-`sahi predict --model_path yolov5s.pt --model_config_path coco.yaml --model_type yolov5 --source /home/user/picture.png --export_visual`
-
 
 ## <div align="center">Citation</div>
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -3,10 +3,30 @@
 ## `predict` command usage:
 
 ```bash
-sahi predict --source image/file/or/folder --model_path path/to/model --model_config_path path/to/config
+sahi predict --source image/file/or/folder --model_path path/to/model --model_config_path path/to/config --export_visual
 ```
 
 will perform sliced inference on default parameters and export the prediction visuals to runs/predict/exp folder.
+
+- It also supports video input:
+
+```bash
+sahi predict --model_path yolov5s.pt --model_type yolov5 --source video.mp4 --export_visual
+``` 
+
+You can also view video render during video inference with `--view_video`:
+
+```bash
+sahi predict --model_path yolov5s.pt --model_type yolov5 --source video.mp4 --export_visual --view_video
+``` 
+
+- To `forward 100 frames`, on opened window press key `D `
+- To `revert 100 frames`, on opened window press key `A`
+- To `forward 20 frames`, on opened window press key `G`
+- To `revert 20 frames`, on opened window press key `F`
+- To `exit`, on opened window press key `Esc`
+
+Note: If `--view_video` is slow, you can add `--frame_skip_interval=20` argument to skip interval of 20 frames each time.
 
 You can specify additional sliced prediction parameters as:
 

--- a/sahi/predict.py
+++ b/sahi/predict.py
@@ -319,7 +319,6 @@ def predict(
     export_visual: bool = False,
     view_image: bool = False,
     time_interval: int = 0,
-    avarage_prediction_time: int = 250,
     export_pickle: bool = False,
     export_crop: bool = False,
     dataset_json_path: bool = None,
@@ -385,11 +384,7 @@ def predict(
         view_image: bool
             View result of prediction during inference.
         time_interval: int
-            If view_image is slow, you can process one frames of 3(for exp: --time_interval=3). Only can use with view_image.
-        avarage_prediction_time: int
-            If you use time_interval and if you export video during view_image; you must enter appearing aproximately
-            avarage_prediction_time in terminal. You decide avarage_prediction_time. We use this value for skipped frames
-            with time_interval, because fps of exporting video is very increase.
+            If view_image or export_visual is slow, you can process one frames of 3(for exp: --time_interval=3).
         export_pickle: bool
             Export predictions as .pickle
         export_crop: bool
@@ -450,7 +445,7 @@ def predict(
     visual_dir = save_dir / "visuals"
     visual_with_gt_dir = save_dir / "visuals_with_gt"
     pickle_dir = save_dir / "pickles"
-    if export_visual:
+    if export_visual or export_pickle or export_crop or dataset_json_path is not None:
         save_dir.mkdir(parents=True, exist_ok=True)  # make dir
 
     # init model instance
@@ -484,9 +479,7 @@ def predict(
         input_video = False
 
     if input_video:
-        read_video_frame, out, image_base = get_video_reader(
-            source, save_dir, time_interval, avarage_prediction_time, export_visual, view_image
-        )
+        read_video_frame, out, image_base = get_video_reader(source, save_dir, time_interval, export_visual, view_image)
         item = read_video_frame
 
     else:

--- a/sahi/predict.py
+++ b/sahi/predict.py
@@ -23,7 +23,7 @@ from sahi.postprocess.legacy.combine import UnionMergePostprocess
 from sahi.prediction import ObjectPrediction, PredictionResult
 from sahi.slicing import slice_image
 from sahi.utils.coco import Coco, CocoImage
-from sahi.utils.cv import crop_object_predictions, read_image_as_pil, visualize_object_predictions, get_video_reader
+from sahi.utils.cv import crop_object_predictions, get_video_reader, read_image_as_pil, visualize_object_predictions
 from sahi.utils.file import Path, import_class, increment_path, list_files, save_json, save_pickle
 
 MODEL_TYPE_TO_MODEL_CLASS_NAME = {
@@ -353,7 +353,7 @@ def predict(
         model_category_remapping: dict: str to int
             Remap category ids after performing inference
         source: str
-            Folder directory that contains images or path of the image to be predicted. Also video to be predicted. 
+            Folder directory that contains images or path of the image to be predicted. Also video to be predicted.
         no_standard_prediction: bool
             Dont perform standard prediction. Default: False.
         no_sliced_prediction: bool
@@ -479,16 +479,17 @@ def predict(
 
         read_video_frame, image_base = get_video_reader(source, save_dir, export_visual, view_image, fast_forwarding)
         item = read_video_frame
-    
+
     elif input_video and export_visual:
-        
-        read_video_frame, out, image_base = get_video_reader(source, save_dir, export_visual, view_image, fast_forwarding)
+
+        read_video_frame, out, image_base = get_video_reader(
+            source, save_dir, export_visual, view_image, fast_forwarding
+        )
         item = read_video_frame
-    
+
     else:
         # If you don't want to prediction on video, the model will be given image_path_list.
         item = image_path_list
-
 
     for ind, image_path in enumerate(tqdm(item, "Performing inference on images")):
         # get filename
@@ -632,11 +633,9 @@ def predict(
             Path(output_dir).mkdir(parents=True, exist_ok=True)
             save_path = os.path.join(output_dir, filename_without_extension + "." + "png")
             cv2.imwrite(save_path, cv2.cvtColor(get_image_from_dict, cv2.COLOR_RGB2BGR))
-        
+
         time_end = time.time() - time_start
         durations_in_seconds["export_files"] = time_end
-
-        
 
     # export coco results
     if dataset_json_path:

--- a/sahi/predict.py
+++ b/sahi/predict.py
@@ -417,9 +417,8 @@ def predict(
             If True, auto postprocess check will e disabled
     """
     # assert prediction type
-    assert (
-        no_standard_prediction and no_sliced_prediction
-    ) is not True, "'no_standard_prediction' and 'no_sliced_prediction' cannot be True at the same time."
+    if no_standard_prediction and no_sliced_prediction:
+        raise ValueError("'no_standard_prediction' and 'no_sliced_prediction' cannot be True at the same time.")
 
     # auto postprocess type
     if not force_postprocess_type and model_confidence_threshold < LOW_MODEL_CONFIDENCE and postprocess_type != "NMS":

--- a/sahi/predict.py
+++ b/sahi/predict.py
@@ -575,9 +575,6 @@ def predict(
                     output_dir=None,
                     file_name=None,
                     export_format=None,
-                    source_is_video=None,
-                    view_video=None,
-                    output_video_writer=None,
                 )
                 color = (255, 0, 0)  # model predictions in red
                 _ = visualize_object_predictions(
@@ -590,9 +587,6 @@ def predict(
                     output_dir=output_dir,
                     file_name=filename_without_extension,
                     export_format=visual_export_format,
-                    source_is_video=None,
-                    view_video=None,
-                    output_video_writer=None,
                 )
 
         time_start = time.time()

--- a/sahi/predict.py
+++ b/sahi/predict.py
@@ -7,7 +7,6 @@ import time
 import warnings
 from typing import Dict, List, Optional
 
-import cv2
 import numpy as np
 from PIL import Image
 from tqdm import tqdm
@@ -571,6 +570,10 @@ def predict(
                     output_dir=None,
                     file_name=None,
                     export_format=None,
+                    input_video=None,
+                    view_image=None,
+                    out=None,
+                    image_base=None,
                 )
                 color = (255, 0, 0)  # model predictions in red
                 _ = visualize_object_predictions(
@@ -583,6 +586,10 @@ def predict(
                     output_dir=output_dir,
                     file_name=filename_without_extension,
                     export_format=visual_export_format,
+                    input_video=input_video,
+                    view_image=view_image,
+                    out=out,
+                    image_base=image_base,
                 )
 
         time_start = time.time()
@@ -602,10 +609,9 @@ def predict(
             save_pickle(data=object_prediction_list, save_path=save_path)
 
         # export visualization
-        if export_visual or view_image:
+        if export_visual and input_video:
             output_dir = str(visual_dir / Path(relative_filepath).parent)
-            # Get the image with bboxes added on it with cv.py
-            image_and_elapsed_time = visualize_object_predictions(
+            visualize_object_predictions(
                 np.ascontiguousarray(image_as_pil),
                 object_prediction_list=object_prediction_list,
                 rect_th=visual_bbox_thickness,
@@ -614,22 +620,44 @@ def predict(
                 output_dir=output_dir,
                 file_name=filename_without_extension,
                 export_format=visual_export_format,
+                input_video=input_video,
+                view_image=view_image,
+                out=out,
+                image_base=image_base,
             )
 
-            get_image_from_dict = image_and_elapsed_time["image"]
-
-        if export_visual and input_video:
-            out.write(get_image_from_dict)
-
-        if export_visual and not input_video:
+        elif export_visual and not input_video:
             output_dir = str(visual_dir / Path(relative_filepath).parent)
-            Path(output_dir).mkdir(parents=True, exist_ok=True)
-            save_path = os.path.join(output_dir, filename_without_extension + "." + "png")
-            cv2.imwrite(save_path, cv2.cvtColor(get_image_from_dict, cv2.COLOR_RGB2BGR))
+            visualize_object_predictions(
+                np.ascontiguousarray(image_as_pil),
+                object_prediction_list=object_prediction_list,
+                rect_th=visual_bbox_thickness,
+                text_size=visual_text_size,
+                text_th=visual_text_thickness,
+                output_dir=output_dir,
+                file_name=filename_without_extension,
+                export_format=visual_export_format,
+                input_video=input_video,
+                view_image=None,
+                out=None,
+                image_base=None,
+            )
 
-        if view_image and input_video:
-            cv2.imshow("Prediction of {}".format(str(image_base)), get_image_from_dict)
-            cv2.waitKey(1)
+        elif view_image and input_video:
+            visualize_object_predictions(
+                np.ascontiguousarray(image_as_pil),
+                object_prediction_list=object_prediction_list,
+                rect_th=visual_bbox_thickness,
+                text_size=visual_text_size,
+                text_th=visual_text_thickness,
+                output_dir=None,
+                file_name=None,
+                export_format=None,
+                input_video=input_video,
+                view_image=view_image,
+                out=None,
+                image_base=image_base,
+            )
 
         time_end = time.time() - time_start
         durations_in_seconds["export_files"] = time_end

--- a/sahi/utils/cv.py
+++ b/sahi/utils/cv.py
@@ -364,6 +364,7 @@ def visualize_prediction(
         Path(output_dir).mkdir(parents=True, exist_ok=True)
         # save inference result
         save_path = os.path.join(output_dir, file_name + ".png")
+        cv2.imwrite(save_path, cv2.cvtColor(image, cv2.COLOR_RGB2BGR))
 
     elapsed_time = time.time() - elapsed_time
     return {"image": image, "elapsed_time": elapsed_time}
@@ -379,6 +380,10 @@ def visualize_object_predictions(
     output_dir: Optional[str] = None,
     file_name: str = "prediction_visual",
     export_format: str = "png",
+    input_video: bool = False,
+    view_image: bool = False,
+    out=None,
+    image_base: str = None,
 ):
     """
     Visualizes prediction category names, bounding boxes over the source image
@@ -452,9 +457,23 @@ def visualize_object_predictions(
             (255, 255, 255),
             thickness=text_th,
         )
-    if output_dir:
-        # create output folder if not present
+
+    if output_dir and input_video:
+        out.write(image)
+
+    if output_dir and not input_video:
         Path(output_dir).mkdir(parents=True, exist_ok=True)
+        # save inference result
+        save_path = os.path.join(output_dir, file_name + "." + export_format)
+        cv2.imwrite(save_path, cv2.cvtColor(image, cv2.COLOR_RGB2BGR))
+
+    if view_image and input_video:
+        cv2.imshow("Prediction of {}".format(str(image_base)), image)
+        cv2.waitKey(1)
+    elif output_dir and view_image and input_video:
+        out.write(image)
+        cv2.imshow("Prediction of {}".format(str(image_base)), image)
+        cv2.waitKey(1)
 
     elapsed_time = time.time() - elapsed_time
     return {"image": image, "elapsed_time": elapsed_time}

--- a/sahi/utils/cv.py
+++ b/sahi/utils/cv.py
@@ -214,7 +214,6 @@ def get_video_reader(
     source: str,
     save_dir: str,
     time_interval: int,
-    avarage_prediction_time: int,
     export_visual: bool = False,
     view_image: bool = False,
 ):
@@ -258,6 +257,9 @@ def get_video_reader(
 
         else:
             while video_capture.isOpened:
+                frame_num = video_capture.get(cv2.CAP_PROP_POS_FRAMES)
+                video_capture.set(cv2.CAP_PROP_POS_FRAMES, frame_num + time_interval)
+
                 ret, frame = video_capture.read()
                 if not ret:
                     print("\n=========================== Video Ended ===========================")

--- a/sahi/utils/cv.py
+++ b/sahi/utils/cv.py
@@ -482,7 +482,7 @@ def visualize_object_predictions(
         # export image with predictions
         Path(output_dir).mkdir(parents=True, exist_ok=True)
         # save inference result
-        save_path = Path(output_dir / (file_name + "." + export_format))
+        save_path = Path(output_dir) / (file_name + "." + export_format)
         cv2.imwrite(save_path, cv2.cvtColor(image, cv2.COLOR_RGB2BGR))
 
     elapsed_time = time.time() - elapsed_time

--- a/sahi/utils/cv.py
+++ b/sahi/utils/cv.py
@@ -287,7 +287,7 @@ def visualize_prediction(
         Path(output_dir).mkdir(parents=True, exist_ok=True)
         # save inference result
         save_path = os.path.join(output_dir, file_name + ".png")
-        
+
     elapsed_time = time.time() - elapsed_time
     return {"image": image, "elapsed_time": elapsed_time}
 
@@ -380,9 +380,9 @@ def visualize_object_predictions(
         Path(output_dir).mkdir(parents=True, exist_ok=True)
         # save inference result
         save_path = os.path.join(output_dir, file_name + "." + export_format)
-        
+
     elapsed_time = time.time() - elapsed_time
-    return {"image": image, "elapsed_time": elapsed_time}, image
+    return {"image": image, "elapsed_time": elapsed_time}
 
 
 def get_coco_segmentation_from_bool_mask(bool_mask):

--- a/sahi/utils/cv.py
+++ b/sahi/utils/cv.py
@@ -482,7 +482,7 @@ def visualize_object_predictions(
         # export image with predictions
         Path(output_dir).mkdir(parents=True, exist_ok=True)
         # save inference result
-        save_path = Path(output_dir) / (file_name + "." + export_format)
+        save_path = str(Path(output_dir) / (file_name + "." + export_format))
         cv2.imwrite(save_path, cv2.cvtColor(image, cv2.COLOR_RGB2BGR))
 
     elapsed_time = time.time() - elapsed_time

--- a/sahi/utils/cv.py
+++ b/sahi/utils/cv.py
@@ -217,6 +217,60 @@ def get_video_reader(
     image_base = os.path.basename(source)
     # get video from video path
     video_capture = cv2.VideoCapture(source)
+
+    def read_video_frame(video_capture):
+        if view_image:
+            cv2.imshow("Prediction of {}".format(str(image_base)), cv2.WINDOW_AUTOSIZE)
+            if fast_forwarding:
+                while video_capture.isOpened:
+                    k = cv2.waitKey(30)
+
+                    frame_num = video_capture.get(cv2.CAP_PROP_POS_FRAMES)
+
+                    if k == 27:
+                        print(
+                            "\n===========================Closing==========================="
+                        )  # Exit the prediction, Key = Esc
+                        exit()
+                    if k == 100:
+                        frame_num += 100  # Skip 100 frames, Key = d
+                    if k == 97:
+                        frame_num -= 100  # Prev 100 frames, Key = a
+                    if k == 103:
+                        frame_num += 10  # Skip 10 frames, Key = g
+                    if k == 102:
+                        frame_num -= 10  # Prev 10 frames, Key = f
+                    video_capture.set(cv2.CAP_PROP_POS_FRAMES, frame_num)
+
+                    ret, frame = video_capture.read()
+                    if not ret:
+                        print("\n===========================Video Ended===========================")
+                        break
+                    yield Image.fromarray(frame)
+
+            else:
+                while video_capture.isOpened:
+                    k = cv2.waitKey(30)
+
+                    if k == 27:
+                        print(
+                            "\n===========================Closing==========================="
+                        )  # Exit the prediction, Key = Esc
+                        exit()
+
+                    ret, frame = video_capture.read()
+                    if not ret:
+                        print("\n===========================Video Ended===========================")
+                        break
+                    yield Image.fromarray(frame)
+        else:
+            while video_capture.isOpened:
+                ret, frame = video_capture.read()
+                if not ret:
+                    print("\n===========================Video Ended===========================")
+                    break
+                yield Image.fromarray(frame)
+
     if export_visual:
         # get video properties and create VideoWriter object
         fps = video_capture.get(cv2.CAP_PROP_FPS)
@@ -226,58 +280,8 @@ def get_video_reader(
         fourcc = cv2.VideoWriter_fourcc(*"mp4v")
         out = cv2.VideoWriter(os.path.join(save_dir, image_base), fourcc, fps, size)
 
-        if view_image:
-            cv2.imshow("Prediction of {}".format(str(image_base)), cv2.WINDOW_AUTOSIZE)
-
-    if fast_forwarding:
-
-        def read_video_frame(video_capture):
-            while video_capture.isOpened:
-                k = cv2.waitKey(30)
-
-                frame_num = video_capture.get(cv2.CAP_PROP_POS_FRAMES)
-
-                if k == 27:
-                    print(
-                        "\n===========================Closing==========================="
-                    )  # Exit the prediction, Key = Esc
-                    exit()
-                if k == 100:
-                    frame_num += 100  # Skip 100 frames, Key = d
-                if k == 97:
-                    frame_num -= 100  # Prev 100 frames, Key = a
-                if k == 103:
-                    frame_num += 10  # Skip 10 frames, Key = g
-                if k == 102:
-                    frame_num -= 10  # Prev 10 frames, Key = f
-                video_capture.set(cv2.CAP_PROP_POS_FRAMES, frame_num)
-
-                ret, frame = video_capture.read()
-                if not ret:
-                    print("\n===========================Video Ended===========================")
-                    break
-                yield Image.fromarray(frame)
-
-    else:
-
-        def read_video_frame(video_capture):
-            while video_capture.isOpened:
-                k = cv2.waitKey(30)
-
-                if k == 27:
-                    print(
-                        "\n===========================Closing==========================="
-                    )  # Exit the prediction, Key = Esc
-                    exit()
-
-                ret, frame = video_capture.read()
-                if not ret:
-                    print("\n===========================Video Ended===========================")
-                    break
-                yield Image.fromarray(frame)
-
-    if export_visual:
         return read_video_frame(video_capture), out, image_base
+
     else:
         return read_video_frame(video_capture), image_base
 

--- a/sahi/utils/cv.py
+++ b/sahi/utils/cv.py
@@ -287,7 +287,7 @@ def visualize_prediction(
         Path(output_dir).mkdir(parents=True, exist_ok=True)
         # save inference result
         save_path = os.path.join(output_dir, file_name + ".png")
-        cv2.imwrite(save_path, cv2.cvtColor(image, cv2.COLOR_RGB2BGR))
+        
     elapsed_time = time.time() - elapsed_time
     return {"image": image, "elapsed_time": elapsed_time}
 
@@ -380,9 +380,9 @@ def visualize_object_predictions(
         Path(output_dir).mkdir(parents=True, exist_ok=True)
         # save inference result
         save_path = os.path.join(output_dir, file_name + "." + export_format)
-        cv2.imwrite(save_path, cv2.cvtColor(image, cv2.COLOR_RGB2BGR))
+        
     elapsed_time = time.time() - elapsed_time
-    return {"image": image, "elapsed_time": elapsed_time}
+    return {"image": image, "elapsed_time": elapsed_time}, image
 
 
 def get_coco_segmentation_from_bool_mask(bool_mask):

--- a/sahi/utils/cv.py
+++ b/sahi/utils/cv.py
@@ -209,7 +209,10 @@ def apply_color_mask(image: np.ndarray, color: tuple):
     colored_mask = np.stack([r, g, b], axis=2)
     return colored_mask
 
-def get_video_reader(source: str, save_dir: str, export_visual: bool = False, view_image: bool = False, fast_forwarding: bool = False):
+
+def get_video_reader(
+    source: str, save_dir: str, export_visual: bool = False, view_image: bool = False, fast_forwarding: bool = False
+):
     # get video name with extension
     image_base = os.path.basename(source)
     # get video from video path
@@ -225,51 +228,54 @@ def get_video_reader(source: str, save_dir: str, export_visual: bool = False, vi
 
         if view_image:
             cv2.imshow("Prediction of {}".format(str(image_base)), cv2.WINDOW_AUTOSIZE)
-    
+
     if fast_forwarding:
+
         def read_video_frame(video_capture):
             while video_capture.isOpened:
-                    k = cv2.waitKey(30)
+                k = cv2.waitKey(30)
 
-                    frame_num = video_capture.get(cv2.CAP_PROP_POS_FRAMES)
+                frame_num = video_capture.get(cv2.CAP_PROP_POS_FRAMES)
 
-                    if k == 27:
-                        print(
-                            "\n===========================Closing==========================="
-                        )  # Exit the prediction, Key = Esc
-                        exit()
-                    if k == 100:
-                        frame_num += 100  # Skip 100 frames, Key = d
-                    if k == 97:
-                        frame_num -= 100  # Prev 100 frames, Key = a
-                    if k == 103:
-                        frame_num += 10  # Skip 10 frames, Key = g
-                    if k == 102:
-                        frame_num -= 10  # Prev 10 frames, Key = f
-                    video_capture.set(cv2.CAP_PROP_POS_FRAMES, frame_num)
+                if k == 27:
+                    print(
+                        "\n===========================Closing==========================="
+                    )  # Exit the prediction, Key = Esc
+                    exit()
+                if k == 100:
+                    frame_num += 100  # Skip 100 frames, Key = d
+                if k == 97:
+                    frame_num -= 100  # Prev 100 frames, Key = a
+                if k == 103:
+                    frame_num += 10  # Skip 10 frames, Key = g
+                if k == 102:
+                    frame_num -= 10  # Prev 10 frames, Key = f
+                video_capture.set(cv2.CAP_PROP_POS_FRAMES, frame_num)
 
-                    ret, frame = video_capture.read()
-                    if not ret:
-                        print("\n===========================Video Ended===========================")
-                        break
-                    yield Image.fromarray(frame)
-    
+                ret, frame = video_capture.read()
+                if not ret:
+                    print("\n===========================Video Ended===========================")
+                    break
+                yield Image.fromarray(frame)
+
     else:
+
         def read_video_frame(video_capture):
-                while video_capture.isOpened:
-                    k = cv2.waitKey(30)
+            while video_capture.isOpened:
+                k = cv2.waitKey(30)
 
-                    if k == 27:
-                        print(
-                            "\n===========================Closing==========================="
-                        )  # Exit the prediction, Key = Esc
-                        exit()
+                if k == 27:
+                    print(
+                        "\n===========================Closing==========================="
+                    )  # Exit the prediction, Key = Esc
+                    exit()
 
-                    ret, frame = video_capture.read()
-                    if not ret:
-                        print("\n===========================Video Ended===========================")
-                        break
-                    yield Image.fromarray(frame)
+                ret, frame = video_capture.read()
+                if not ret:
+                    print("\n===========================Video Ended===========================")
+                    break
+                yield Image.fromarray(frame)
+
     if export_visual:
         return read_video_frame(video_capture), out, image_base
     else:
@@ -353,7 +359,7 @@ def visualize_prediction(
         Path(output_dir).mkdir(parents=True, exist_ok=True)
         # save inference result
         save_path = os.path.join(output_dir, file_name + ".png")
-        
+
     elapsed_time = time.time() - elapsed_time
     return {"image": image, "elapsed_time": elapsed_time}
 
@@ -444,7 +450,7 @@ def visualize_object_predictions(
     if output_dir:
         # create output folder if not present
         Path(output_dir).mkdir(parents=True, exist_ok=True)
-        
+
     elapsed_time = time.time() - elapsed_time
     return {"image": image, "elapsed_time": elapsed_time}
 

--- a/sahi/utils/cv.py
+++ b/sahi/utils/cv.py
@@ -242,7 +242,8 @@ def get_video_reader(
 
     num_frames = int(video_capture.get(cv2.CAP_PROP_FRAME_COUNT))
     if view_visual:
-        num_frames /= frame_skip_interval
+        num_frames /= frame_skip_interval + 1
+        num_frames = int(num_frames)
 
     def read_video_frame(video_capture, frame_skip_interval):
         if view_visual:

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -265,7 +265,7 @@ class TestPredict(unittest.TestCase):
         source = "tests/data/coco_utils/"
         project_dir = "tests/data/predict_result"
 
-        # get full sized prediction
+        # get sliced prediction
         if os.path.isdir(project_dir):
             shutil.rmtree(project_dir, ignore_errors=True)
         predict(
@@ -304,7 +304,7 @@ class TestPredict(unittest.TestCase):
         source = "tests/data/coco_utils/"
         project_dir = "tests/data/predict_result"
 
-        # get full sized prediction
+        # get sliced prediction
         if os.path.isdir(project_dir):
             shutil.rmtree(project_dir, ignore_errors=True)
         predict(
@@ -330,6 +330,133 @@ class TestPredict(unittest.TestCase):
             export_pickle=False,
             export_crop=False,
             dataset_json_path=dataset_json_path,
+            project=project_dir,
+            name="exp",
+            verbose=1,
+        )
+
+    def test_video_prediction(self):
+        from os import path
+
+        from sahi.predict import predict
+        from sahi.utils.file import download_from_url
+        from sahi.utils.yolov5 import Yolov5TestConstants, download_yolov5n_model
+
+        # download video file
+        source_url = "https://github.com/obss/sahi/releases/download/0.9.2/test.mp4"
+        destination_path = "tests/data/test.mp4"
+        if not path.exists(destination_path):
+            download_from_url(source_url, destination_path)
+
+        # init model
+        download_yolov5n_model()
+
+        postprocess_type = "GREEDYNMM"
+        match_metric = "IOS"
+        match_threshold = 0.5
+        image_size = 320
+        class_agnostic = True
+
+        # prepare paths
+        source = destination_path
+        project_dir = "tests/data/predict_result"
+
+        # get sliced inference from video input without exporting visual
+        if os.path.isdir(project_dir):
+            shutil.rmtree(project_dir, ignore_errors=True)
+        predict(
+            model_type="yolov5",
+            model_path=Yolov5TestConstants.YOLOV5N_MODEL_PATH,
+            model_config_path=None,
+            model_confidence_threshold=CONFIDENCE_THRESHOLD,
+            model_device=MODEL_DEVICE,
+            model_category_mapping=None,
+            model_category_remapping=None,
+            source=source,
+            no_sliced_prediction=False,
+            no_standard_prediction=True,
+            slice_height=512,
+            slice_width=512,
+            image_size=image_size,
+            overlap_height_ratio=0.2,
+            overlap_width_ratio=0.2,
+            postprocess_type=postprocess_type,
+            postprocess_match_metric=match_metric,
+            postprocess_match_threshold=match_threshold,
+            postprocess_class_agnostic=class_agnostic,
+            export_visual=False,
+            export_pickle=False,
+            export_crop=False,
+            dataset_json_path=None,
+            project=project_dir,
+            name="exp",
+            verbose=1,
+        )
+
+        postprocess_type = "GREEDYNMM"
+        match_metric = "IOS"
+        match_threshold = 0.5
+        image_size = 320
+        class_agnostic = True
+
+        # get standard inference from video input without exporting visual
+        if os.path.isdir(project_dir):
+            shutil.rmtree(project_dir, ignore_errors=True)
+        predict(
+            model_type="yolov5",
+            model_path=Yolov5TestConstants.YOLOV5N_MODEL_PATH,
+            model_config_path=None,
+            model_confidence_threshold=CONFIDENCE_THRESHOLD,
+            model_device=MODEL_DEVICE,
+            model_category_mapping=None,
+            model_category_remapping=None,
+            source=source,
+            no_sliced_prediction=True,
+            no_standard_prediction=False,
+            image_size=image_size,
+            postprocess_type=postprocess_type,
+            postprocess_match_metric=match_metric,
+            postprocess_match_threshold=match_threshold,
+            postprocess_class_agnostic=class_agnostic,
+            export_visual=False,
+            export_pickle=False,
+            export_crop=False,
+            dataset_json_path=None,
+            project=project_dir,
+            name="exp",
+            verbose=1,
+        )
+
+        # get standard inference from video input and export visual
+        postprocess_type = "GREEDYNMM"
+        match_metric = "IOS"
+        match_threshold = 0.5
+        image_size = 320
+        class_agnostic = True
+
+        # get full sized prediction
+        if os.path.isdir(project_dir):
+            shutil.rmtree(project_dir, ignore_errors=True)
+        predict(
+            model_type="yolov5",
+            model_path=Yolov5TestConstants.YOLOV5N_MODEL_PATH,
+            model_config_path=None,
+            model_confidence_threshold=CONFIDENCE_THRESHOLD,
+            model_device=MODEL_DEVICE,
+            model_category_mapping=None,
+            model_category_remapping=None,
+            source=source,
+            no_sliced_prediction=True,
+            no_standard_prediction=False,
+            image_size=image_size,
+            postprocess_type=postprocess_type,
+            postprocess_match_metric=match_metric,
+            postprocess_match_threshold=match_threshold,
+            postprocess_class_agnostic=class_agnostic,
+            export_visual=True,
+            export_pickle=False,
+            export_crop=False,
+            dataset_json_path=None,
             project=project_dir,
             name="exp",
             verbose=1,


### PR DESCRIPTION
This PR brings full support for sliced/standard inference for video input format for all MMDetection/Detectron2/YOLOv5 models :fire: 

- Just give video file as source:

```bash
sahi predict --model_path yolov5s.pt --model_type yolov5 --source video.mp4 --export_visual
``` 

You can also view video render during video inference with `--view_video`:

```bash
sahi predict --model_path yolov5s.pt --model_type yolov5 --source video.mp4 --export_visual --view_video
``` 

- To `forward 100 frames`, on opened window press key `D `
- To `revert 100 frames`, on opened window press key `A`
- To `forward 20 frames`, on opened window press key `G`
- To `revert 20 frames`, on opened window press key `F`
- To `exit`, on opened window press key `Esc`

Note: If `--view_video` is slow, you can add `--frame_skip_interval=20` argument to skip interval of 20 frames each time.