### PR TITLE
add YOLOX model support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ If you use this package in your work, please cite it as:
 
 ## <div align="center">Contributing</div>
 
-`sahi` library currently supports all [YOLOv5 models](https://github.com/ultralytics/yolov5/releases), [MMDetection models](https://github.com/open-mmlab/mmdetection/blob/master/docs/model_zoo.md), [Detectron2 models](https://github.com/facebookresearch/detectron2/blob/main/MODEL_ZOO.md), and [HuggingFace object detection models](https://huggingface.co/models?pipeline_tag=object-detection&sort=downloads). Moreover, it is easy to add new frameworks.
+`sahi` library currently supports all [YOLOv5 models](https://github.com/ultralytics/yolov5/releases), [MMDetection models](https://github.com/open-mmlab/mmdetection/blob/master/docs/en/model_zoo.md), [Detectron2 models](https://github.com/facebookresearch/detectron2/blob/main/MODEL_ZOO.md), and [HuggingFace object detection models](https://huggingface.co/models?pipeline_tag=object-detection&sort=downloads). Moreover, it is easy to add new frameworks.
 
 All you need to do is, creating a new class in [model.py](sahi/model.py) that implements [DetectionModel class](https://github.com/obss/sahi/blob/21ecb285aa6bf93c2a00605dfb9b138f19d8d62d/sahi/model.py#L21). You can take the [MMDetection wrapper](https://github.com/obss/sahi/blob/21ecb285aa6bf93c2a00605dfb9b138f19d8d62d/sahi/model.py#L177) or [YOLOv5 wrapper](https://github.com/obss/sahi/blob/21ecb285aa6bf93c2a00605dfb9b138f19d8d62d/sahi/model.py#L388) as a reference.
 

--- a/sahi/model.py
+++ b/sahi/model.py
@@ -2,7 +2,6 @@
 # Code written by Fatih C Akyon, 2020.
 
 import logging
-import warnings
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -1073,16 +1072,21 @@ class YoloxDetectionModel(DetectionModel):
         import torch
 
         try:
-            model = torch.hub.load("Megvii-BaseDetection/YOLOX", self.model_path)
+            model = torch.hub.load(
+                "Megvii-BaseDetection/YOLOX",
+                "yolox_custom",
+                ckpt_path=self.model_path,
+                exp_path=self.config_path,
+                device=self.device,
+            )
             model = model.eval()
-            model = model.to(self.device)
             self.model = model
 
         except Exception as e:
             raise ImportError("model_path is not a valid yolox model path: ", e)
 
         # set category_mapping
-        from sahi.utils.torchvision import COCO_CLASSES
+        from sahi.utils.yolox import COCO_CLASSES
 
         if self.category_mapping is None:
             category_names = {str(i): COCO_CLASSES[i] for i in range(len(COCO_CLASSES))}

--- a/sahi/utils/yolox.py
+++ b/sahi/utils/yolox.py
@@ -1,7 +1,49 @@
+import urllib.request
+from os import path
+from pathlib import Path
+from typing import Optional
+
 import cv2
 import numpy as np
 import torch
 import torchvision
+
+
+class YoloxTestConstants:
+    YOLOX_LARGE_MODEL_URL = "https://github.com/Megvii-BaseDetection/YOLOX/releases/download/0.1.1rc0/yolox_x.pth"
+    YOLOX_LARGE_MODEL_PATH = "tests/data/models/yolox/yolox_x.pth"
+
+    YOLOX_MODEL_URL = "https://github.com/Megvii-BaseDetection/YOLOX/releases/download/0.1.1rc0/yolox_m.pth"
+    YOLOX_MODEL_PATH = "tests/data/models/yolox/yolox_m.pth"
+
+
+def download_yolox_model(destination_path: Optional[str] = None):
+
+    if destination_path is None:
+        destination_path = YoloxTestConstants.YOLOX_MODEL_PATH
+
+    Path(destination_path).parent.mkdir(parents=True, exist_ok=True)
+
+    if not path.exists(destination_path):
+        urllib.request.urlretrieve(
+            YoloxTestConstants.YOLOX_MODEL_URL,
+            destination_path,
+        )
+
+
+def download_yolox_large_model(destination_path: Optional[str] = None):
+
+    if destination_path is None:
+        destination_path = YoloxTestConstants.YOLOX_LARGE_MODEL_PATH
+
+    Path(destination_path).parent.mkdir(parents=True, exist_ok=True)
+
+    if not path.exists(destination_path):
+        urllib.request.urlretrieve(
+            YoloxTestConstants.YOLOX_LARGE_MODEL_URL,
+            destination_path,
+        )
+
 
 # adapted from https://github.com/Megvii-BaseDetection/YOLOX/blob/main/yolox/utils/boxes.py
 
@@ -73,3 +115,87 @@ def preproc(img, input_size, swap=(2, 0, 1)):
     padded_img = padded_img.transpose(swap)
     padded_img = np.ascontiguousarray(padded_img, dtype=np.float32)
     return padded_img, r
+
+
+COCO_CLASSES = [
+    "person",
+    "bicycle",
+    "car",
+    "motorcycle",
+    "airplane",
+    "bus",
+    "train",
+    "truck",
+    "boat",
+    "traffic light",
+    "fire hydrant",
+    "stop sign",
+    "parking meter",
+    "bench",
+    "bird",
+    "cat",
+    "dog",
+    "horse",
+    "sheep",
+    "cow",
+    "elephant",
+    "bear",
+    "zebra",
+    "giraffe",
+    "backpack",
+    "umbrella",
+    "handbag",
+    "tie",
+    "suitcase",
+    "frisbee",
+    "skis",
+    "snowboard",
+    "sports ball",
+    "kite",
+    "baseball bat",
+    "baseball glove",
+    "skateboard",
+    "surfboard",
+    "tennis racket",
+    "bottle",
+    "wine glass",
+    "cup",
+    "fork",
+    "knife",
+    "spoon",
+    "bowl",
+    "banana",
+    "apple",
+    "sandwich",
+    "orange",
+    "broccoli",
+    "carrot",
+    "hot dog",
+    "pizza",
+    "donut",
+    "cake",
+    "chair",
+    "couch",
+    "potted plant",
+    "bed",
+    "dining table",
+    "toilet",
+    "tv",
+    "laptop",
+    "mouse",
+    "remote",
+    "keyboard",
+    "cell phone",
+    "microwave",
+    "oven",
+    "toaster",
+    "sink",
+    "refrigerator",
+    "book",
+    "clock",
+    "vase",
+    "scissors",
+    "teddy bear",
+    "hair drier",
+    "toothbrush",
+]

--- a/sahi/utils/yolox.py
+++ b/sahi/utils/yolox.py
@@ -1,0 +1,51 @@
+import torch
+import torchvision
+
+# adapted from https://github.com/Megvii-BaseDetection/YOLOX/blob/main/yolox/utils/boxes.py
+
+
+def postprocess(prediction, num_classes=80, conf_thre=0.7, nms_thre=0.45, class_agnostic=False):
+    box_corner = prediction.new(prediction.shape)
+    box_corner[:, :, 0] = prediction[:, :, 0] - prediction[:, :, 2] / 2
+    box_corner[:, :, 1] = prediction[:, :, 1] - prediction[:, :, 3] / 2
+    box_corner[:, :, 2] = prediction[:, :, 0] + prediction[:, :, 2] / 2
+    box_corner[:, :, 3] = prediction[:, :, 1] + prediction[:, :, 3] / 2
+    prediction[:, :, :4] = box_corner[:, :, :4]
+
+    output = [None for _ in range(len(prediction))]
+    for i, image_pred in enumerate(prediction):
+
+        # If none are remaining => process next image
+        if not image_pred.size(0):
+            continue
+        # Get score and class with highest confidence
+        class_conf, class_pred = torch.max(image_pred[:, 5 : 5 + num_classes], 1, keepdim=True)
+
+        conf_mask = (image_pred[:, 4] * class_conf.squeeze() >= conf_thre).squeeze()
+        # Detections ordered as (x1, y1, x2, y2, obj_conf, class_conf, class_pred)
+        detections = torch.cat((image_pred[:, :5], class_conf, class_pred.float()), 1)
+        detections = detections[conf_mask]
+        if not detections.size(0):
+            continue
+
+        if class_agnostic:
+            nms_out_index = torchvision.ops.nms(
+                detections[:, :4],
+                detections[:, 4] * detections[:, 5],
+                nms_thre,
+            )
+        else:
+            nms_out_index = torchvision.ops.batched_nms(
+                detections[:, :4],
+                detections[:, 4] * detections[:, 5],
+                detections[:, 6],
+                nms_thre,
+            )
+
+        detections = detections[nms_out_index]
+        if output[i] is None:
+            output[i] = detections
+        else:
+            output[i] = torch.cat((output[i], detections))
+
+    return output

--- a/sahi/utils/yolox.py
+++ b/sahi/utils/yolox.py
@@ -1,3 +1,5 @@
+import cv2
+import numpy as np
 import torch
 import torchvision
 
@@ -49,3 +51,25 @@ def postprocess(prediction, num_classes=80, conf_thre=0.7, nms_thre=0.45, class_
             output[i] = torch.cat((output[i], detections))
 
     return output
+
+
+# adapted from https://github.com/Megvii-BaseDetection/YOLOX/blob/main/yolox/data/data_augment.py
+
+
+def preproc(img, input_size, swap=(2, 0, 1)):
+    if len(img.shape) == 3:
+        padded_img = np.ones((input_size[0], input_size[1], 3), dtype=np.uint8) * 114
+    else:
+        padded_img = np.ones(input_size, dtype=np.uint8) * 114
+
+    r = min(input_size[0] / img.shape[0], input_size[1] / img.shape[1])
+    resized_img = cv2.resize(
+        img,
+        (int(img.shape[1] * r), int(img.shape[0] * r)),
+        interpolation=cv2.INTER_LINEAR,
+    ).astype(np.uint8)
+    padded_img[: int(img.shape[0] * r), : int(img.shape[1] * r)] = resized_img
+
+    padded_img = padded_img.transpose(swap)
+    padded_img = np.ascontiguousarray(padded_img, dtype=np.float32)
+    return padded_img, r


### PR DESCRIPTION
SAHI kütüphanesine YOLOX modelini en basit haliyle ekledim. #535 

Düzeltilecekler:

- [X] Resize modulu yazıldı.
- [ ] Test kodu yazılacak.
- [ ] Notebook dosyası oluşturulacak.

Resize kodunu özellikle yazmadım. SAHI için ortak bir resize modulu oluşturabilir miyiz? Yolox reposundaki örneği incelleyip geri dönüş yapabilir misiniz? [YOLOX-RESIZE](https://github.com/Megvii-BaseDetection/YOLOX/blob/main/tools/demo.py#L140-%20L146)

Ayrıca nms_thre değerini kullanıcıdan istesek nasıl olur? Şuan ben manuel değer veriyorum. Aynı durum yolov7 modeli içinde geçerli.