### PR TITLE
improve requirements and import handling

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -134,6 +134,22 @@ If you want to export extra mAP bar plots and annotation area stats add `--extra
 
 If you want to specify area regions, set it as `--areas "[1024 9216 10000000000]"`.
 
+## `env` command usage:
+
+Print related package versions in the current env as:
+
+```bash
+sahi env
+```
+
+## `version` command usage:
+
+Print your SAHI verison as:
+
+```bash
+sahi version
+```
+
 ## Custom scripts
 
 All scripts can be downloaded from [scripts directory](https://github.com/obss/sahi/main/cli/sahi/scripts) and modified by your needs. After installing `sahi` by pip, all scripts can be called from any directory as:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -3,7 +3,7 @@
 ## `predict` command usage:
 
 ```bash
-sahi predict --source image/file/or/folder --model_path path/to/model --model_config_path path/to/config
+>>sahi predict --source image/file/or/folder --model_path path/to/model --model_config_path path/to/config
 ```
 
 will perform sliced inference on default parameters and export the prediction visuals to runs/predict/exp folder.
@@ -11,13 +11,13 @@ will perform sliced inference on default parameters and export the prediction vi
 - It also supports video input:
 
 ```bash
-sahi predict --model_path yolov5s.pt --model_type yolov5 --source video.mp4
+>>sahi predict --model_path yolov5s.pt --model_type yolov5 --source video.mp4
 ``` 
 
 You can also view video render during video inference with `--view_video`:
 
 ```bash
-sahi predict --model_path yolov5s.pt --model_type yolov5 --source video.mp4 --view_video
+>>sahi predict --model_path yolov5s.pt --model_type yolov5 --source video.mp4 --view_video
 ``` 
 
 - To `forward 100 frames`, on opened window press key `D `
@@ -31,7 +31,7 @@ Note: If `--view_video` is slow, you can add `--frame_skip_interval=20` argument
 You can specify additional sliced prediction parameters as:
 
 ```bash
-sahi predict --slice_width 512 --slice_height 512 --overlap_height_ratio 0.1 --overlap_width_ratio 0.1 --model_confidence_threshold 0.25 --source image/file/or/folder --model_path path/to/model --model_config_path path/to/config
+>>sahi predict --slice_width 512 --slice_height 512 --overlap_height_ratio 0.1 --overlap_width_ratio 0.1 --model_confidence_threshold 0.25 --source image/file/or/folder --model_path path/to/model --model_config_path path/to/config
 ```
 
 - Specify detection framework as `--model_type mmdet` for MMDetection or `--model_type yolov5` for YOLOv5, to match with your model weight
@@ -55,7 +55,7 @@ sahi predict --slice_width 512 --slice_height 512 --overlap_height_ratio 0.1 --o
 ## `predict-fiftyone` command usage:
 
 ```bash
-sahi predict-fiftyone --image_dir image/file/or/folder --dataset_json_path dataset.json --model_path path/to/model --model_config_path path/to/config
+>>sahi predict-fiftyone --image_dir image/file/or/folder --dataset_json_path dataset.json --model_path path/to/model --model_config_path path/to/config
 ```
 
 will perform sliced inference on default parameters and show the inference result on FiftyOne App.
@@ -67,7 +67,7 @@ You can specify additional all extra parameters of the [sahi predict](https://gi
 You need to convert your predictions into [COCO result json](https://cocodataset.org/#format-results), [sahi predict](https://github.com/obss/sahi/blob/main/docs/CLI.md#predict-command-usage) command can be used to create that.
 
 ```bash
-sahi coco fiftyone --image_dir dir/to/images --dataset_json_path dataset.json cocoresult1.json cocoresult2.json
+>>sahi coco fiftyone --image_dir dir/to/images --dataset_json_path dataset.json cocoresult1.json cocoresult2.json
 ```
 
 will open a FiftyOne app that visualizes the given dataset and 2 detection results.
@@ -77,7 +77,7 @@ Specify IOU threshold for FP/TP by `--iou_threshold 0.5` argument
 ## `coco slice` command usage:
 
 ```bash
-sahi coco slice --image_dir dir/to/images --dataset_json_path dataset.json
+>>sahi coco slice --image_dir dir/to/images --dataset_json_path dataset.json
 ```
 
 will slice the given images and COCO formatted annotations and export them to given output folder directory.
@@ -93,7 +93,7 @@ If you want to ignore images with annotations set it add `--ignore_negative_samp
 (In Windows be sure to open anaconda cmd prompt/windows cmd `as admin` to be able to create symlinks properly.)
 
 ```bash
-sahi coco yolov5 --image_dir dir/to/images --dataset_json_path dataset.json  --train_split 0.9
+>>sahi coco yolov5 --image_dir dir/to/images --dataset_json_path dataset.json  --train_split 0.9
 ```
 
 will convert given coco dataset to yolov5 format and export to runs/coco2yolov5/exp folder.
@@ -103,7 +103,7 @@ will convert given coco dataset to yolov5 format and export to runs/coco2yolov5/
 You need to convert your predictions into [COCO result json](https://cocodataset.org/#format-results), [sahi predict](https://github.com/obss/sahi/blob/main/docs/CLI.md#predict-command-usage) command can be used to create that.
 
 ```bash
-sahi coco evaluate --dataset_json_path dataset.json --result_json_path result.json
+>>sahi coco evaluate --dataset_json_path dataset.json --result_json_path result.json
 ```
 
 will calculate coco evaluation and export them to given output folder directory.
@@ -123,7 +123,7 @@ If you want to specify export directory, set it as `--out_dir output/folder/dire
 You need to convert your predictions into [COCO result json](https://cocodataset.org/#format-results), [sahi predict](https://github.com/obss/sahi/blob/main/docs/CLI.md#predict-command-usage) command can be used to create that.
 
 ```bash
-sahi coco analyse --dataset_json_path dataset.json --result_json_path result.json --out_dir output/directory
+>>sahi coco analyse --dataset_json_path dataset.json --result_json_path result.json --out_dir output/directory
 ```
 
 will calculate coco error plots and export them to given output folder directory.
@@ -139,7 +139,18 @@ If you want to specify area regions, set it as `--areas "[1024 9216 10000000000]
 Print related package versions in the current env as:
 
 ```bash
-sahi env
+>>sahi env
+06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   torch version 1.11.0 is available.
+06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   torchvision version 0.12.0 is available.
+06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   yolov5 version 6.1.3 is available.
+06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   mmdet version 2.25.0 is available.
+06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   mmcv version 1.5.3 is available.
+06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   detectron2 version 0.6+cpu is available.
+06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   transformers version 4.20.0 is available.
+06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   timm version 0.4.12 is available.
+06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   layer version 0.10.2510447650 is available.
+06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   fiftyone version 0.14.2 is available.
+06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   norfair version 1.0.0 is available.
 ```
 
 ## `version` command usage:
@@ -147,7 +158,8 @@ sahi env
 Print your SAHI verison as:
 
 ```bash
-sahi version
+>>sahi version
+0.10.0
 ```
 
 ## Custom scripts

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,11 @@ opencv-python>=4.2.0.32
 shapely>=1.8.0
 tqdm>=4.48.2
 pillow>=8.2.0
-pybboxes==0.1.1
+pybboxes==0.1.1; python_version < '3.8'
+pybboxes; python_version >= '3.8'
 pyyaml
 fire
 terminaltables
 requests
-click==8.0.4
+click==8.0.4; python_version < '3.8'
+click; python_version >= '3.8'

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,4 @@ pyyaml
 fire
 terminaltables
 requests
-click==8.0.4; python_version < '3.8'
-click; python_version >= '3.8'
+click==8.0.4

--- a/sahi/cli.py
+++ b/sahi/cli.py
@@ -7,6 +7,7 @@ from sahi.scripts.coco2yolov5 import main as coco2yolov5
 from sahi.scripts.coco_error_analysis import analyse
 from sahi.scripts.coco_evaluation import evaluate
 from sahi.scripts.slice_coco import slice
+from sahi.utils.import_utils import print_enviroment_info
 
 coco_app = {
     "evaluate": evaluate,
@@ -16,7 +17,13 @@ coco_app = {
     "yolov5": coco2yolov5,
 }
 
-sahi_app = {"predict": predict, "predict-fiftyone": predict_fiftyone, "coco": coco_app, "version": sahi_version}
+sahi_app = {
+    "predict": predict,
+    "predict-fiftyone": predict_fiftyone,
+    "coco": coco_app,
+    "version": sahi_version,
+    "env": print_enviroment_info,
+}
 
 
 def app() -> None:

--- a/sahi/utils/fiftyone.py
+++ b/sahi/utils/fiftyone.py
@@ -2,9 +2,9 @@ import os
 import subprocess
 import sys
 
-from sahi.utils.import_utils import _fiftyone_available
+from sahi.utils.import_utils import is_available
 
-if _fiftyone_available:
+if is_available("fiftyone"):
     # to fix https://github.com/voxel51/fiftyone/issues/845
     if sys.platform == "win32":
         _ = subprocess.run("tskill mongod", stderr=subprocess.DEVNULL)

--- a/sahi/utils/import_utils.py
+++ b/sahi/utils/import_utils.py
@@ -17,30 +17,39 @@ def get_package_info(package_name: str):
     """
     Returns the package version as a string and the package name as a string.
     """
-    try:
-        package = importlib.import_module(package_name)
+    _is_available = is_available(package_name)
+
+    if _is_available:
         try:
-            version = package.__version__
-        except AttributeError:
-            version = "unknown"
-        name = package.__name__
-        logger.info(f"{name} version {version} available.")
-        _is_available = True
-    except ImportError:
-        _is_available = False
-        version = "unknown"
-    return _is_available, version
+            import importlib.metadata as _importlib_metadata
+
+            _version = _importlib_metadata.version(package_name)
+        except (importlib.metadata.PackageNotFoundError, ModuleNotFoundError):
+            try:
+                _version = importlib.import_module(package_name).__version__
+            except AttributeError:
+                _version = "unknown"
+        logger.info(f"{package_name} version {_version} is available.")
+    else:
+        _version = "N/A"
+
+    return _is_available, _version
 
 
-_torch_available, _torch_version = get_package_info("torch")
-_torchvision_available, _torchvision_version = get_package_info("torchvision")
-_yolov5_available, _yolov5_version = get_package_info("yolov5")
-_mmdet_available, _mmdet_version = get_package_info("mmdet")
-_mmcv_available, _mmcv_version = get_package_info("mmcv")
-_detectron2_available, _detectron2_version = get_package_info("detectron2")
-_fiftyone_available, _fiftyone_version = get_package_info("fiftyone")
-_norfair_available, _norfair_version = get_package_info("norfair")
-_layer_available, _layer_version = get_package_info("layer")
+def print_enviroment_info():
+    _torch_available, _torch_version = get_package_info("torch")
+    _torchvision_available, _torchvision_version = get_package_info("torchvision")
+    _tensorflow_available, _tensorflow_version = get_package_info("tensorflow")
+    _tensorflow_hub_available, _tensorflow_hub_version = get_package_info("tensorflow-hub")
+    _yolov5_available, _yolov5_version = get_package_info("yolov5")
+    _mmdet_available, _mmdet_version = get_package_info("mmdet")
+    _mmcv_available, _mmcv_version = get_package_info("mmcv")
+    _detectron2_available, _detectron2_version = get_package_info("detectron2")
+    _transformers_available, _transformers_version = get_package_info("transformers")
+    _timm_available, _timm_version = get_package_info("timm")
+    _layer_available, _layer_version = get_package_info("layer")
+    _fiftyone_available, _fiftyone_version = get_package_info("fiftyone")
+    _norfair_available, _norfair_version = get_package_info("norfair")
 
 
 def is_available(module_name: str):

--- a/sahi/utils/import_utils.py
+++ b/sahi/utils/import_utils.py
@@ -24,7 +24,7 @@ def get_package_info(package_name: str, verbose: bool = True):
             import importlib.metadata as _importlib_metadata
 
             _version = _importlib_metadata.version(package_name)
-        except (importlib.metadata.PackageNotFoundError, AttributeError):
+        except (ModuleNotFoundError, AttributeError):
             try:
                 _version = importlib.import_module(package_name).__version__
             except AttributeError:

--- a/sahi/utils/import_utils.py
+++ b/sahi/utils/import_utils.py
@@ -13,7 +13,7 @@ logging.basicConfig(
 )
 
 
-def get_package_info(package_name: str):
+def get_package_info(package_name: str, verbose: bool = True):
     """
     Returns the package version as a string and the package name as a string.
     """
@@ -29,7 +29,8 @@ def get_package_info(package_name: str):
                 _version = importlib.import_module(package_name).__version__
             except AttributeError:
                 _version = "unknown"
-        logger.info(f"{package_name} version {_version} is available.")
+        if verbose:
+            logger.info(f"{package_name} version {_version} is available.")
     else:
         _version = "N/A"
 

--- a/sahi/utils/import_utils.py
+++ b/sahi/utils/import_utils.py
@@ -24,7 +24,7 @@ def get_package_info(package_name: str, verbose: bool = True):
             import importlib.metadata as _importlib_metadata
 
             _version = _importlib_metadata.version(package_name)
-        except (importlib.metadata.PackageNotFoundError, ModuleNotFoundError):
+        except (importlib.metadata.PackageNotFoundError, AttributeError):
             try:
                 _version = importlib.import_module(package_name).__version__
             except AttributeError:

--- a/sahi/utils/mot.py
+++ b/sahi/utils/mot.py
@@ -7,7 +7,7 @@ import numpy as np
 from sahi.utils.file import increment_path
 from sahi.utils.import_utils import check_requirements, is_available
 
-if is_available('norfair'):
+if is_available("norfair"):
     from norfair.metrics import PredictionsTextFile
 
 

--- a/sahi/utils/mot.py
+++ b/sahi/utils/mot.py
@@ -5,9 +5,9 @@ from typing import Dict, List, Optional
 import numpy as np
 
 from sahi.utils.file import increment_path
-from sahi.utils.import_utils import _norfair_available, check_requirements
+from sahi.utils.import_utils import check_requirements, is_available
 
-if _norfair_available:
+if is_available('norfair'):
     from norfair.metrics import PredictionsTextFile
 
 

--- a/sahi/utils/torch.py
+++ b/sahi/utils/torch.py
@@ -15,37 +15,37 @@ def empty_cuda_cache():
         raise RuntimeError("CUDA not available.")
 
 
-if is_available("torch"):
+@check_requirements(["torch"])
+def to_float_tensor(img):
+    """
+    Converts a PIL.Image (RGB) or numpy.ndarray (H x W x C) in the range
+    [0, 255] to a torch.FloatTensor of shape (C x H x W).
+    Args:
+        img: np.ndarray
+    Returns:
+        torch.tensor
+    """
+    import torch
 
-    @check_requirements(["torch"])
-    def to_float_tensor(img):
-        """
-        Converts a PIL.Image (RGB) or numpy.ndarray (H x W x C) in the range
-        [0, 255] to a torch.FloatTensor of shape (C x H x W).
-        Args:
-            img: np.ndarray
-        Returns:
-            torch.tensor
-        """
-        import torch
+    img = img.transpose((2, 0, 1))
+    img = torch.from_numpy(img).float()
+    if img.max() > 1:
+        img /= 255
 
-        img = img.transpose((2, 0, 1))
-        img = torch.from_numpy(img).float()
-        if img.max() > 1:
-            img /= 255
-
-        return img
-
-    @check_requirements(["torch"])
-    def torch_to_numpy(img):
-        import torch
-
-        img = img.numpy()
-        if img.max() > 1:
-            img /= 255
-        return img.transpose((1, 2, 0))
+    return img
 
 
+@check_requirements(["torch"])
+def torch_to_numpy(img):
+    import torch
+
+    img = img.numpy()
+    if img.max() > 1:
+        img /= 255
+    return img.transpose((1, 2, 0))
+
+
+@check_requirements(["torch"])
 def is_torch_cuda_available():
     if is_available("torch"):
         import torch

--- a/sahi/utils/torchvision.py
+++ b/sahi/utils/torchvision.py
@@ -4,13 +4,15 @@
 
 from packaging import version
 
-from sahi.utils.import_utils import _torchvision_available, _torchvision_version, is_available
+from sahi.utils.import_utils import get_package_info
 
 
 class TorchVisionTestConstants:
     FASTERRCNN_CONFIG_PATH = "tests/data/models/torchvision/fasterrcnn_resnet50_fpn.yaml"
     SSD300_CONFIG_PATH = "tests/data/models/torchvision/ssd300_vgg16.yaml"
 
+
+_torchvision_available, _torchvision_version = get_package_info("torchvision", verbose=False)
 
 if _torchvision_available:
     import torchvision

--- a/tests/test_detectron2.py
+++ b/tests/test_detectron2.py
@@ -6,7 +6,7 @@ import unittest
 from sahi.model import Detectron2DetectionModel
 from sahi.utils.cv import read_image
 from sahi.utils.detectron2 import Detectron2TestConstants
-from sahi.utils.import_utils import _torch_version
+from sahi.utils.import_utils import get_package_info
 
 MODEL_DEVICE = "cpu"
 CONFIDENCE_THRESHOLD = 0.5
@@ -14,7 +14,7 @@ IMAGE_SIZE = 320
 
 # note that detectron2 binaries are available only for linux
 
-if _torch_version == "1.10.2":
+if get_package_info("torch", verbose=False)[1] == "1.10.2":
 
     class TestDetectron2DetectionModel(unittest.TestCase):
         def test_load_model(self):


### PR DESCRIPTION
## `env` command usage:

Print related package versions in the current env as:

```bash
>> sahi env
06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   torch version 1.11.0 is available.
06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   torchvision version 0.12.0 is available.
06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   yolov5 version 6.1.3 is available.
06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   mmdet version 2.25.0 is available.
06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   mmcv version 1.5.3 is available.
06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   detectron2 version 0.6+cpu is available.
06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   transformers version 4.20.0 is available.
06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   timm version 0.4.12 is available.
06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   layer version 0.10.2510447650 is available.
06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   fiftyone version 0.14.2 is available.
06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   norfair version 1.0.0 is available.
```


## `version` command usage:

Print your SAHI verison as:

```bash
>> sahi version
0.10.0
```


## `get_package_info` function usage:
```python
>>> from sahi.utils.import_utils import get_package_info
>>> get_package_info("torch", verbose=False)
(True, '1.11.0')
```