### PR TITLE
add automodel structure for unified model loading

### DIFF
--- a/sahi/auto_model.py
+++ b/sahi/auto_model.py
@@ -1,0 +1,72 @@
+from typing import Dict, Optional
+
+from sahi.utils.file import import_model_class
+
+MODEL_TYPE_TO_MODEL_CLASS_NAME = {
+    "mmdet": "MmdetDetectionModel",
+    "yolov5": "Yolov5DetectionModel",
+    "detectron2": "Detectron2DetectionModel",
+    "torchvision": "TorchVisionDetectionModel",
+}
+
+
+class AutoDetectionModel:
+    @staticmethod
+    def from_local(
+        model_type: str,
+        model_path: str,
+        config_path: Optional[str] = None,
+        device: Optional[str] = None,
+        mask_threshold: float = 0.5,
+        confidence_threshold: float = 0.3,
+        category_mapping: Optional[Dict] = None,
+        category_remapping: Optional[Dict] = None,
+        load_at_init: bool = True,
+        image_size: int = None,
+        **kwargs,
+    ):
+        """
+        Loads a DetectionModel from local path.
+
+        Args:
+            model_type: str
+                Name of the detection framework (example: "yolov5", "mmdet", "detectron2")
+            model_path: str
+                Path of the Layer model (ex. '/sahi/yolo/models/yolov5')
+            config_path: str
+                Path of the config file (ex. 'mmdet/configs/cascade_rcnn_r50_fpn_1x.py')
+            device: str
+                Device, "cpu" or "cuda:0"
+            mask_threshold: float
+                Value to threshold mask pixels, should be between 0 and 1
+            confidence_threshold: float
+                All predictions with score < confidence_threshold will be discarded
+            category_mapping: dict: str to str
+                Mapping from category id (str) to category name (str) e.g. {"1": "pedestrian"}
+            category_remapping: dict: str to int
+                Remap category ids based on category names, after performing inference e.g. {"car": 3}
+            load_at_init: bool
+                If True, automatically loads the model at initalization
+            image_size: int
+                Inference input size.
+        Returns:
+            Returns an instance of a DetectionModel
+        Raises:
+            ImportError: If given {model_type} framework is not installed
+        """
+
+        class_name = MODEL_TYPE_TO_MODEL_CLASS_NAME[model_type]
+        DetectionModel = import_model_class(class_name)
+
+        return DetectionModel(
+            model_path=model_path,
+            config_path=config_path,
+            device=device,
+            mask_threshold=mask_threshold,
+            confidence_threshold=confidence_threshold,
+            category_mapping=category_mapping,
+            category_remapping=category_remapping,
+            load_at_init=load_at_init,
+            image_size=image_size,
+            **kwargs,
+        )

--- a/sahi/predict.py
+++ b/sahi/predict.py
@@ -462,7 +462,7 @@ def predict(
     # init model instance
     time_start = time.time()
     if detection_model is None:
-        detection_model = AutoDetectionModel(
+        detection_model = AutoDetectionModel.from_local(
             model_type=model_type,
             model_path=model_path,
             config_path=model_config_path,
@@ -755,7 +755,7 @@ def predict_fiftyone(
 
     # init model instance
     time_start = time.time()
-    detection_model = AutoDetectionModel(
+    detection_model = AutoDetectionModel.from_local(
         model_type=model_type,
         model_path=model_path,
         config_path=model_config_path,

--- a/sahi/predict.py
+++ b/sahi/predict.py
@@ -11,6 +11,7 @@ import numpy as np
 from PIL import Image
 from tqdm import tqdm
 
+from sahi.auto_model import AutoDetectionModel
 from sahi.model import DetectionModel
 from sahi.postprocess.combine import (
     GreedyNMMPostprocess,
@@ -31,13 +32,8 @@ from sahi.utils.cv import (
     read_image_as_pil,
     visualize_object_predictions,
 )
-from sahi.utils.file import Path, import_class, increment_path, list_files, save_json, save_pickle
+from sahi.utils.file import Path, increment_path, list_files, save_json, save_pickle
 
-MODEL_TYPE_TO_MODEL_CLASS_NAME = {
-    "mmdet": "MmdetDetectionModel",
-    "yolov5": "Yolov5DetectionModel",
-    "detectron2": "Detectron2DetectionModel",
-}
 POSTPROCESS_NAME_TO_CLASS = {
     "GREEDYNMM": GreedyNMMPostprocess,
     "NMM": NMMPostprocess,
@@ -466,9 +462,8 @@ def predict(
     # init model instance
     time_start = time.time()
     if detection_model is None:
-        model_class_name = MODEL_TYPE_TO_MODEL_CLASS_NAME[model_type]
-        DetectionModel = import_class(model_class_name)
-        detection_model = DetectionModel(
+        detection_model = AutoDetectionModel(
+            model_type=model_type,
             model_path=model_path,
             config_path=model_config_path,
             confidence_threshold=model_confidence_threshold,
@@ -540,7 +535,7 @@ def predict(
         tqdm.write("Prediction time is: {:.2f} ms".format(prediction_result.durations_in_seconds["prediction"] * 1000))
 
         if dataset_json_path:
-            if source_is_video == True:
+            if source_is_video is True:
                 raise NotImplementedError("Video input type not supported with coco formatted dataset json")
 
             # append predictions in coco format
@@ -760,9 +755,8 @@ def predict_fiftyone(
 
     # init model instance
     time_start = time.time()
-    model_class_name = MODEL_TYPE_TO_MODEL_CLASS_NAME[model_type]
-    DetectionModel = import_class(model_class_name)
-    detection_model = DetectionModel(
+    detection_model = AutoDetectionModel(
+        model_type=model_type,
         model_path=model_path,
         config_path=model_config_path,
         confidence_threshold=model_confidence_threshold,

--- a/sahi/utils/file.py
+++ b/sahi/utils/file.py
@@ -195,7 +195,7 @@ def save_pickle(data, save_path):
         pickle.dump(data, outfile)
 
 
-def import_class(model_name):
+def import_model_class(class_name):
     """
     Imports a predefined detection class by class name.
 
@@ -205,8 +205,8 @@ def import_class(model_name):
     Returns:
         class_: class with given path
     """
-    module = __import__("sahi.model", fromlist=[model_name])
-    class_ = getattr(module, model_name)
+    module = __import__("sahi.model", fromlist=[class_name])
+    class_ = getattr(module, class_name)
     return class_
 
 

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -126,7 +126,7 @@ class TestPredict(unittest.TestCase):
         # init model
         download_yolov5n_model()
 
-        yolov5_detection_model = AutoDetectionModel(
+        yolov5_detection_model = AutoDetectionModel.from_local(
             model_type="yolov5",
             model_path=Yolov5TestConstants.YOLOV5N_MODEL_PATH,
             confidence_threshold=CONFIDENCE_THRESHOLD,

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -118,6 +118,53 @@ class TestPredict(unittest.TestCase):
                 num_car += 1
         self.assertEqual(num_car, 2)
 
+    def test_get_prediction_automodel_yolov5(self):
+        from sahi.auto_model import AutoDetectionModel
+        from sahi.predict import get_prediction
+        from sahi.utils.yolov5 import Yolov5TestConstants, download_yolov5n_model
+
+        # init model
+        download_yolov5n_model()
+
+        yolov5_detection_model = AutoDetectionModel(
+            model_type="yolov5",
+            model_path=Yolov5TestConstants.YOLOV5N_MODEL_PATH,
+            confidence_threshold=CONFIDENCE_THRESHOLD,
+            device=MODEL_DEVICE,
+            category_remapping=None,
+            load_at_init=False,
+            image_size=IMAGE_SIZE,
+        )
+        yolov5_detection_model.load_model()
+
+        # prepare image
+        image_path = "tests/data/small-vehicles1.jpeg"
+        image = read_image(image_path)
+
+        # get full sized prediction
+        prediction_result = get_prediction(
+            image=image, detection_model=yolov5_detection_model, shift_amount=[0, 0], full_shape=None, postprocess=None
+        )
+        object_prediction_list = prediction_result.object_prediction_list
+
+        # compare
+        self.assertEqual(len(object_prediction_list), 2)
+        num_person = 0
+        for object_prediction in object_prediction_list:
+            if object_prediction.category.name == "person":
+                num_person += 1
+        self.assertEqual(num_person, 0)
+        num_truck = 0
+        for object_prediction in object_prediction_list:
+            if object_prediction.category.name == "truck":
+                num_truck += 1
+        self.assertEqual(num_truck, 0)
+        num_car = 0
+        for object_prediction in object_prediction_list:
+            if object_prediction.category.name == "car":
+                num_car += 1
+        self.assertEqual(num_car, 2)
+
     def test_get_sliced_prediction_mmdet(self):
         from sahi.model import MmdetDetectionModel
         from sahi.predict import get_sliced_prediction


### PR DESCRIPTION
New `AutoDetectionModel` class makes it easier to load any `yolov5`,  `mmdet`, `detectron2` model!

```python
from sahi import AutoDetectionModel

# load yolov5 models
detection_model = AutoDetectionModel.from_local(
    model_type='yolov5',
    model_path='yolov5s.pt',
    image_size=640,
)

# load mmdet models
detection_model = AutoDetectionModel.from_local(
    model_type='mmdet',
    model_path='model.pt',
    model_config='config.py',
    image_size=640,
)

# load detectron2 models
detection_model = AutoDetectionModel.from_local(
    model_type='detectron2',
    model_path='model.pt',
    model_config='config.yaml',
    image_size=640,
)
```