### PR TITLE
fix json.decoder.JSONDecodeError in coco to yolov5 conversion

### DIFF
--- a/sahi/utils/coco.py
+++ b/sahi/utils/coco.py
@@ -1535,7 +1535,7 @@ def export_yolov5_images_and_txts_from_coco_object(output_dir, coco, ignore_nega
 
 
 def export_single_yolov5_image_and_corresponding_txt(
-    coco_image, coco_image_dir, output_dir, ignore_negative_samples=False
+    coco_image, coco_image_dir, output_dir, ignore_negative_samples=False, shutil_copy=False
 ):
     """
     Generates yolov5 formatted image symlink and annotation txt file.
@@ -1578,7 +1578,12 @@ def export_single_yolov5_image_and_corresponding_txt(
             yolo_image_path = str(parent_dir / (filename + filesuffix))
             name_increment += 1
         # create a symbolic link pointing to coco_image_path named yolo_image_path
-        os.symlink(coco_image_path, yolo_image_path)
+        if shutil_copy:
+            import shutil
+
+            shutil.copy(coco_image_path, yolo_image_path)
+        else:
+            os.symlink(coco_image_path, yolo_image_path)
         # calculate annotation normalization ratios
         width = coco_image.width
         height = coco_image.height

--- a/sahi/utils/coco.py
+++ b/sahi/utils/coco.py
@@ -1535,7 +1535,7 @@ def export_yolov5_images_and_txts_from_coco_object(output_dir, coco, ignore_nega
 
 
 def export_single_yolov5_image_and_corresponding_txt(
-    coco_image, coco_image_dir, output_dir, ignore_negative_samples=False, shutil_copy=False
+    coco_image, coco_image_dir, output_dir, ignore_negative_samples=False, disable_symlink=False
 ):
     """
     Generates yolov5 formatted image symlink and annotation txt file.
@@ -1578,7 +1578,7 @@ def export_single_yolov5_image_and_corresponding_txt(
             yolo_image_path = str(parent_dir / (filename + filesuffix))
             name_increment += 1
         # create a symbolic link pointing to coco_image_path named yolo_image_path
-        if shutil_copy:
+        if disable_symlink:
             import shutil
 
             shutil.copy(coco_image_path, yolo_image_path)

--- a/sahi/utils/file.py
+++ b/sahi/utils/file.py
@@ -28,12 +28,13 @@ def unzip(file_path: str, dest_dir: str):
         zf.extractall(dest_dir)
 
 
-def save_json(data, save_path, indent: Optional[int] = 4):
+def save_json(data, save_path, indent: Optional[int] = None):
     """
     Saves json formatted data (given as "data") as save_path
     Example inputs:
         data: {"image_id": 5}
         save_path: "dirname/coco.json"
+        indent: Train json files with indent=None, val json files with indent=4
     """
     # create dir if not present
     Path(save_path).parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
@fcakyon 

Eğitim yaparken indent "None" olması gerekiyor. Int değeri verildiğinde json dosyasını okuyamıyor.  SAHI ile coco işlemleri yapan kullanıcılar hata almaması için default değerin None olması daha doğru olacaktır.

Colab da yolov5 coco desteğini kullanabilmek için shutil.copy ekledim. Merge edildikten sonra paket sürümünü güncelleyebilir misiniz?