### PR TITLE
Added support for exporting predictions in COCO format

### DIFF
--- a/docs/coco.md
+++ b/docs/coco.md
@@ -62,7 +62,7 @@ coco_image.add_prediction(
 coco_image.add_prediction(
   CocoPrediction(
     score=0.653424,
-    segmentation=[x_min, y_min, width, height],
+    bbox=[x_min, y_min, width, height],
     category_id=1,
     category_name='vehicle'
   )

--- a/docs/coco.md
+++ b/docs/coco.md
@@ -48,6 +48,26 @@ coco_image.add_annotation(
   )
 )
 ```
+- add predictions to coco image:
+
+```python
+coco_image.add_prediction(
+  CocoPrediction(
+    score=0.864434,
+    bbox=[x_min, y_min, width, height],
+    category_id=0,
+    category_name='human'
+  )
+)
+coco_image.add_prediction(
+  CocoPrediction(
+    score=0.653424,
+    segmentation=[x_min, y_min, width, height],
+    category_id=1,
+    category_name='vehicle'
+  )
+)
+```
 
 - add coco image to Coco object:
 
@@ -68,6 +88,32 @@ from sahi.utils.file import save_json
 
 save_json(coco_json, "coco_dataset.json")
 ```
+- you can also export prediction array in coco prediction format and save it as json :
+
+```python
+from sahi.utils.file import save_json
+
+predictions_array = coco.prediction_array
+save_json = save_json(predictions_array, "coco_predictions.json")
+```
+- this prediction array can be used to get standard coco metrics for the predictions using official pycocotool api :
+
+```python
+# note:- pycocotools need to be installed seperately 
+from pycocotools.cocoeval import COCOeval
+from pycocotools.coco import COCO
+
+coco_ground_truth = COCO(annotation_file="coco_dataset.json")
+coco_predictions = coco_ground_truth.loadRes("coco_predictions.json")
+
+coco_evaluator = COCOeval(coco_ground_truth, coco_predictions, "bbox")
+coco_evaluator.evaluate()
+coco_evaluator.accumulate()
+coco_evaluator.summarize()
+```
+
+
+
 </details>
 
 <details closed>

--- a/sahi/utils/coco.py
+++ b/sahi/utils/coco.py
@@ -620,8 +620,8 @@ class CocoImage:
     file_name: {self.file_name},
     height: {self.height},
     width: {self.width},
-    annotations: List[CocoAnnotation]>,
-    predictions: List[CocoPrediction]"""
+    annotations: List[CocoAnnotation],
+    predictions: List[CocoPrediction]>"""
 
 
 class CocoVidImage(CocoImage):

--- a/sahi/utils/coco.py
+++ b/sahi/utils/coco.py
@@ -599,7 +599,6 @@ class CocoImage:
         """
         Adds prediction to this CocoImage instance
 
-        annotation : CocoAnnotation
         prediction : CocoPrediction
         """
 

--- a/sahi/utils/coco.py
+++ b/sahi/utils/coco.py
@@ -798,6 +798,7 @@ class Coco:
         remapping_dict=None,
         ignore_negative_samples=False,
         clip_bboxes_to_img_dims=False,
+        image_id_setting="auto",
     ):
         """
         Creates Coco object.
@@ -811,7 +812,12 @@ class Coco:
                 {1:0, 2:1} maps category id 1 to 0 and category id 2 to 1
             ignore_negative_samples: bool
                 If True ignores images without annotations in all operations.
+            image_id_setting: str
+                how to assign image ids while exporting can be
+                    auto --> will assign id from scratch (<CocoImage>.id will be ignored)
+                    manual --> you will need to provide image ids in <CocoImage> instances (<CocoImage>.id can not be None)
         """
+        assert image_id_setting in ["auto", "manual"]
         self.name = name
         self.image_dir = image_dir
         self.remapping_dict = remapping_dict
@@ -820,6 +826,7 @@ class Coco:
         self.images = []
         self._stats = None
         self.clip_bboxes_to_img_dims = clip_bboxes_to_img_dims
+        self.image_id_setting = image_id_setting
 
     def add_categories_from_coco_category_list(self, coco_category_list):
         """
@@ -863,6 +870,8 @@ class Coco:
         """
 
         assert type(image) == CocoImage, "image must be a CocoImage instance"
+        if self.image_id_setting == "manual":
+            assert image.id is not None
 
         self.images.append(image)
 
@@ -1079,11 +1088,16 @@ class Coco:
             images=self.images,
             categories=self.json_categories,
             ignore_negative_samples=self.ignore_negative_samples,
+            image_id_setting=self.image_id_setting,
         )
 
     @property
     def prediction_array(self):
-        return create_coco_prediction_array(images=self.images, ignore_negative_samples=self.ignore_negative_samples)
+        return create_coco_prediction_array(
+            images=self.images,
+            ignore_negative_samples=self.ignore_negative_samples,
+            image_id_setting=self.image_id_setting,
+        )
 
     @property
     def stats(self):
@@ -1833,7 +1847,7 @@ def get_imageid2annotationlist_mapping(
     return image_id_to_annotation_list
 
 
-def create_coco_dict(images, categories, ignore_negative_samples=False):
+def create_coco_dict(images, categories, ignore_negative_samples=False, image_id_setting="auto"):
     """
     Creates COCO dict with fields "images", "annotations", "categories".
 
@@ -1844,21 +1858,23 @@ def create_coco_dict(images, categories, ignore_negative_samples=False):
             COCO categories
         ignore_negative_samples : Bool
             If True, images without annotations are ignored
+        image_id_setting: str
+            how to assign image ids while exporting can be
+                auto --> will assign id from scratch (<CocoImage>.id will be ignored)
+                manual --> you will need to provide image ids in <CocoImage> instances (<CocoImage>.id can not be None)
     Returns
     -------
         coco_dict : Dict
             COCO dict with fields "images", "annotations", "categories"
     """
-    out_images = []
-    out_annotations = []
-    out_categories = categories
+    # assertion of parameters
+    assert image_id_setting in ["auto", "manual"]
 
-    num_images = len(images)
-    image_id = 1
+    # define accumulators
     annotation_id = 1
-    for image_ind in range(num_images):
-        # get coco image and its coco annotations
-        coco_image = images[image_ind]
+    coco_dict = dict(images=[], annotations=[], categories=categories)
+    for image_index, coco_image in enumerate(images):
+        # get coco annotations
         coco_annotations = coco_image.annotations
         # get num annotations
         num_annotations = len(coco_annotations)
@@ -1866,6 +1882,13 @@ def create_coco_dict(images, categories, ignore_negative_samples=False):
         if ignore_negative_samples and num_annotations == 0:
             continue
         else:
+            # get image_id
+            if image_id_setting == "auto":
+                image_id = image_index + 1
+            elif image_id_setting == "manual":
+                assert coco_image.id is not None
+                image_id = coco_image.id
+
             # create coco image object
             out_image = {
                 "height": coco_image.height,
@@ -1873,7 +1896,7 @@ def create_coco_dict(images, categories, ignore_negative_samples=False):
                 "id": image_id,
                 "file_name": coco_image.file_name,
             }
-            out_images.append(out_image)
+            coco_dict["images"].append(out_image)
 
             # do the same for image annotations
             for coco_annotation in coco_annotations:
@@ -1887,23 +1910,15 @@ def create_coco_dict(images, categories, ignore_negative_samples=False):
                     "id": annotation_id,
                     "area": coco_annotation.area,
                 }
-                out_annotations.append(out_annotation)
-                annotation_id = annotation_id + 1
+                coco_dict["annotations"].append(out_annotation)
+                # increment annotation id
+                annotation_id += 1
 
-            # increment annotation id
-            image_id = image_id + 1
-
-    # form coco dict
-    coco_dict = {
-        "images": out_images,
-        "annotations": out_annotations,
-        "categories": out_categories,
-    }
     # return coco dict
     return coco_dict
 
 
-def create_coco_prediction_array(images, ignore_negative_samples=False):
+def create_coco_prediction_array(images, ignore_negative_samples=False, image_id_setting="auto"):
     """
     Creates COCO prediction array which is list of predictions
 
@@ -1912,19 +1927,23 @@ def create_coco_prediction_array(images, ignore_negative_samples=False):
         images : List of CocoImage containing a list of CocoAnnotation
         ignore_negative_samples : Bool
             If True, images without predictions are ignored
+        image_id_setting: str
+            how to assign image ids while exporting can be
+                auto --> will assign id from scratch (<CocoImage>.id will be ignored)
+                manual --> you will need to provide image ids in <CocoImage> instances (<CocoImage>.id can not be None)
     Returns
     -------
         coco_prediction_array : List
             COCO predictions array
     """
-    predictions_array = []
+    # assertion of parameters
+    assert image_id_setting in ["auto", "manual"]
 
-    num_images = len(images)
-    image_id = 1
+    # define accumulators
     prediction_id = 1
-    for image_ind in range(num_images):
-        # get coco image and its coco predictions
-        coco_image = images[image_ind]
+    predictions_array = []
+    for image_index, coco_image in enumerate(images):
+        # get coco predictions
         coco_predictions = coco_image.predictions
         # get num annotations
         num_predictions = len(coco_predictions)
@@ -1932,8 +1951,15 @@ def create_coco_prediction_array(images, ignore_negative_samples=False):
         if ignore_negative_samples and num_predictions == 0:
             continue
         else:
+            # get image_id
+            if image_id_setting == "auto":
+                image_id = image_index + 1
+            elif image_id_setting == "manual":
+                assert coco_image.id is not None
+                image_id = coco_image.id
+
             # create coco prediction object
-            for coco_prediction in coco_predictions:
+            for prediction_index, coco_prediction in enumerate(coco_predictions):
                 # create coco prediction object
                 out_prediction = {
                     "id": prediction_id,
@@ -1946,10 +1972,9 @@ def create_coco_prediction_array(images, ignore_negative_samples=False):
                     "area": coco_prediction.area,
                 }
                 predictions_array.append(out_prediction)
-                prediction_id = prediction_id + 1
 
-            # increment annotation id
-            image_id = image_id + 1
+                # increment prediction id
+                prediction_id += 1
 
     # return predictions array
     return predictions_array

--- a/sahi/utils/coco.py
+++ b/sahi/utils/coco.py
@@ -1868,7 +1868,8 @@ def create_coco_dict(images, categories, ignore_negative_samples=False, image_id
             COCO dict with fields "images", "annotations", "categories"
     """
     # assertion of parameters
-    assert image_id_setting in ["auto", "manual"]
+    if image_id_setting not in ["auto", "manual"]:
+        raise ValueError(f"'image_id_setting' should be one of ['auto', 'manual']")
 
     # define accumulators
     image_index = 1
@@ -1888,7 +1889,8 @@ def create_coco_dict(images, categories, ignore_negative_samples=False, image_id
                 image_id = image_index
                 image_index += 1
             elif image_id_setting == "manual":
-                assert coco_image.id is not None
+                if coco_image.id is None:
+                    raise ValueError("'coco_image.id' should be set manually when image_id_setting == 'manual'")
                 image_id = coco_image.id
 
             # create coco image object
@@ -1939,8 +1941,8 @@ def create_coco_prediction_array(images, ignore_negative_samples=False, image_id
             COCO predictions array
     """
     # assertion of parameters
-    assert image_id_setting in ["auto", "manual"]
-
+    if image_id_setting not in ["auto", "manual"]:
+        raise ValueError(f"'image_id_setting' should be one of ['auto', 'manual']")
     # define accumulators
     image_index = 1
     prediction_id = 1
@@ -1948,7 +1950,7 @@ def create_coco_prediction_array(images, ignore_negative_samples=False, image_id
     for coco_image in images:
         # get coco predictions
         coco_predictions = coco_image.predictions
-        # get num annotations
+        # get num predictions
         num_predictions = len(coco_predictions)
         # if ignore_negative_samples is True and no annotations, skip image
         if ignore_negative_samples and num_predictions == 0:
@@ -1959,7 +1961,8 @@ def create_coco_prediction_array(images, ignore_negative_samples=False, image_id
                 image_id = image_index
                 image_index += 1
             elif image_id_setting == "manual":
-                assert coco_image.id is not None
+                if coco_image.id is None:
+                    raise ValueError("'coco_image.id' should be set manually when image_id_setting == 'manual'")
                 image_id = coco_image.id
 
             # create coco prediction object

--- a/sahi/utils/coco.py
+++ b/sahi/utils/coco.py
@@ -1083,10 +1083,7 @@ class Coco:
 
     @property
     def prediction_array(self):
-        return create_coco_prediction_array(
-            images=self.images,
-            ignore_negative_samples=self.ignore_negative_samples
-        )
+        return create_coco_prediction_array(images=self.images, ignore_negative_samples=self.ignore_negative_samples)
 
     @property
     def stats(self):

--- a/sahi/utils/coco.py
+++ b/sahi/utils/coco.py
@@ -1871,9 +1871,10 @@ def create_coco_dict(images, categories, ignore_negative_samples=False, image_id
     assert image_id_setting in ["auto", "manual"]
 
     # define accumulators
+    image_index = 1
     annotation_id = 1
     coco_dict = dict(images=[], annotations=[], categories=categories)
-    for image_index, coco_image in enumerate(images):
+    for coco_image in images:
         # get coco annotations
         coco_annotations = coco_image.annotations
         # get num annotations
@@ -1884,7 +1885,8 @@ def create_coco_dict(images, categories, ignore_negative_samples=False, image_id
         else:
             # get image_id
             if image_id_setting == "auto":
-                image_id = image_index + 1
+                image_id = image_index
+                image_index += 1
             elif image_id_setting == "manual":
                 assert coco_image.id is not None
                 image_id = coco_image.id
@@ -1940,9 +1942,10 @@ def create_coco_prediction_array(images, ignore_negative_samples=False, image_id
     assert image_id_setting in ["auto", "manual"]
 
     # define accumulators
+    image_index = 1
     prediction_id = 1
     predictions_array = []
-    for image_index, coco_image in enumerate(images):
+    for coco_image in images:
         # get coco predictions
         coco_predictions = coco_image.predictions
         # get num annotations
@@ -1953,7 +1956,8 @@ def create_coco_prediction_array(images, ignore_negative_samples=False, image_id
         else:
             # get image_id
             if image_id_setting == "auto":
-                image_id = image_index + 1
+                image_id = image_index
+                image_index += 1
             elif image_id_setting == "manual":
                 assert coco_image.id is not None
                 image_id = coco_image.id

--- a/tests/test_cocoutils.py
+++ b/tests/test_cocoutils.py
@@ -110,7 +110,7 @@ class TestCocoUtils(unittest.TestCase):
         self.assertEqual(cocovid_annotation.json["iscrowd"], iscrowd)
 
     def test_coco_image(self):
-        from sahi.utils.coco import CocoAnnotation, CocoImage
+        from sahi.utils.coco import CocoAnnotation, CocoImage, CocoPrediction
 
         # init coco image
         file_name = "tests/data/small-vehicles1.jpeg"
@@ -138,6 +138,29 @@ class TestCocoUtils(unittest.TestCase):
         )
         coco_image.add_annotation(coco_annotation_2)
 
+        # create and add first prediction
+        prediction_coco_segmentation = [[4, 3, 315, 124, 265, 198, 5, 198]]
+        score = 0.983425
+        category_id = 3
+        category_name = "car"
+        coco_prediction_1 = CocoPrediction.from_coco_segmentation(
+            segmentation=prediction_coco_segmentation,
+            category_id=category_id,
+            category_name=category_name,
+            score=score
+        )
+        coco_image.add_prediction(coco_prediction_1)
+
+        # create and add second prediction
+        prediction_coco_bbox = [2, 5, 103, 98]
+        score = 0.683465
+        category_id = 2
+        category_name = "bus"
+        coco_prediction_2 = CocoPrediction.from_coco_bbox(
+            bbox=prediction_coco_bbox, category_id=category_id, category_name=category_name, score=score
+        )
+        coco_image.add_prediction(coco_prediction_2)
+
         # compare
         self.assertEqual(coco_image.file_name, file_name)
         self.assertEqual(coco_image.height, height)
@@ -149,6 +172,17 @@ class TestCocoUtils(unittest.TestCase):
         self.assertEqual(coco_image.annotations[1].category_id, 2)
         self.assertEqual(coco_image.annotations[1].category_name, "bus")
         self.assertEqual(coco_image.annotations[1].bbox, coco_bbox)
+
+        self.assertEqual(len(coco_image.predictions), 2)
+        self.assertEqual(coco_image.predictions[0].category_id, 3)
+        self.assertEqual(coco_image.predictions[0].category_name, "car")
+        self.assertEqual(coco_image.predictions[0].segmentation, prediction_coco_segmentation)
+        self.assertEqual(coco_image.predictions[0].score, 0.983425)
+        self.assertEqual(coco_image.predictions[1].category_id, 2)
+        self.assertEqual(coco_image.predictions[1].category_name, "bus")
+        self.assertEqual(coco_image.predictions[1].bbox, prediction_coco_bbox)
+        self.assertEqual(coco_image.predictions[1].score, 0.683465)
+
 
     def test_cocovid_image(self):
         from sahi.utils.coco import CocoVidAnnotation, CocoVidImage

--- a/tests/test_cocoutils.py
+++ b/tests/test_cocoutils.py
@@ -144,10 +144,7 @@ class TestCocoUtils(unittest.TestCase):
         category_id = 3
         category_name = "car"
         coco_prediction_1 = CocoPrediction.from_coco_segmentation(
-            segmentation=prediction_coco_segmentation,
-            category_id=category_id,
-            category_name=category_name,
-            score=score
+            segmentation=prediction_coco_segmentation, category_id=category_id, category_name=category_name, score=score
         )
         coco_image.add_prediction(coco_prediction_1)
 
@@ -182,7 +179,6 @@ class TestCocoUtils(unittest.TestCase):
         self.assertEqual(coco_image.predictions[1].category_name, "bus")
         self.assertEqual(coco_image.predictions[1].bbox, prediction_coco_bbox)
         self.assertEqual(coco_image.predictions[1].score, 0.683465)
-
 
     def test_cocovid_image(self):
         from sahi.utils.coco import CocoVidAnnotation, CocoVidImage


### PR DESCRIPTION
# Added support for exporting predictions in COCO format 

## changelog: -
* COCO prediction object of class `CocoPrediction` can be added into COCO image object of class `sahi.utils.cocoCocoImage` using method `<CocoImage_Instance>.add_prediction`
* `__repr__` method updated to reflect predictions in class `sahi.utils..coco.CocoImage`
* Additional property `prediction_array` added in class `sahi.utils.coco.Coco` to export COCO predictions in json-serializable format. Logic for the property is defined in new function `sahi.utils.coco.create_coco_prediction_array` 
* added the test cases for the same in `test_cocoutils.py`
* updated file `coco.md` with necessary documentation

#### Basic flow is like this
```python
from sahi.utils.coco import Coco, CocoImage, CocoAnnotation, CocoPrediction
from sahi.utils.file import save_json

coco_obj = Coco()

# add n images to coco_obj
for _ in range(n):
    image = CocoImage(**kwargs)
    
    # add n annotations to the image
    for _ in ange(n):
        image.add_annotation(CocoAnnotation(**kwargs))
    
    # add n predictions to the image
    for _ in range(n)
        image.add_prediction(CocoPrediction(**kwargs))
    
    # add image to coco object
    coco_obj.add_image(image)

# export ground truth annotations
coco_gt = coco_obj.json
save_json(coco_gt , "ground_truth.json")

# export preadictions 
coco_predictions = coco_obj.prediction_array
save_json(coco_predictions, "predictions.json"
```

## Why this is useful?
The user can utilize the exported files to calculate standard coco metrics using offical COCO api `pycocotool` with relative ease.
This is example of using that
```python
from pycocotools.cocoeval import COCOeval
from pycocotools.coco import COCO

# load json files
coco_ground_truth = COCO(annotation_file="ground_truth.json")
coco_predictions = coco_ground_truth.loadRes("predictions.json")

coco_evaluator = COCOeval(coco_ground_truth, coco_predictions, "bbox")
coco_evaluator.evaluate()
coco_evaluator.accumulate()
coco_evaluator.summarize()
```
This can be further expanded to define class which can be conveniently used to evaluate the prediction, something like this
```python
class DatasetEvalutor:
    # user can inherit and overwrite the given load_model, get_annotation and get_prediction methods
    def __init__(self, **kwargs):
        self.images = []  # list of image meta data
        self.model = None # model place holder
        self.dataset = Coco() # coco object

    def load_model(self,**kwargs):
        # logic for loading model goes here
        # set self.model to model

    def get_annotation(self, **kwargs):
        # logic for annotation goes here
        # result must return a sahi.utils.coco.CocoAnnotation instance

    def get_prediction(self, **kwargs):
        # logic for prediction goes here
        # result must return a sahi.utils.coco.CocoPrediction instance

    def run_inference(self, **kwargs):
        # loop over images create CocoImage and add annotations and prediction to it
        # add those CocoImage instance into self.dataset

    def evaluate(self, **kwargs):
        # pycocotool code to generate metrics
```