### PR TITLE
Downgrade Pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 opencv-python>=4.2.0.32
 shapely>=1.8.0
 tqdm>=4.48.2
-pillow>=8.2.0
+pillow==6.2.2
 pybboxes==0.1.5; python_version < '3.8'
 pybboxes==0.1.5; python_version >= '3.8'
 pyyaml


### PR DESCRIPTION
**Issue**

When running the sahi colab notebooks, an error occurs when attempting to run inference using a pretrained model:

```
ImportError                               Traceback (most recent call last)
[<ipython-input-5-6c3be4aaa524>](https://localhost:8080/#) in <module>
----> 1 detection_model = AutoDetectionModel.from_pretrained(
      2     model_type='detectron2',
      3     model_path=model_path,
      4     config_path=model_path,
      5     confidence_threshold=0.5,

14 frames
[/usr/local/lib/python3.8/dist-packages/PIL/ImageFont.py](https://localhost:8080/#) in <module>
     35 from . import Image
     36 from ._deprecate import deprecate
---> 37 from ._util import is_directory, is_path
     38 
     39 

ImportError: cannot import name 'is_directory' from 'PIL._util' (/usr/local/lib/python3.8/dist-packages/PIL/_util.py)
```
**Solution**

A solution to this problem (as per [this stack overflow post](https://stackoverflow.com/questions/73711994/importerror-cannot-import-name-is-directory-from-pil-util-usr-local-lib)) is to downgrade Pillow and freeze it at version 6.2.2. Using this version of Pillow allows users to successfully execute the entire notebook demonstrating the functionality of sahi.

**Risks**

Freezing the version of Pillow to an earlier state may result in unexpected behaviour, and lead to vulnerabilities in the future if more up to date versions of Pillow are not supported.

