### PR TITLE
add batch inference support, rename object_prediction_list

### DIFF
--- a/demo/inference_for_detectron2.ipynb
+++ b/demo/inference_for_detectron2.ipynb
@@ -488,7 +488,7 @@
    },
    "outputs": [],
    "source": [
-    "object_prediction_list = result.object_prediction_list"
+    "object_predictions = result.object_predictions"
    ]
   },
   {
@@ -529,7 +529,7 @@
     }
    ],
    "source": [
-    "object_prediction_list[0]"
+    "object_predictions[0]"
    ]
   },
   {
@@ -925,7 +925,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3.8.8 ('sahi')",
+   "display_name": "Python 3.9.7 ('sahi')",
    "language": "python",
    "name": "python3"
   },
@@ -939,11 +939,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.9.7"
   },
   "vscode": {
    "interpreter": {
-    "hash": "f2680c47b11e1b3873482f0b7ab37c9292181f84f7b4413a77eb41d52d22c05d"
+    "hash": "e436cacdc68e69c9957f8df660bf404d2e00097bec42de0852f84077698d425d"
    }
   }
  },

--- a/demo/inference_for_huggingface.ipynb
+++ b/demo/inference_for_huggingface.ipynb
@@ -523,7 +523,7 @@
    },
    "outputs": [],
    "source": [
-    "object_prediction_list = result.object_prediction_list"
+    "object_predictions = result.object_predictions"
    ]
   },
   {
@@ -564,7 +564,7 @@
     }
    ],
    "source": [
-    "object_prediction_list[0]"
+    "object_predictions[0]"
    ]
   },
   {
@@ -959,7 +959,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3.8.8 ('sahi')",
+   "display_name": "Python 3.9.7 ('sahi')",
    "language": "python",
    "name": "python3"
   },
@@ -973,11 +973,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.9.7"
   },
   "vscode": {
    "interpreter": {
-    "hash": "f2680c47b11e1b3873482f0b7ab37c9292181f84f7b4413a77eb41d52d22c05d"
+    "hash": "e436cacdc68e69c9957f8df660bf404d2e00097bec42de0852f84077698d425d"
    }
   }
  },

--- a/demo/inference_for_mmdetection.ipynb
+++ b/demo/inference_for_mmdetection.ipynb
@@ -278,7 +278,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "object_prediction_list = result.object_prediction_list"
+    "object_predictions = result.object_predictions"
    ]
   },
   {
@@ -302,7 +302,7 @@
     }
    ],
    "source": [
-    "object_prediction_list[0]"
+    "object_predictions[0]"
    ]
   },
   {
@@ -759,7 +759,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.8 ('sahi')",
+   "display_name": "Python 3.9.7 ('sahi')",
    "language": "python",
    "name": "python3"
   },
@@ -773,11 +773,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.9.7"
   },
   "vscode": {
    "interpreter": {
-    "hash": "f2680c47b11e1b3873482f0b7ab37c9292181f84f7b4413a77eb41d52d22c05d"
+    "hash": "e436cacdc68e69c9957f8df660bf404d2e00097bec42de0852f84077698d425d"
    }
   }
  },

--- a/demo/inference_for_torchvision.ipynb
+++ b/demo/inference_for_torchvision.ipynb
@@ -392,7 +392,7 @@
    },
    "outputs": [],
    "source": [
-    "object_prediction_list = result.object_prediction_list"
+    "object_predictions = result.object_predictions"
    ]
   },
   {
@@ -432,7 +432,7 @@
     }
    ],
    "source": [
-    "object_prediction_list[0]"
+    "object_predictions[0]"
    ]
   },
   {
@@ -812,11 +812,8 @@
    "name": "inference_for_torchvision.ipynb",
    "provenance": []
   },
-  "interpreter": {
-   "hash": "f2680c47b11e1b3873482f0b7ab37c9292181f84f7b4413a77eb41d52d22c05d"
-  },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.9.7 ('sahi')",
    "language": "python",
    "name": "python3"
   },
@@ -830,7 +827,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.9.7"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "e436cacdc68e69c9957f8df660bf404d2e00097bec42de0852f84077698d425d"
+   }
   }
  },
  "nbformat": 4,

--- a/demo/inference_for_yolov5.ipynb
+++ b/demo/inference_for_yolov5.ipynb
@@ -266,7 +266,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "object_prediction_list = result.object_prediction_list"
+    "object_predictions = result.object_predictions"
    ]
   },
   {
@@ -290,7 +290,7 @@
     }
    ],
    "source": [
-    "object_prediction_list[0]"
+    "object_predictions[0]"
    ]
   },
   {
@@ -636,9 +636,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.8 ('sahi')",
+   "display_name": "sahi",
    "language": "python",
-   "name": "python3"
+   "name": "sahi"
   },
   "language_info": {
    "codemirror_mode": {
@@ -650,7 +650,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.9.7"
   },
   "vscode": {
    "interpreter": {

--- a/sahi/__init__.py
+++ b/sahi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.11.4"
+__version__ = "0.12.0"
 
 from sahi.annotation import BoundingBox, Category, Mask
 from sahi.auto_model import AutoDetectionModel

--- a/sahi/models/base.py
+++ b/sahi/models/base.py
@@ -121,18 +121,18 @@ class DetectionModel:
 
     def _create_object_predictions_from_original_predictions(
         self,
-        shift_amount_list: Optional[List[List[int]]] = [[0, 0]],
-        full_shape_list: Optional[List[List[int]]] = None,
+        shift_amounts: Optional[List[List[int]]] = [[0, 0]],
+        full_shapes: Optional[List[List[int]]] = None,
     ):
         """
         This function should be implemented in a way that self._original_predictions should
         be converted to a list of prediction.ObjectPrediction and set to
         self._object_predictions. self.mask_threshold can also be utilized.
         Args:
-            shift_amount_list: list of list
+            shift_amounts: list of list
                 To shift the box and mask predictions from sliced image to full sized image, should
                 be in the form of List[[shift_x, shift_y],[shift_x, shift_y],...]
-            full_shape_list: list of list
+            full_shapes: list of list
                 Size of the full image after shifting, should be in the form of
                 List[[height, width],[height, width],...]
         """
@@ -154,21 +154,23 @@ class DetectionModel:
 
     def convert_original_predictions(
         self,
-        shift_amount: Optional[List[int]] = [0, 0],
-        full_shape: Optional[List[int]] = None,
+        shift_amounts: Optional[List[List[int]]] = [[0, 0]],
+        full_shapes: Optional[List[List[int]]] = None,
     ):
         """
         Converts original predictions of the detection model to a list of
         prediction.ObjectPrediction object. Should be called after perform_inference().
         Args:
-            shift_amount: list
-                To shift the box and mask predictions from sliced image to full sized image, should be in the form of [shift_x, shift_y]
-            full_shape: list
-                Size of the full image after shifting, should be in the form of [height, width]
+            shift_amounts: list of list
+                To shift the box and mask predictions from sliced image to full sized image, should
+                be in the form of List[[shift_x, shift_y],[shift_x, shift_y],...]
+            full_shapes: list of list
+                Size of the full image after shifting, should be in the form of
+                List[[height, width],[height, width],...]
         """
         self._create_object_predictions_from_original_predictions(
-            shift_amount_list=shift_amount,
-            full_shape_list=full_shape,
+            shift_amounts=shift_amounts,
+            full_shapes=full_shapes,
         )
         if self.category_remapping:
             self._apply_category_remapping()

--- a/sahi/models/base.py
+++ b/sahi/models/base.py
@@ -1,6 +1,7 @@
 # OBSS SAHI Tool
 # Code written by Fatih C Akyon, 2020.
 
+import warnings
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -55,7 +56,7 @@ class DetectionModel:
         self.category_remapping = category_remapping
         self.image_size = image_size
         self._original_predictions = None
-        self._object_prediction_list_per_image = None
+        self._object_predictions_per_image = None
 
         self.set_device()
 
@@ -118,7 +119,7 @@ class DetectionModel:
         """
         raise NotImplementedError()
 
-    def _create_object_prediction_list_from_original_predictions(
+    def _create_object_predictions_from_original_predictions(
         self,
         shift_amount_list: Optional[List[List[int]]] = [[0, 0]],
         full_shape_list: Optional[List[List[int]]] = None,
@@ -126,7 +127,7 @@ class DetectionModel:
         """
         This function should be implemented in a way that self._original_predictions should
         be converted to a list of prediction.ObjectPrediction and set to
-        self._object_prediction_list. self.mask_threshold can also be utilized.
+        self._object_predictions. self.mask_threshold can also be utilized.
         Args:
             shift_amount_list: list of list
                 To shift the box and mask predictions from sliced image to full sized image, should
@@ -145,8 +146,8 @@ class DetectionModel:
         if self.category_remapping is None:
             raise ValueError("self.category_remapping cannot be None")
         # remap categories
-        for object_prediction_list in self._object_prediction_list_per_image:
-            for object_prediction in object_prediction_list:
+        for object_predictions in self._object_predictions_per_image:
+            for object_prediction in object_predictions:
                 old_category_id_str = str(object_prediction.category.id)
                 new_category_id_int = self.category_remapping[old_category_id_str]
                 object_prediction.category.id = new_category_id_int
@@ -165,7 +166,7 @@ class DetectionModel:
             full_shape: list
                 Size of the full image after shifting, should be in the form of [height, width]
         """
-        self._create_object_prediction_list_from_original_predictions(
+        self._create_object_predictions_from_original_predictions(
             shift_amount_list=shift_amount,
             full_shape_list=full_shape,
         )
@@ -174,11 +175,27 @@ class DetectionModel:
 
     @property
     def object_prediction_list(self):
-        return self._object_prediction_list_per_image[0]
+        warnings.warn(
+            "object_prediction_list is deprecated, use object_predictions instead",
+            DeprecationWarning,
+        )
+        return self._object_predictions_per_image[0]
+
+    @property
+    def object_predictions(self):
+        return self._object_predictions_per_image[0]
 
     @property
     def object_prediction_list_per_image(self):
-        return self._object_prediction_list_per_image
+        warnings.warn(
+            "object_prediction_list_per_image is deprecated, use object_predictions_per_image instead",
+            DeprecationWarning,
+        )
+        return self._object_predictions_per_image
+
+    @property
+    def object_predictions_per_image(self):
+        return self._object_predictions_per_image
 
     @property
     def original_predictions(self):

--- a/sahi/models/detectron2.py
+++ b/sahi/models/detectron2.py
@@ -70,23 +70,29 @@ class Detectron2DetectionModel(DetectionModel):
         else:
             self.category_names = list(self.category_mapping.values())
 
-    def perform_inference(self, image: np.ndarray):
+    def perform_inference(self, images: List):
         """
         Prediction is performed using self.model and the prediction result is set to self._original_predictions.
         Args:
-            image: np.ndarray
-                A numpy array that contains the image to be predicted. 3 channel image should be in RGB order.
+            images: List[np.ndarray, PIL.Image.Image]
+                A numpy array that contains one image to be predicted. 3 channel image should be in RGB order.
         """
+
+        if not isinstance(images, list):
+            images = [images]
+
+        if len(images) > 1:
+            raise NotImplementedError("Detectron2 does not support batch inference.")
 
         # Confirm model is loaded
         if self.model is None:
             raise RuntimeError("Model is not loaded, load it by calling .load_model()")
 
-        if isinstance(image, np.ndarray) and self.model.input_format == "BGR":
+        if isinstance(images[0], np.ndarray) and self.model.input_format == "BGR":
             # convert RGB image to BGR format
-            image = image[:, :, ::-1]
+            images[0] = images[0][:, :, ::-1]
 
-        prediction_result = self.model(image)
+        prediction_result = self.model(images[0])
 
         self._original_predictions = prediction_result
 

--- a/sahi/models/detectron2.py
+++ b/sahi/models/detectron2.py
@@ -98,14 +98,14 @@ class Detectron2DetectionModel(DetectionModel):
         num_categories = len(self.category_mapping)
         return num_categories
 
-    def _create_object_prediction_list_from_original_predictions(
+    def _create_object_predictions_from_original_predictions(
         self,
         shift_amount_list: Optional[List[List[int]]] = [[0, 0]],
         full_shape_list: Optional[List[List[int]]] = None,
     ):
         """
         self._original_predictions is converted to a list of prediction.ObjectPrediction and set to
-        self._object_prediction_list_per_image.
+        self._object_predictions_per_image.
         Args:
             shift_amount_list: list of list
                 To shift the box and mask predictions from sliced image to full sized image, should
@@ -133,9 +133,9 @@ class Detectron2DetectionModel(DetectionModel):
         except AttributeError:
             masks = None
 
-        # create object_prediction_list
-        object_prediction_list_per_image = []
-        object_prediction_list = []
+        # create object_predictions
+        object_predictions_per_image = []
+        object_predictions = []
 
         # detectron2 DefaultPredictor supports single image
         shift_amount = shift_amount_list[0]
@@ -170,9 +170,9 @@ class Detectron2DetectionModel(DetectionModel):
                 score=score,
                 full_shape=full_shape,
             )
-            object_prediction_list.append(object_prediction)
+            object_predictions.append(object_prediction)
 
         # detectron2 DefaultPredictor supports single image
-        object_prediction_list_per_image = [object_prediction_list]
+        object_predictions_per_image = [object_predictions]
 
-        self._object_prediction_list_per_image = object_prediction_list_per_image
+        self._object_predictions_per_image = object_predictions_per_image

--- a/sahi/models/detectron2.py
+++ b/sahi/models/detectron2.py
@@ -106,8 +106,8 @@ class Detectron2DetectionModel(DetectionModel):
 
     def _create_object_predictions_from_original_predictions(
         self,
-        shift_amount_list: Optional[List[List[int]]] = [[0, 0]],
-        full_shape_list: Optional[List[List[int]]] = None,
+        shift_amounts: Optional[List[List[int]]] = [[0, 0]],
+        full_shapes: Optional[List[List[int]]] = None,
     ):
         """
         self._original_predictions is converted to a list of prediction.ObjectPrediction and set to
@@ -121,12 +121,6 @@ class Detectron2DetectionModel(DetectionModel):
                 List[[height, width],[height, width],...]
         """
         original_predictions = self._original_predictions
-
-        # compatilibty for sahi v0.8.15
-        if isinstance(shift_amount_list[0], int):
-            shift_amount_list = [shift_amount_list]
-        if full_shape_list is not None and isinstance(full_shape_list[0], int):
-            full_shape_list = [full_shape_list]
 
         # parse boxes, masks, scores, category_ids from predictions
         boxes = original_predictions["instances"].pred_boxes.tensor.tolist()
@@ -144,8 +138,8 @@ class Detectron2DetectionModel(DetectionModel):
         object_predictions = []
 
         # detectron2 DefaultPredictor supports single image
-        shift_amount = shift_amount_list[0]
-        full_shape = None if full_shape_list is None else full_shape_list[0]
+        shift_amount = shift_amounts[0]
+        full_shape = None if full_shapes is None else full_shapes[0]
 
         for ind in range(len(boxes)):
             score = scores[ind]

--- a/sahi/models/huggingface.py
+++ b/sahi/models/huggingface.py
@@ -145,7 +145,7 @@ class HuggingfaceDetectionModel(DetectionModel):
     ):
         """
         self._original_predictions is converted to a list of prediction.ObjectPrediction and set to
-        self._object_prediction_list_per_image.
+        self._object_predictions_per_image.
         Args:
             shift_amount_list: list of list
                 To shift the box and mask predictions from sliced image to full sized image, should
@@ -161,15 +161,15 @@ class HuggingfaceDetectionModel(DetectionModel):
         full_shape_list = fix_full_shape_list(full_shape_list)
 
         n_image = original_predictions.logits.shape[0]
-        object_prediction_list_per_image = []
+        object_predictions_per_image = []
         for image_ind in range(n_image):
             image_height, image_width, _ = self.image_shapes[image_ind]
             scores, cat_ids, boxes = self.get_valid_predictions(
                 logits=original_predictions.logits[image_ind], pred_boxes=original_predictions.pred_boxes[image_ind]
             )
 
-            # create object_prediction_list
-            object_prediction_list = []
+            # create object_predictions
+            object_predictions = []
 
             shift_amount = shift_amount_list[image_ind]
             full_shape = None if full_shape_list is None else full_shape_list[image_ind]
@@ -203,7 +203,7 @@ class HuggingfaceDetectionModel(DetectionModel):
                     score=scores[ind].item(),
                     full_shape=full_shape,
                 )
-                object_prediction_list.append(object_prediction)
-            object_prediction_list_per_image.append(object_prediction_list)
+                object_predictions.append(object_prediction)
+            object_predictionst_per_image.append(object_predictions)
 
-        self._object_prediction_list_per_image = object_prediction_list_per_image
+        self._object_predictions_per_image = object_predictions_per_image

--- a/sahi/models/huggingface.py
+++ b/sahi/models/huggingface.py
@@ -149,8 +149,8 @@ class HuggingfaceDetectionModel(DetectionModel):
 
     def _create_object_predictions_from_original_predictions(
         self,
-        shift_amount_list: Optional[List[List[int]]] = [[0, 0]],
-        full_shape_list: Optional[List[List[int]]] = None,
+        shift_amounts: Optional[List[List[int]]] = [[0, 0]],
+        full_shapes: Optional[List[List[int]]] = None,
     ):
         """
         self._original_predictions is converted to a list of prediction.ObjectPrediction and set to
@@ -165,10 +165,6 @@ class HuggingfaceDetectionModel(DetectionModel):
         """
         original_predictions = self._original_predictions
 
-        # compatilibty for sahi v0.8.15
-        shift_amount_list = fix_shift_amount_list(shift_amount_list)
-        full_shape_list = fix_full_shape_list(full_shape_list)
-
         n_image = original_predictions.logits.shape[0]
         object_predictions_per_image = []
         for image_ind in range(n_image):
@@ -180,8 +176,8 @@ class HuggingfaceDetectionModel(DetectionModel):
             # create object_predictions
             object_predictions = []
 
-            shift_amount = shift_amount_list[image_ind]
-            full_shape = None if full_shape_list is None else full_shape_list[image_ind]
+            shift_amount = shift_amounts[image_ind]
+            full_shape = None if full_shapes is None else full_shapes[image_ind]
 
             for ind in range(len(boxes)):
                 category_id = cat_ids[ind].item()

--- a/sahi/models/huggingface.py
+++ b/sahi/models/huggingface.py
@@ -204,6 +204,6 @@ class HuggingfaceDetectionModel(DetectionModel):
                     full_shape=full_shape,
                 )
                 object_predictions.append(object_prediction)
-            object_predictionst_per_image.append(object_predictions)
+            object_predictions_per_image.append(object_predictions)
 
         self._object_predictions_per_image = object_predictions_per_image

--- a/sahi/models/huggingface.py
+++ b/sahi/models/huggingface.py
@@ -138,7 +138,7 @@ class HuggingfaceDetectionModel(DetectionModel):
         boxes = pred_boxes[valid_mask]
         return scores, cat_ids, boxes
 
-    def _create_object_prediction_list_from_original_predictions(
+    def _create_object_predictions_from_original_predictions(
         self,
         shift_amount_list: Optional[List[List[int]]] = [[0, 0]],
         full_shape_list: Optional[List[List[int]]] = None,

--- a/sahi/models/mmdet.py
+++ b/sahi/models/mmdet.py
@@ -54,13 +54,16 @@ class MmdetDetectionModel(DetectionModel):
             category_mapping = {str(ind): category_name for ind, category_name in enumerate(self.category_names)}
             self.category_mapping = category_mapping
 
-    def perform_inference(self, image: np.ndarray):
+    def perform_inference(self, images: List):
         """
         Prediction is performed using self.model and the prediction result is set to self._original_predictions.
         Args:
-            image: np.ndarray
-                A numpy array that contains the image to be predicted. 3 channel image should be in RGB order.
+            images: List[np.ndarray, str, PIL.Image.Image]
+                A numpy array that contains a list of images to be predicted. 3 channel image should be in RGB order.
         """
+
+        if not isinstance(images, list):
+            images = [images]
 
         # Confirm model is loaded
         if self.model is None:
@@ -69,13 +72,12 @@ class MmdetDetectionModel(DetectionModel):
         from mmdet.apis import inference_detector
 
         # perform inference
-        if isinstance(image, np.ndarray):
-            # https://github.com/obss/sahi/issues/265
-            image = image[:, :, ::-1]
-        # compatibility with sahi v0.8.15
-        if not isinstance(image, list):
-            image = [image]
-        prediction_result = inference_detector(self.model, image)
+        if isinstance(images[0], np.ndarray):
+            # mmdet accepts in BGR order
+            for i, image in enumerate(images):
+                images[i] = image[..., ::-1]
+
+        prediction_result = inference_detector(self.model, images)
 
         self._original_predictions = prediction_result
 

--- a/sahi/models/mmdet.py
+++ b/sahi/models/mmdet.py
@@ -106,14 +106,14 @@ class MmdetDetectionModel(DetectionModel):
         else:
             return self.model.CLASSES
 
-    def _create_object_prediction_list_from_original_predictions(
+    def _create_object_predictions_from_original_predictions(
         self,
         shift_amount_list: Optional[List[List[int]]] = [[0, 0]],
         full_shape_list: Optional[List[List[int]]] = None,
     ):
         """
         self._original_predictions is converted to a list of prediction.ObjectPrediction and set to
-        self._object_prediction_list_per_image.
+        self._object_predictions_per_image.
         Args:
             shift_amount_list: list of list
                 To shift the box and mask predictions from sliced image to full sized image, should
@@ -131,7 +131,7 @@ class MmdetDetectionModel(DetectionModel):
 
         # parse boxes and masks from predictions
         num_categories = self.num_categories
-        object_prediction_list_per_image = []
+        object_predictions_per_image = []
         for image_ind, original_prediction in enumerate(original_predictions):
             shift_amount = shift_amount_list[image_ind]
             full_shape = None if full_shape_list is None else full_shape_list[image_ind]
@@ -142,7 +142,7 @@ class MmdetDetectionModel(DetectionModel):
             else:
                 boxes = original_prediction
 
-            object_prediction_list = []
+            object_predictions = []
 
             # process predictions
             for category_id in range(num_categories):
@@ -197,6 +197,6 @@ class MmdetDetectionModel(DetectionModel):
                         shift_amount=shift_amount,
                         full_shape=full_shape,
                     )
-                    object_prediction_list.append(object_prediction)
-            object_prediction_list_per_image.append(object_prediction_list)
-        self._object_prediction_list_per_image = object_prediction_list_per_image
+                    object_predictions.append(object_prediction)
+            object_predictions_per_image.append(object_predictions)
+        self._object_predictions_per_image = object_predictions_per_image

--- a/sahi/models/torchvision.py
+++ b/sahi/models/torchvision.py
@@ -124,14 +124,14 @@ class TorchVisionDetectionModel(DetectionModel):
     def category_names(self):
         return list(self.category_mapping.values())
 
-    def _create_object_prediction_list_from_original_predictions(
+    def _create_object_predictions_from_original_predictions(
         self,
         shift_amount_list: Optional[List[List[int]]] = [[0, 0]],
         full_shape_list: Optional[List[List[int]]] = None,
     ):
         """
         self._original_predictions is converted to a list of prediction.ObjectPrediction and set to
-        self._object_prediction_list_per_image.
+        self._object_predictions_per_image.
         Args:
             shift_amount_list: list of list
                 To shift the box and mask predictions from sliced image to full sized image, should
@@ -149,7 +149,7 @@ class TorchVisionDetectionModel(DetectionModel):
             full_shape_list = [full_shape_list]
 
         for image_predictions in original_predictions:
-            object_prediction_list_per_image = []
+            object_predictions_per_image = []
 
             # get indices of boxes with score > confidence_threshold
             scores = image_predictions["scores"].cpu().detach().numpy()
@@ -167,8 +167,8 @@ class TorchVisionDetectionModel(DetectionModel):
             else:
                 masks = None
 
-            # create object_prediction_list
-            object_prediction_list = []
+            # create object_predictions
+            object_predictions = []
 
             shift_amount = shift_amount_list[0]
             full_shape = None if full_shape_list is None else full_shape_list[0]
@@ -189,7 +189,7 @@ class TorchVisionDetectionModel(DetectionModel):
                     score=scores[ind],
                     full_shape=full_shape,
                 )
-                object_prediction_list.append(object_prediction)
-            object_prediction_list_per_image.append(object_prediction_list)
+                object_predictions.append(object_prediction)
+            object_predictions_per_image.append(object_predictions)
 
-        self._object_prediction_list_per_image = object_prediction_list_per_image
+        self._object_predictions_per_image = object_predictions_per_image

--- a/sahi/models/yolov5.py
+++ b/sahi/models/yolov5.py
@@ -2,9 +2,7 @@
 # Code written by Fatih C Akyon, 2020.
 
 import logging
-from typing import Any, Dict, List, Optional
-
-import numpy as np
+from typing import Any, Dict, List, Optional, Sequence
 
 from sahi.models.base import DetectionModel
 from sahi.prediction import ObjectPrediction
@@ -50,21 +48,24 @@ class Yolov5DetectionModel(DetectionModel):
             category_mapping = {str(ind): category_name for ind, category_name in enumerate(self.category_names)}
             self.category_mapping = category_mapping
 
-    def perform_inference(self, image: np.ndarray):
+    def perform_inference(self, images: List):
         """
         Prediction is performed using self.model and the prediction result is set to self._original_predictions.
         Args:
-            image: np.ndarray
-                A numpy array that contains the image to be predicted. 3 channel image should be in RGB order.
+            images: List[np.ndarray, str, PIL.Image.Image]
+                A numpy array that contains a list of images to be predicted. 3 channel image should be in RGB order.
         """
+
+        if not isinstance(images, list):
+            images = [images]
 
         # Confirm model is loaded
         if self.model is None:
             raise ValueError("Model is not loaded, load it by calling .load_model()")
         if self.image_size is not None:
-            prediction_result = self.model(image, size=self.image_size)
+            prediction_result = self.model(images, size=self.image_size)
         else:
-            prediction_result = self.model(image)
+            prediction_result = self.model(images)
 
         self._original_predictions = prediction_result
 
@@ -125,7 +126,7 @@ class Yolov5DetectionModel(DetectionModel):
             object_predictions = []
 
             # process predictions
-            for prediction in image_predictions_in_xyxy_format.cpu().detach().numpy():
+            for prediction in image_predictions_in_xyxy_format.tolist():
                 x1 = prediction[0]
                 y1 = prediction[1]
                 x2 = prediction[2]

--- a/sahi/models/yolov5.py
+++ b/sahi/models/yolov5.py
@@ -95,14 +95,14 @@ class Yolov5DetectionModel(DetectionModel):
         else:
             return self.model.names
 
-    def _create_object_prediction_list_from_original_predictions(
+    def _create_object_predictions_from_original_predictions(
         self,
         shift_amount_list: Optional[List[List[int]]] = [[0, 0]],
         full_shape_list: Optional[List[List[int]]] = None,
     ):
         """
         self._original_predictions is converted to a list of prediction.ObjectPrediction and set to
-        self._object_prediction_list_per_image.
+        self._object_predictions_per_image.
         Args:
             shift_amount_list: list of list
                 To shift the box and mask predictions from sliced image to full sized image, should
@@ -118,11 +118,11 @@ class Yolov5DetectionModel(DetectionModel):
         full_shape_list = fix_full_shape_list(full_shape_list)
 
         # handle all predictions
-        object_prediction_list_per_image = []
+        object_predictions_per_image = []
         for image_ind, image_predictions_in_xyxy_format in enumerate(original_predictions.xyxy):
             shift_amount = shift_amount_list[image_ind]
             full_shape = None if full_shape_list is None else full_shape_list[image_ind]
-            object_prediction_list = []
+            object_predictions = []
 
             # process predictions
             for prediction in image_predictions_in_xyxy_format.cpu().detach().numpy():
@@ -162,7 +162,7 @@ class Yolov5DetectionModel(DetectionModel):
                     shift_amount=shift_amount,
                     full_shape=full_shape,
                 )
-                object_prediction_list.append(object_prediction)
-            object_prediction_list_per_image.append(object_prediction_list)
+                object_predictions.append(object_prediction)
+            object_predictions_per_image.append(object_predictions)
 
-        self._object_prediction_list_per_image = object_prediction_list_per_image
+        self._object_predictions_per_image = object_predictions_per_image

--- a/sahi/models/yolov5.py
+++ b/sahi/models/yolov5.py
@@ -98,31 +98,27 @@ class Yolov5DetectionModel(DetectionModel):
 
     def _create_object_predictions_from_original_predictions(
         self,
-        shift_amount_list: Optional[List[List[int]]] = [[0, 0]],
-        full_shape_list: Optional[List[List[int]]] = None,
+        shift_amounts: Optional[List[List[int]]] = [[0, 0]],
+        full_shapes: Optional[List[List[int]]] = None,
     ):
         """
         self._original_predictions is converted to a list of prediction.ObjectPrediction and set to
         self._object_predictions_per_image.
         Args:
-            shift_amount_list: list of list
+            shift_amounts: list of list
                 To shift the box and mask predictions from sliced image to full sized image, should
                 be in the form of List[[shift_x, shift_y],[shift_x, shift_y],...]
-            full_shape_list: list of list
+            full_shapes: list of list
                 Size of the full image after shifting, should be in the form of
                 List[[height, width],[height, width],...]
         """
         original_predictions = self._original_predictions
 
-        # compatilibty for sahi v0.8.15
-        shift_amount_list = fix_shift_amount_list(shift_amount_list)
-        full_shape_list = fix_full_shape_list(full_shape_list)
-
         # handle all predictions
         object_predictions_per_image = []
         for image_ind, image_predictions_in_xyxy_format in enumerate(original_predictions.xyxy):
-            shift_amount = shift_amount_list[image_ind]
-            full_shape = None if full_shape_list is None else full_shape_list[image_ind]
+            shift_amount = shift_amounts[image_ind]
+            full_shape = None if full_shapes is None else full_shapes[image_ind]
             object_predictions = []
 
             # process predictions

--- a/sahi/postprocess/combine.py
+++ b/sahi/postprocess/combine.py
@@ -475,8 +475,8 @@ class NMSPostprocess(PostprocessPredictions):
         self,
         object_predictions: List[ObjectPrediction],
     ):
-        object_prediction_list = ObjectPredictionList(object_predictions)
-        object_predictions_as_torch = object_prediction_list.totensor()
+        object_predictions = ObjectPredictionList(object_predictions)
+        object_predictions_as_torch = object_predictions.totensor()
         if self.class_agnostic:
             keep = nms(
                 object_predictions_as_torch, match_threshold=self.match_threshold, match_metric=self.match_metric
@@ -486,7 +486,7 @@ class NMSPostprocess(PostprocessPredictions):
                 object_predictions_as_torch, match_threshold=self.match_threshold, match_metric=self.match_metric
             )
 
-        selected_object_predictions = object_prediction_list[keep].tolist()
+        selected_object_predictions = object_predictions[keep].tolist()
         if not isinstance(selected_object_predictions, list):
             selected_object_predictions = [selected_object_predictions]
 
@@ -498,8 +498,8 @@ class NMMPostprocess(PostprocessPredictions):
         self,
         object_predictions: List[ObjectPrediction],
     ):
-        object_prediction_list = ObjectPredictionList(object_predictions)
-        object_predictions_as_torch = object_prediction_list.totensor()
+        object_predictions = ObjectPredictionList(object_predictions)
+        object_predictions_as_torch = object_predictions.totensor()
         if self.class_agnostic:
             keep_to_merge_list = nmm(
                 object_predictions_as_torch,
@@ -517,15 +517,15 @@ class NMMPostprocess(PostprocessPredictions):
         for keep_ind, merge_ind_list in keep_to_merge_list.items():
             for merge_ind in merge_ind_list:
                 if has_match(
-                    object_prediction_list[keep_ind].tolist(),
-                    object_prediction_list[merge_ind].tolist(),
+                    object_predictions[keep_ind].tolist(),
+                    object_predictions[merge_ind].tolist(),
                     self.match_metric,
                     self.match_threshold,
                 ):
-                    object_prediction_list[keep_ind] = merge_object_prediction_pair(
-                        object_prediction_list[keep_ind].tolist(), object_prediction_list[merge_ind].tolist()
+                    object_predictions[keep_ind] = merge_object_prediction_pair(
+                        object_predictions[keep_ind].tolist(), object_predictions[merge_ind].tolist()
                     )
-            selected_object_predictions.append(object_prediction_list[keep_ind].tolist())
+            selected_object_predictions.append(object_predictions[keep_ind].tolist())
 
         return selected_object_predictions
 
@@ -535,8 +535,8 @@ class GreedyNMMPostprocess(PostprocessPredictions):
         self,
         object_predictions: List[ObjectPrediction],
     ):
-        object_prediction_list = ObjectPredictionList(object_predictions)
-        object_predictions_as_torch = object_prediction_list.totensor()
+        object_predictions = ObjectPredictionList(object_predictions)
+        object_predictions_as_torch = object_predictions.totensor()
         if self.class_agnostic:
             keep_to_merge_list = greedy_nmm(
                 object_predictions_as_torch,
@@ -554,15 +554,15 @@ class GreedyNMMPostprocess(PostprocessPredictions):
         for keep_ind, merge_ind_list in keep_to_merge_list.items():
             for merge_ind in merge_ind_list:
                 if has_match(
-                    object_prediction_list[keep_ind].tolist(),
-                    object_prediction_list[merge_ind].tolist(),
+                    object_predictions[keep_ind].tolist(),
+                    object_predictions[merge_ind].tolist(),
                     self.match_metric,
                     self.match_threshold,
                 ):
-                    object_prediction_list[keep_ind] = merge_object_prediction_pair(
-                        object_prediction_list[keep_ind].tolist(), object_prediction_list[merge_ind].tolist()
+                    object_predictions[keep_ind] = merge_object_prediction_pair(
+                        object_predictions[keep_ind].tolist(), object_predictions[merge_ind].tolist()
                     )
-            selected_object_predictions.append(object_prediction_list[keep_ind].tolist())
+            selected_object_predictions.append(object_predictions[keep_ind].tolist())
 
         return selected_object_predictions
 
@@ -585,8 +585,8 @@ class LSNMSPostprocess(PostprocessPredictions):
 
         logger.warning("LSNMSPostprocess is experimental and not recommended to use.")
 
-        object_prediction_list = ObjectPredictionList(object_predictions)
-        object_predictions_as_numpy = object_prediction_list.tonumpy()
+        object_predictions = ObjectPredictionList(object_predictions)
+        object_predictions_as_numpy = object_predictions.tonumpy()
 
         boxes = object_predictions_as_numpy[:, :4]
         scores = object_predictions_as_numpy[:, 4]
@@ -596,7 +596,7 @@ class LSNMSPostprocess(PostprocessPredictions):
             boxes, scores, iou_threshold=self.match_threshold, class_ids=None if self.class_agnostic else class_ids
         )
 
-        selected_object_predictions = object_prediction_list[keep].tolist()
+        selected_object_predictions = object_predictions[keep].tolist()
         if not isinstance(selected_object_predictions, list):
             selected_object_predictions = [selected_object_predictions]
 

--- a/sahi/postprocess/utils.py
+++ b/sahi/postprocess/utils.py
@@ -47,8 +47,8 @@ class ObjectPredictionList(Sequence):
     def __str__(self):
         return str(self.list)
 
-    def extend(self, object_prediction_list):
-        self.list.extend(object_prediction_list.list)
+    def extend(self, object_predictions):
+        self.list.extend(object_predictions.list)
 
     def totensor(self):
         return object_prediction_list_to_torch(self)

--- a/sahi/predict.py
+++ b/sahi/predict.py
@@ -128,8 +128,8 @@ def get_sliced_prediction(
     overlap_height_ratio: float = 0.2,
     overlap_width_ratio: float = 0.2,
     perform_standard_pred: bool = True,
-    postprocess_type: str = "GREEDYNMM",
-    postprocess_match_metric: str = "IOS",
+    postprocess_type: str = "NMS",
+    postprocess_match_metric: str = "IOU",
     postprocess_match_threshold: float = 0.5,
     postprocess_class_agnostic: bool = False,
     verbose: int = 1,
@@ -306,8 +306,8 @@ def predict(
     slice_width: int = 512,
     overlap_height_ratio: float = 0.2,
     overlap_width_ratio: float = 0.2,
-    postprocess_type: str = "GREEDYNMM",
-    postprocess_match_metric: str = "IOS",
+    postprocess_type: str = "NMS",
+    postprocess_match_metric: str = "IOU",
     postprocess_match_threshold: float = 0.5,
     postprocess_class_agnostic: bool = False,
     novisual: bool = False,
@@ -370,7 +370,7 @@ def predict(
             Default to ``0.2``.
         postprocess_type: str
             Type of the postprocess to be used after sliced inference while merging/eliminating predictions.
-            Options are 'NMM', 'GRREDYNMM' or 'NMS'. Default is 'GRREDYNMM'.
+            Options are 'NMM', 'GRREDYNMM' or 'NMS'. Default is 'NMS'.
         postprocess_match_metric: str
             Metric to be used during object prediction matching after sliced prediction.
             'IOU' for intersection over union, 'IOS' for intersection over smaller area.
@@ -678,8 +678,8 @@ def predict_fiftyone(
     slice_width: int = 256,
     overlap_height_ratio: float = 0.2,
     overlap_width_ratio: float = 0.2,
-    postprocess_type: str = "GREEDYNMM",
-    postprocess_match_metric: str = "IOS",
+    postprocess_type: str = "NMS",
+    postprocess_match_metric: str = "IOU",
     postprocess_match_threshold: float = 0.5,
     postprocess_class_agnostic: bool = False,
     verbose: int = 1,
@@ -726,7 +726,7 @@ def predict_fiftyone(
             Default to ``0.2``.
         postprocess_type: str
             Type of the postprocess to be used after sliced inference while merging/eliminating predictions.
-            Options are 'NMM', 'GRREDYNMM' or 'NMS'. Default is 'GRREDYNMM'.
+            Options are 'NMM', 'GRREDYNMM' or 'NMS'. Default is 'NMS'.
         postprocess_match_metric: str
             Metric to be used during object prediction matching after sliced prediction.
             'IOU' for intersection over union, 'IOS' for intersection over smaller area.

--- a/sahi/utils/cv.py
+++ b/sahi/utils/cv.py
@@ -57,7 +57,7 @@ class Colors:
 
 def crop_object_predictions(
     image: np.ndarray,
-    object_prediction_list,
+    object_predictions,
     output_dir: str = "",
     file_name: str = "prediction_visual",
     export_format: str = "png",
@@ -73,8 +73,8 @@ def crop_object_predictions(
     # create output folder if not present
     Path(output_dir).mkdir(parents=True, exist_ok=True)
     # add bbox and mask to image if present
-    for ind, object_prediction in enumerate(object_prediction_list):
-        # deepcopy object_prediction_list so that original is not altered
+    for ind, object_prediction in enumerate(object_predictions):
+        # deepcopy object_predictions so that original is not altered
         object_prediction = object_prediction.deepcopy()
         bbox = object_prediction.bbox.to_xyxy()
         category_id = object_prediction.category.id
@@ -396,7 +396,7 @@ def visualize_prediction(
 
 def visualize_object_predictions(
     image: np.array,
-    object_prediction_list,
+    object_predictions,
     rect_th: int = None,
     text_size: float = None,
     text_th: float = None,
@@ -409,7 +409,7 @@ def visualize_object_predictions(
     Visualizes prediction category names, bounding boxes over the source image
     and exports it to output folder.
     Arguments:
-        object_prediction_list: a list of prediction.ObjectPrediction
+        object_predictions: a list of prediction.ObjectPrediction
         rect_th: rectangle thickness
         text_size: size of the category name over box
         text_th: text thickness
@@ -433,8 +433,8 @@ def visualize_object_predictions(
     # set text_size for category names
     text_size = text_size or rect_th / 3
     # add bbox and mask to image if present
-    for object_prediction in object_prediction_list:
-        # deepcopy object_prediction_list so that original is not altered
+    for object_prediction in object_predictions:
+        # deepcopy object_predictions so that original is not altered
         object_prediction = object_prediction.deepcopy()
 
         bbox = object_prediction.bbox.to_xyxy()

--- a/sahi/utils/torch.py
+++ b/sahi/utils/torch.py
@@ -4,6 +4,9 @@
 
 import os
 
+import numpy as np
+from PIL import Image
+
 from sahi.utils.import_utils import is_available
 
 if is_available("torch"):
@@ -47,7 +50,7 @@ def to_float_batch_tensor(images):
     return torch.stack(batch)
 
 
-def to_float_tensor(img):
+def to_float_tensor(img: Image.Image) -> torch.Tensor:
     """
     Converts a PIL.Image (RGB) or numpy.ndarray (H x W x C) in the range
     [0, 255] to a torch.FloatTensor of shape (C x H x W).
@@ -57,7 +60,7 @@ def to_float_tensor(img):
         torch.tensor
     """
 
-    img = img.transpose((2, 0, 1))
+    img = np.array(img).transpose((2, 0, 1))
     img = torch.from_numpy(img).float()
     if img.max() > 1:
         img /= 255

--- a/sahi/utils/torch.py
+++ b/sahi/utils/torch.py
@@ -17,6 +17,36 @@ def empty_cuda_cache():
         return torch.cuda.empty_cache()
 
 
+def to_float_tensors(images, device):
+    """
+    Converts a list of PIL.Image (RGB) or numpy.ndarray (H x W x C) in the range
+    [0, 255] to a torch.FloatTensor of shape (N x C x H x W).
+    Args:
+        images: list[np.ndarray]
+    Returns:
+        List[torch.FloatTensor]
+    """
+    batch = []
+    for img in images:
+        batch.append(to_float_tensor(img).to(device))
+    return batch
+
+
+def to_float_batch_tensor(images):
+    """
+    Converts a list of PIL.Image (RGB) or numpy.ndarray (H x W x C) in the range
+    [0, 255] to a torch.FloatTensor of shape (N x C x H x W).
+    Args:
+        images: list[np.ndarray]
+    Returns:
+        torch.tensor
+    """
+    batch = []
+    for img in images:
+        batch.append(to_float_tensor(img))
+    return torch.stack(batch)
+
+
 def to_float_tensor(img):
     """
     Converts a PIL.Image (RGB) or numpy.ndarray (H x W x C) in the range

--- a/tests/test_detectron2.py
+++ b/tests/test_detectron2.py
@@ -3,9 +3,7 @@
 
 import unittest
 
-from sahi.models.detectron2 import Detectron2DetectionModel
 from sahi.utils.cv import read_image
-from sahi.utils.detectron2 import Detectron2TestConstants
 from sahi.utils.import_utils import get_package_info
 
 MODEL_DEVICE = "cpu"
@@ -15,6 +13,8 @@ IMAGE_SIZE = 320
 # note that detectron2 binaries are available only for linux
 
 if get_package_info("torch", verbose=False)[1] == "1.10.2":
+    from sahi.models.detectron2 import Detectron2DetectionModel
+    from sahi.utils.detectron2 import Detectron2TestConstants
 
     class TestDetectron2DetectionModel(unittest.TestCase):
         def test_load_model(self):
@@ -80,22 +80,22 @@ if get_package_info("torch", verbose=False)[1] == "1.10.2":
 
             # convert predictions to ObjectPrediction list
             detectron2_detection_model.convert_original_predictions()
-            object_prediction_list = detectron2_detection_model.object_prediction_list
+            object_predictions = detectron2_detection_model.object_predictions
 
             # compare
-            self.assertEqual(len(object_prediction_list), 16)
-            self.assertEqual(object_prediction_list[0].category.id, 2)
-            self.assertEqual(object_prediction_list[0].category.name, "car")
-            predicted_bbox = object_prediction_list[0].bbox.to_xywh()
+            self.assertEqual(len(object_predictions), 16)
+            self.assertEqual(object_predictions[0].category.id, 2)
+            self.assertEqual(object_predictions[0].category.name, "car")
+            predicted_bbox = object_predictions[0].bbox.to_xywh()
             desired_bbox = [831, 303, 42, 43]
             margin = 3
             for ind, point in enumerate(predicted_bbox):
                 if not (point < desired_bbox[ind] + margin and point > desired_bbox[ind] - margin):
                     raise AssertionError(f"desired_bbox: {desired_bbox}, predicted_bbox: {predicted_bbox}")
 
-            self.assertEqual(object_prediction_list[5].category.id, 2)
-            self.assertEqual(object_prediction_list[5].category.name, "car")
-            predicted_bbox = object_prediction_list[2].bbox.to_xywh()
+            self.assertEqual(object_predictions[5].category.id, 2)
+            self.assertEqual(object_predictions[5].category.name, "car")
+            predicted_bbox = object_predictions[2].bbox.to_xywh()
             desired_bbox = [383, 277, 36, 29]
             margin = 3
             for ind, point in enumerate(predicted_bbox):
@@ -122,22 +122,22 @@ if get_package_info("torch", verbose=False)[1] == "1.10.2":
 
             # convert predictions to ObjectPrediction list
             detectron2_detection_model.convert_original_predictions()
-            object_prediction_list = detectron2_detection_model.object_prediction_list
+            object_predictions = detectron2_detection_model.object_predictions
 
             # compare
-            self.assertEqual(len(object_prediction_list), 13)
-            self.assertEqual(object_prediction_list[0].category.id, 2)
-            self.assertEqual(object_prediction_list[0].category.name, "car")
-            predicted_bbox = object_prediction_list[0].bbox.to_xywh()
+            self.assertEqual(len(object_predictions), 13)
+            self.assertEqual(object_predictions[0].category.id, 2)
+            self.assertEqual(object_predictions[0].category.name, "car")
+            predicted_bbox = object_predictions[0].bbox.to_xywh()
             desired_bbox = [321, 324, 59, 38]
             margin = 3
             for ind, point in enumerate(predicted_bbox):
                 if not (point < desired_bbox[ind] + margin and point > desired_bbox[ind] - margin):
                     raise AssertionError(f"desired_bbox: {desired_bbox}, predicted_bbox: {predicted_bbox}")
 
-            self.assertEqual(object_prediction_list[5].category.id, 2)
-            self.assertEqual(object_prediction_list[5].category.name, "car")
-            predicted_bbox = object_prediction_list[5].bbox.to_xywh()
+            self.assertEqual(object_predictions[5].category.id, 2)
+            self.assertEqual(object_predictions[5].category.name, "car")
+            predicted_bbox = object_predictions[5].bbox.to_xywh()
             desired_bbox = [719, 243, 27, 30]
             margin = 3
             for ind, point in enumerate(predicted_bbox):
@@ -145,7 +145,6 @@ if get_package_info("torch", verbose=False)[1] == "1.10.2":
                     raise AssertionError(f"desired_bbox: {desired_bbox}, predicted_bbox: {predicted_bbox}")
 
         def test_get_prediction_detectron2(self):
-            from sahi.model import Detectron2DetectionModel
             from sahi.predict import get_prediction
             from sahi.utils.detectron2 import Detectron2TestConstants
 
@@ -173,28 +172,27 @@ if get_package_info("torch", verbose=False)[1] == "1.10.2":
                 full_shape=None,
                 postprocess=None,
             )
-            object_prediction_list = prediction_result.object_prediction_list
+            object_predictions = prediction_result.object_predictions
 
             # compare
-            self.assertEqual(len(object_prediction_list), 16)
+            self.assertEqual(len(object_predictions), 16)
             num_person = 0
-            for object_prediction in object_prediction_list:
+            for object_prediction in object_predictions:
                 if object_prediction.category.name == "person":
                     num_person += 1
             self.assertEqual(num_person, 0)
             num_truck = 0
-            for object_prediction in object_prediction_list:
+            for object_prediction in object_predictions:
                 if object_prediction.category.name == "truck":
                     num_truck += 1
             self.assertEqual(num_truck, 0)
             num_car = 0
-            for object_prediction in object_prediction_list:
+            for object_prediction in object_predictions:
                 if object_prediction.category.name == "car":
                     num_car += 1
             self.assertEqual(num_car, 16)
 
         def test_get_sliced_prediction_detectron2(self):
-            from sahi.model import Detectron2DetectionModel
             from sahi.predict import get_sliced_prediction
             from sahi.utils.detectron2 import Detectron2TestConstants
 
@@ -236,22 +234,22 @@ if get_package_info("torch", verbose=False)[1] == "1.10.2":
                 postprocess_match_metric=match_metric,
                 postprocess_class_agnostic=class_agnostic,
             )
-            object_prediction_list = prediction_result.object_prediction_list
+            object_predictions = prediction_result.object_predictions
 
             # compare
-            self.assertEqual(len(object_prediction_list), 18)
+            self.assertEqual(len(object_predictions), 18)
             num_person = 0
-            for object_prediction in object_prediction_list:
+            for object_prediction in object_predictions:
                 if object_prediction.category.name == "person":
                     num_person += 1
             self.assertEqual(num_person, 0)
             num_truck = 0
-            for object_prediction in object_prediction_list:
+            for object_prediction in object_predictions:
                 if object_prediction.category.name == "truck":
                     num_truck += 1
             self.assertEqual(num_truck, 0)
             num_car = 0
-            for object_prediction in object_prediction_list:
+            for object_prediction in object_predictions:
                 if object_prediction.category.name == "car":
                     num_car += 1
             self.assertEqual(num_car, 18)

--- a/tests/test_huggingfacemodel.py
+++ b/tests/test_huggingfacemodel.py
@@ -83,7 +83,7 @@ if sys.version_info >= (3, 7):
                 if huggingface_detection_model.category_mapping[cat_ids[i].item()] == "car":  # if category car
                     break
 
-            image_height, image_width, _ = huggingface_detection_model.image_shapes[0]
+            image_height, image_width = huggingface_detection_model.image_shapes[0]
             box = list(
                 pbf.convert_bbox(
                     box.tolist(),

--- a/tests/test_huggingfacemodel.py
+++ b/tests/test_huggingfacemodel.py
@@ -166,10 +166,10 @@ if sys.version_info >= (3, 7):
 
             # get full sized prediction
             prediction_result = get_prediction(
-                image=image,
+                images=image,
                 detection_model=huggingface_detection_model,
-                shift_amount=[0, 0],
-                full_shape=None,
+                shift_amounts=[[0, 0]],
+                full_shapes=None,
                 postprocess=None,
             )
             object_predictions = prediction_result.object_predictions
@@ -210,10 +210,10 @@ if sys.version_info >= (3, 7):
 
             # get full sized prediction
             prediction_result = get_prediction(
-                image=image,
+                images=image,
                 detection_model=huggingface_detection_model,
-                shift_amount=[0, 0],
-                full_shape=None,
+                shift_amounts=[[0, 0]],
+                full_shapes=None,
                 postprocess=None,
             )
             object_predictions = prediction_result.object_predictions

--- a/tests/test_huggingfacemodel.py
+++ b/tests/test_huggingfacemodel.py
@@ -124,25 +124,25 @@ if sys.version_info >= (3, 7):
 
             # convert predictions to ObjectPrediction list
             huggingface_detection_model.convert_original_predictions()
-            object_prediction_list = huggingface_detection_model.object_prediction_list
+            object_predictions = huggingface_detection_model.object_predictions
 
             # compare
-            self.assertEqual(len(object_prediction_list), 28)
-            self.assertEqual(object_prediction_list[0].category.id, 3)
-            self.assertEqual(object_prediction_list[0].category.name, "car")
+            self.assertEqual(len(object_predictions), 28)
+            self.assertEqual(object_predictions[0].category.id, 3)
+            self.assertEqual(object_predictions[0].category.name, "car")
             desired_bbox = [639, 198, 24, 20]
-            predicted_bbox = object_prediction_list[0].bbox.to_xywh()
+            predicted_bbox = object_predictions[0].bbox.to_xywh()
             margin = 2
             for ind, point in enumerate(predicted_bbox):
                 assert point < desired_bbox[ind] + margin and point > desired_bbox[ind] - margin
-            self.assertEqual(object_prediction_list[2].category.id, 3)
-            self.assertEqual(object_prediction_list[2].category.name, "car")
+            self.assertEqual(object_predictions[2].category.id, 3)
+            self.assertEqual(object_predictions[2].category.name, "car")
             desired_bbox = [745, 169, 15, 14]
-            predicted_bbox = object_prediction_list[2].bbox.to_xywh()
+            predicted_bbox = object_predictions[2].bbox.to_xywh()
             for ind, point in enumerate(predicted_bbox):
                 assert point < desired_bbox[ind] + margin and point > desired_bbox[ind] - margin
 
-            for object_prediction in object_prediction_list:
+            for object_prediction in object_predictions:
                 self.assertGreaterEqual(object_prediction.score.value, CONFIDENCE_THRESHOLD)
 
         def test_get_prediction_huggingface(self):
@@ -172,12 +172,12 @@ if sys.version_info >= (3, 7):
                 full_shape=None,
                 postprocess=None,
             )
-            object_prediction_list = prediction_result.object_prediction_list
+            object_predictions = prediction_result.object_predictions
 
             # compare
-            self.assertEqual(len(object_prediction_list), 28)
+            self.assertEqual(len(object_predictions), 28)
             num_person = num_truck = num_car = 0
-            for object_prediction in object_prediction_list:
+            for object_prediction in object_predictions:
                 if object_prediction.category.name == "person":
                     num_person += 1
                 elif object_prediction.category.name == "truck":
@@ -216,12 +216,12 @@ if sys.version_info >= (3, 7):
                 full_shape=None,
                 postprocess=None,
             )
-            object_prediction_list = prediction_result.object_prediction_list
+            object_predictions = prediction_result.object_predictions
 
             # compare
-            self.assertEqual(len(object_prediction_list), 28)
+            self.assertEqual(len(object_predictions), 28)
             num_person = num_truck = num_car = 0
-            for object_prediction in object_prediction_list:
+            for object_prediction in object_predictions:
                 if object_prediction.category.name == "person":
                     num_person += 1
                 elif object_prediction.category.name == "truck":
@@ -273,12 +273,12 @@ if sys.version_info >= (3, 7):
                 postprocess_match_metric=match_metric,
                 postprocess_class_agnostic=class_agnostic,
             )
-            object_prediction_list = prediction_result.object_prediction_list
+            object_predictions = prediction_result.object_predictions
 
             # compare
-            self.assertEqual(len(object_prediction_list), 54)
+            self.assertEqual(len(object_predictions), 54)
             num_person = num_truck = num_car = 0
-            for object_prediction in object_prediction_list:
+            for object_prediction in object_predictions:
                 if object_prediction.category.name == "person":
                     num_person += 1
                 elif object_prediction.category.name == "truck":

--- a/tests/test_mmdetectionmodel.py
+++ b/tests/test_mmdetectionmodel.py
@@ -130,23 +130,23 @@ class TestMmdetDetectionModel(unittest.TestCase):
 
         # convert predictions to ObjectPrediction list
         mmdet_detection_model.convert_original_predictions()
-        object_prediction_list = mmdet_detection_model.object_prediction_list
+        object_predictions = mmdet_detection_model.object_predictions
 
         # compare
-        self.assertEqual(len(object_prediction_list), 3)
-        self.assertEqual(object_prediction_list[0].category.id, 2)
-        self.assertEqual(object_prediction_list[0].category.name, "car")
+        self.assertEqual(len(object_predictions), 3)
+        self.assertEqual(object_predictions[0].category.id, 2)
+        self.assertEqual(object_predictions[0].category.name, "car")
         self.assertEqual(
-            object_prediction_list[0].bbox.to_xywh(),
+            object_predictions[0].bbox.to_xywh(),
             [448, 308, 41, 36],
         )
-        self.assertEqual(object_prediction_list[2].category.id, 2)
-        self.assertEqual(object_prediction_list[2].category.name, "car")
+        self.assertEqual(object_predictions[2].category.id, 2)
+        self.assertEqual(object_predictions[2].category.name, "car")
         self.assertEqual(
-            object_prediction_list[2].bbox.to_xywh(),
+            object_predictions[2].bbox.to_xywh(),
             [381, 280, 33, 30],
         )
-        for object_prediction in object_prediction_list:
+        for object_prediction in object_predictions:
             self.assertGreaterEqual(object_prediction.score.value, CONFIDENCE_THRESHOLD)
 
     def test_convert_original_predictions_without_mask_output(self):
@@ -174,21 +174,17 @@ class TestMmdetDetectionModel(unittest.TestCase):
 
         # convert predictions to ObjectPrediction list
         mmdet_detection_model.convert_original_predictions()
-        object_prediction_list = mmdet_detection_model.object_prediction_list
+        object_predictions = mmdet_detection_model.object_predictions
 
         # compare
-        self.assertEqual(len(object_prediction_list), 2)
-        self.assertEqual(object_prediction_list[0].category.id, 2)
-        self.assertEqual(object_prediction_list[0].category.name, "car")
-        np.testing.assert_almost_equal(
-            object_prediction_list[0].bbox.to_xywh(), [320.28, 323.55, 60.60, 41.91], decimal=1
-        )
-        self.assertEqual(object_prediction_list[1].category.id, 2)
-        self.assertEqual(object_prediction_list[1].category.name, "car")
-        np.testing.assert_almost_equal(
-            object_prediction_list[1].bbox.to_xywh(), [448.45, 310.97, 44.49, 30.86], decimal=1
-        )
-        for object_prediction in object_prediction_list:
+        self.assertEqual(len(object_predictions), 2)
+        self.assertEqual(object_predictions[0].category.id, 2)
+        self.assertEqual(object_predictions[0].category.name, "car")
+        np.testing.assert_almost_equal(object_predictions[0].bbox.to_xywh(), [320.28, 323.55, 60.60, 41.91], decimal=1)
+        self.assertEqual(object_predictions[1].category.id, 2)
+        self.assertEqual(object_predictions[1].category.name, "car")
+        np.testing.assert_almost_equal(object_predictions[1].bbox.to_xywh(), [448.45, 310.97, 44.49, 30.86], decimal=1)
+        for object_prediction in object_predictions:
             self.assertGreaterEqual(object_prediction.score.value, CONFIDENCE_THRESHOLD)
 
 

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -52,22 +52,22 @@ class TestPredict(unittest.TestCase):
         prediction_result = get_prediction(
             image=image, detection_model=mmdet_detection_model, shift_amount=[0, 0], full_shape=None
         )
-        object_prediction_list = prediction_result.object_prediction_list
+        object_predictions = prediction_result.object_predictions
 
         # compare
-        self.assertEqual(len(object_prediction_list), 2)
+        self.assertEqual(len(object_predictions), 2)
         num_person = 0
-        for object_prediction in object_prediction_list:
+        for object_prediction in object_predictions:
             if object_prediction.category.name == "person":
                 num_person += 1
         self.assertEqual(num_person, 0)
         num_truck = 0
-        for object_prediction in object_prediction_list:
+        for object_prediction in object_predictions:
             if object_prediction.category.name == "truck":
                 num_truck += 1
         self.assertEqual(num_truck, 0)
         num_car = 0
-        for object_prediction in object_prediction_list:
+        for object_prediction in object_predictions:
             if object_prediction.category.name == "car":
                 num_car += 1
         self.assertEqual(num_car, 2)
@@ -98,22 +98,22 @@ class TestPredict(unittest.TestCase):
         prediction_result = get_prediction(
             image=image, detection_model=yolov5_detection_model, shift_amount=[0, 0], full_shape=None, postprocess=None
         )
-        object_prediction_list = prediction_result.object_prediction_list
+        object_predictions = prediction_result.object_predictions
 
         # compare
-        self.assertEqual(len(object_prediction_list), 2)
+        self.assertEqual(len(object_predictions), 2)
         num_person = 0
-        for object_prediction in object_prediction_list:
+        for object_prediction in object_predictions:
             if object_prediction.category.name == "person":
                 num_person += 1
         self.assertEqual(num_person, 0)
         num_truck = 0
-        for object_prediction in object_prediction_list:
+        for object_prediction in object_predictions:
             if object_prediction.category.name == "truck":
                 num_truck += 1
         self.assertEqual(num_truck, 0)
         num_car = 0
-        for object_prediction in object_prediction_list:
+        for object_prediction in object_predictions:
             if object_prediction.category.name == "car":
                 num_car += 1
         self.assertEqual(num_car, 2)
@@ -145,22 +145,22 @@ class TestPredict(unittest.TestCase):
         prediction_result = get_prediction(
             image=image, detection_model=yolov5_detection_model, shift_amount=[0, 0], full_shape=None, postprocess=None
         )
-        object_prediction_list = prediction_result.object_prediction_list
+        object_predictions = prediction_result.object_predictions
 
         # compare
-        self.assertEqual(len(object_prediction_list), 2)
+        self.assertEqual(len(object_predictions), 2)
         num_person = 0
-        for object_prediction in object_prediction_list:
+        for object_prediction in object_predictions:
             if object_prediction.category.name == "person":
                 num_person += 1
         self.assertEqual(num_person, 0)
         num_truck = 0
-        for object_prediction in object_prediction_list:
+        for object_prediction in object_predictions:
             if object_prediction.category.name == "truck":
                 num_truck += 1
         self.assertEqual(num_truck, 0)
         num_car = 0
-        for object_prediction in object_prediction_list:
+        for object_prediction in object_predictions:
             if object_prediction.category.name == "car":
                 num_car += 1
         self.assertEqual(num_car, 2)
@@ -210,22 +210,22 @@ class TestPredict(unittest.TestCase):
             postprocess_match_metric=match_metric,
             postprocess_class_agnostic=class_agnostic,
         )
-        object_prediction_list = prediction_result.object_prediction_list
+        object_predictions = prediction_result.object_predictions
 
         # compare
-        self.assertEqual(len(object_prediction_list), 15)
+        self.assertEqual(len(object_predictions), 15)
         num_person = 0
-        for object_prediction in object_prediction_list:
+        for object_prediction in object_predictions:
             if object_prediction.category.name == "person":
                 num_person += 1
         self.assertEqual(num_person, 0)
         num_truck = 0
-        for object_prediction in object_prediction_list:
+        for object_prediction in object_predictions:
             if object_prediction.category.name == "truck":
                 num_truck += 1
         self.assertEqual(num_truck, 0)
         num_car = 0
-        for object_prediction in object_prediction_list:
+        for object_prediction in object_predictions:
             if object_prediction.category.name == "car":
                 num_car += 1
         self.assertEqual(num_car, 15)
@@ -274,22 +274,22 @@ class TestPredict(unittest.TestCase):
             postprocess_match_metric=match_metric,
             postprocess_class_agnostic=class_agnostic,
         )
-        object_prediction_list = prediction_result.object_prediction_list
+        object_predictions = prediction_result.object_predictions
 
         # compare
-        self.assertEqual(len(object_prediction_list), 11)
+        self.assertEqual(len(object_predictions), 11)
         num_person = 0
-        for object_prediction in object_prediction_list:
+        for object_prediction in object_predictions:
             if object_prediction.category.name == "person":
                 num_person += 1
         self.assertEqual(num_person, 0)
         num_truck = 0
-        for object_prediction in object_prediction_list:
+        for object_prediction in object_predictions:
             if object_prediction.category.name == "truck":
                 num_truck += 2
         self.assertEqual(num_truck, 0)
         num_car = 0
-        for object_prediction in object_prediction_list:
+        for object_prediction in object_predictions:
             if object_prediction.category.name == "car":
                 num_car += 1
         self.assertEqual(num_car, 11)

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -50,7 +50,7 @@ class TestPredict(unittest.TestCase):
 
         # get full sized prediction
         prediction_result = get_prediction(
-            image=image, detection_model=mmdet_detection_model, shift_amount=[0, 0], full_shape=None
+            images=image, detection_model=mmdet_detection_model, shift_amounts=[[0, 0]], full_shapes=None
         )
         object_predictions = prediction_result.object_predictions
 
@@ -96,7 +96,11 @@ class TestPredict(unittest.TestCase):
 
         # get full sized prediction
         prediction_result = get_prediction(
-            image=image, detection_model=yolov5_detection_model, shift_amount=[0, 0], full_shape=None, postprocess=None
+            images=image,
+            detection_model=yolov5_detection_model,
+            shift_amounts=[[0, 0]],
+            full_shapes=None,
+            postprocess=None,
         )
         object_predictions = prediction_result.object_predictions
 
@@ -143,7 +147,11 @@ class TestPredict(unittest.TestCase):
 
         # get full sized prediction
         prediction_result = get_prediction(
-            image=image, detection_model=yolov5_detection_model, shift_amount=[0, 0], full_shape=None, postprocess=None
+            images=image,
+            detection_model=yolov5_detection_model,
+            shift_amounts=[[0, 0]],
+            full_shapes=None,
+            postprocess=None,
         )
         object_predictions = prediction_result.object_predictions
 

--- a/tests/test_torchvision.py
+++ b/tests/test_torchvision.py
@@ -132,15 +132,13 @@ class TestTorchVisionDetectionModel(unittest.TestCase):
 
         # convert predictions to ObjectPrediction list
         torchvision_detection_model.convert_original_predictions()
-        object_prediction_list = torchvision_detection_model.object_prediction_list
+        object_predictions = torchvision_detection_model.object_predictions
 
         # compare
-        self.assertEqual(len(object_prediction_list), 7)
-        self.assertEqual(object_prediction_list[0].category.id, 3)
-        self.assertEqual(object_prediction_list[0].category.name, "car")
-        np.testing.assert_almost_equal(
-            object_prediction_list[0].bbox.to_xywh(), [315.79, 309.33, 64.28, 56.94], decimal=1
-        )
+        self.assertEqual(len(object_predictions), 7)
+        self.assertEqual(object_predictions[0].category.id, 3)
+        self.assertEqual(object_predictions[0].category.name, "car")
+        np.testing.assert_almost_equal(object_predictions[0].bbox.to_xywh(), [315.79, 309.33, 64.28, 56.94], decimal=1)
 
     def test_convert_original_predictions_with_mask_output(self):
         from sahi.models.torchvision import TorchVisionDetectionModel
@@ -163,15 +161,13 @@ class TestTorchVisionDetectionModel(unittest.TestCase):
 
         # convert predictions to ObjectPrediction list
         torchvision_detection_model.convert_original_predictions()
-        object_prediction_list = torchvision_detection_model.object_prediction_list
+        object_predictions = torchvision_detection_model.object_predictions
 
         # compare
-        self.assertEqual(len(object_prediction_list), 7)
-        self.assertEqual(object_prediction_list[0].category.id, 3)
-        self.assertEqual(object_prediction_list[0].category.name, "car")
-        np.testing.assert_almost_equal(
-            object_prediction_list[0].bbox.to_xywh(), [315.79, 309.33, 64.28, 56.94], decimal=1
-        )
+        self.assertEqual(len(object_predictions), 7)
+        self.assertEqual(object_predictions[0].category.id, 3)
+        self.assertEqual(object_predictions[0].category.name, "car")
+        np.testing.assert_almost_equal(object_predictions[0].bbox.to_xywh(), [315.79, 309.33, 64.28, 56.94], decimal=1)
 
     def test_get_prediction_torchvision(self):
         from sahi.models.torchvision import TorchVisionDetectionModel
@@ -200,15 +196,13 @@ class TestTorchVisionDetectionModel(unittest.TestCase):
             full_shape=None,
             postprocess=None,
         )
-        object_prediction_list = prediction_result.object_prediction_list
+        object_predictions = prediction_result.object_predictions
 
         # compare
-        self.assertEqual(len(object_prediction_list), 7)
-        self.assertEqual(object_prediction_list[0].category.id, 3)
-        self.assertEqual(object_prediction_list[0].category.name, "car")
-        np.testing.assert_almost_equal(
-            object_prediction_list[0].bbox.to_xywh(), [315.79, 309.33, 64.28, 56.94], decimal=1
-        )
+        self.assertEqual(len(object_predictions), 7)
+        self.assertEqual(object_predictions[0].category.id, 3)
+        self.assertEqual(object_predictions[0].category.name, "car")
+        np.testing.assert_almost_equal(object_predictions[0].bbox.to_xywh(), [315.79, 309.33, 64.28, 56.94], decimal=1)
 
     def test_get_sliced_prediction_torchvision(self):
         from sahi.models.torchvision import TorchVisionDetectionModel
@@ -251,15 +245,13 @@ class TestTorchVisionDetectionModel(unittest.TestCase):
             postprocess_match_metric=match_metric,
             postprocess_class_agnostic=class_agnostic,
         )
-        object_prediction_list = prediction_result.object_prediction_list
+        object_predictions = prediction_result.object_predictions
 
         # compare
-        self.assertEqual(len(object_prediction_list), 20)
-        self.assertEqual(object_prediction_list[0].category.id, 3)
-        self.assertEqual(object_prediction_list[0].category.name, "car")
-        np.testing.assert_almost_equal(
-            object_prediction_list[0].bbox.to_xywh(), [765.81, 259.37, 28.62, 24.63], decimal=1
-        )
+        self.assertEqual(len(object_predictions), 20)
+        self.assertEqual(object_predictions[0].category.id, 3)
+        self.assertEqual(object_predictions[0].category.name, "car")
+        np.testing.assert_almost_equal(object_predictions[0].bbox.to_xywh(), [765.81, 259.37, 28.62, 24.63], decimal=1)
 
 
 if __name__ == "__main__":

--- a/tests/test_torchvision.py
+++ b/tests/test_torchvision.py
@@ -190,10 +190,10 @@ class TestTorchVisionDetectionModel(unittest.TestCase):
 
         # get full sized prediction
         prediction_result = get_prediction(
-            image=image,
+            images=image,
             detection_model=torchvision_detection_model,
-            shift_amount=[0, 0],
-            full_shape=None,
+            shift_amounts=[[0, 0]],
+            full_shapes=None,
             postprocess=None,
         )
         object_predictions = prediction_result.object_predictions

--- a/tests/test_yolov5model.py
+++ b/tests/test_yolov5model.py
@@ -113,25 +113,25 @@ class TestYolov5DetectionModel(unittest.TestCase):
 
         # convert predictions to ObjectPrediction list
         yolov5_detection_model.convert_original_predictions()
-        object_prediction_list = yolov5_detection_model.object_prediction_list
+        object_predictions = yolov5_detection_model.object_predictions
 
         # compare
-        self.assertEqual(len(object_prediction_list), 3)
-        self.assertEqual(object_prediction_list[0].category.id, 2)
-        self.assertEqual(object_prediction_list[0].category.name, "car")
+        self.assertEqual(len(object_predictions), 3)
+        self.assertEqual(object_predictions[0].category.id, 2)
+        self.assertEqual(object_predictions[0].category.name, "car")
         desired_bbox = [321, 329, 57, 39]
-        predicted_bbox = object_prediction_list[0].bbox.to_xywh()
+        predicted_bbox = object_predictions[0].bbox.to_xywh()
         margin = 2
         for ind, point in enumerate(predicted_bbox):
             assert point < desired_bbox[ind] + margin and point > desired_bbox[ind] - margin
-        self.assertEqual(object_prediction_list[2].category.id, 2)
-        self.assertEqual(object_prediction_list[2].category.name, "car")
+        self.assertEqual(object_predictions[2].category.id, 2)
+        self.assertEqual(object_predictions[2].category.name, "car")
         desired_bbox = [381, 275, 42, 28]
-        predicted_bbox = object_prediction_list[2].bbox.to_xywh()
+        predicted_bbox = object_predictions[2].bbox.to_xywh()
         for ind, point in enumerate(predicted_bbox):
             assert point < desired_bbox[ind] + margin and point > desired_bbox[ind] - margin
 
-        for object_prediction in object_prediction_list:
+        for object_prediction in object_predictions:
             self.assertGreaterEqual(object_prediction.score.value, CONFIDENCE_THRESHOLD)
 
 


### PR DESCRIPTION
- add batch support to all models (hf, torchvision, mmdet, yolov5)
- add batch inference for `get_sliced_inference` and `get_inference` functions
- use torchvision batched_nms when possible
- set default postprocess type and metric to NMS and IOU
- rename object_prediction_list to object_predictions