### PR TITLE
pybboxes allow oob, strict=False fix.

### DIFF
--- a/sahi/model.py
+++ b/sahi/model.py
@@ -837,6 +837,7 @@ class HuggingfaceDetectionModel(DetectionModel):
                         to_type="voc",
                         image_size=(image_width, image_height),
                         return_values=True,
+                        strict=False
                     )
                 )
 

--- a/sahi/model.py
+++ b/sahi/model.py
@@ -837,7 +837,7 @@ class HuggingfaceDetectionModel(DetectionModel):
                         to_type="voc",
                         image_size=(image_width, image_height),
                         return_values=True,
-                        strict=False
+                        strict=False,
                     )
                 )
 


### PR DESCRIPTION
Fix for by-passing OOB boxes.