### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,7 @@ opencv-python>=4.2.0.32
 shapely>=1.8.0
 tqdm>=4.48.2
 pillow>=8.2.0
-pybboxes==0.1.5; python_version < '3.8'
-pybboxes==0.1.5; python_version >= '3.8'
+pybboxes>=0.1.5
 pyyaml
 fire
 terminaltables


### PR DESCRIPTION
Loosen the pinned version of pybboxes dependency to allow for newer versions. The latest pybboxes addresses a poetry package resolution issue but can't be used with this package because of the exact version requirement. 