### PR TITLE
Fixed a bug in greedynmm func

### DIFF
--- a/sahi/postprocess/combine.py
+++ b/sahi/postprocess/combine.py
@@ -235,6 +235,7 @@ def greedy_nmm(
 
         # sanity check
         if len(order) == 0:
+            keep_to_merge_list[idx.tolist()] = []
             break
 
         # select coordinates of BBoxes according to

--- a/tests/test_huggingfacemodel.py
+++ b/tests/test_huggingfacemodel.py
@@ -276,7 +276,7 @@ if sys.version_info >= (3, 7):
             object_prediction_list = prediction_result.object_prediction_list
 
             # compare
-            self.assertEqual(len(object_prediction_list), 53)
+            self.assertEqual(len(object_prediction_list), 54)
             num_person = num_truck = num_car = 0
             for object_prediction in object_prediction_list:
                 if object_prediction.category.name == "person":

--- a/tests/test_huggingfacemodel.py
+++ b/tests/test_huggingfacemodel.py
@@ -287,7 +287,7 @@ if sys.version_info >= (3, 7):
                     num_car += 1
             self.assertEqual(num_person, 0)
             self.assertEqual(num_truck, 5)
-            self.assertEqual(num_car, 48)
+            self.assertEqual(num_car, 49)
 
 
 if __name__ == "__main__":

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -228,7 +228,7 @@ class TestPredict(unittest.TestCase):
         for object_prediction in object_prediction_list:
             if object_prediction.category.name == "car":
                 num_car += 1
-        self.assertEqual(num_car, 14)
+        self.assertEqual(num_car, 15)
 
     def test_get_sliced_prediction_yolov5(self):
         from sahi.model import Yolov5DetectionModel
@@ -292,7 +292,7 @@ class TestPredict(unittest.TestCase):
         for object_prediction in object_prediction_list:
             if object_prediction.category.name == "car":
                 num_car += 1
-        self.assertEqual(num_car, 10)
+        self.assertEqual(num_car, 11)
 
     def test_coco_json_prediction(self):
         from sahi.predict import predict

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -213,7 +213,7 @@ class TestPredict(unittest.TestCase):
         object_prediction_list = prediction_result.object_prediction_list
 
         # compare
-        self.assertEqual(len(object_prediction_list), 14)
+        self.assertEqual(len(object_prediction_list), 15)
         num_person = 0
         for object_prediction in object_prediction_list:
             if object_prediction.category.name == "person":
@@ -277,7 +277,7 @@ class TestPredict(unittest.TestCase):
         object_prediction_list = prediction_result.object_prediction_list
 
         # compare
-        self.assertEqual(len(object_prediction_list), 10)
+        self.assertEqual(len(object_prediction_list), 11)
         num_person = 0
         for object_prediction in object_prediction_list:
             if object_prediction.category.name == "person":

--- a/tests/test_torchvision.py
+++ b/tests/test_torchvision.py
@@ -246,7 +246,7 @@ class TestTorchVisionDetectionModel(unittest.TestCase):
         object_prediction_list = prediction_result.object_prediction_list
 
         # compare
-        self.assertEqual(len(object_prediction_list), 18)
+        self.assertEqual(len(object_prediction_list), 19)
         self.assertEqual(object_prediction_list[0].category.id, 3)
         self.assertEqual(object_prediction_list[0].category.name, "car")
         self.assertEqual(object_prediction_list[0].bbox.to_coco_bbox(), [765, 259, 29, 25])


### PR DESCRIPTION
If there is only one box, there is a object that cannot be displayed in the box because it does not enter keep_to_merge_list.