### PR TITLE
V2.0 add bbox ordering

### DIFF
--- a/.github/workflows/package_testing.yml
+++ b/.github/workflows/package_testing.yml
@@ -71,6 +71,10 @@ jobs:
         run: >
           pip install yolov5==7.0.9
           
+      - name: Install DeepSparse
+        run: >
+          pip install deepsparse
+          
       - name: Install Detectron2(0.6)
         run: >
           python -m pip install detectron2 -f https://dl.fbaipublicfiles.com/detectron2/wheels/cpu/torch1.10/index.html

--- a/sahi/__init__.py
+++ b/sahi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.11.12"
+__version__ = "0.11.13"
 
 from sahi.annotation import BoundingBox, Category, Mask
 from sahi.auto_model import AutoDetectionModel

--- a/sahi/predict.py
+++ b/sahi/predict.py
@@ -310,11 +310,11 @@ def bbox_sort(a, b, thresh):
     return bbox_a[1] - bbox_b[1]
 
 
-def agg_prediction(result: PredictionResult, thresh):
+def agg_prediction(thresh, result):
     coord_list = []
-    res = result.to_coco_annotations()
+    res = result.object_prediction_list
     for ann in res:
-        current_bbox = ann["bbox"]
+        current_bbox = ann.bbox.to_xywh()
         x = current_bbox[0]
         y = current_bbox[1]
         w = current_bbox[2]
@@ -323,7 +323,7 @@ def agg_prediction(result: PredictionResult, thresh):
         coord_list.append((x, y, w, h))
     cnts = sorted(coord_list, key=cmp_to_key(lambda a, b: bbox_sort(a, b, thresh)))
     for pred in range(len(res) - 1):
-        res[pred]["image_id"] = cnts.index(tuple(res[pred]["bbox"]))
+        res[pred].category.id = cnts.index(tuple(res[pred].bbox.to_xywh()))
 
     return res
 
@@ -349,6 +349,7 @@ def predict(
     postprocess_match_metric: str = "IOS",
     postprocess_match_threshold: float = 0.5,
     postprocess_class_agnostic: bool = False,
+    use_bbox_agg_thrsh: int = None,
     novisual: bool = False,
     view_video: bool = False,
     frame_skip_interval: int = 0,
@@ -420,6 +421,8 @@ def predict(
             postprocessed after sliced prediction.
         postprocess_class_agnostic: bool
             If True, postprocess will ignore category ids.
+        use_bbox_agg_thrsh: int
+            If not None orders bboxes ids in object_prediction_list
         novisual: bool
             Dont export predicted video/image visuals.
         view_video: bool
@@ -558,6 +561,8 @@ def predict(
                 verbose=1 if verbose else 0,
             )
             object_prediction_list = prediction_result.object_prediction_list
+            if use_bbox_agg_thrsh is not None:
+                object_prediction_list = agg_prediction(use_bbox_agg_thrsh, prediction_result)
             durations_in_seconds["slice"] += prediction_result.durations_in_seconds["slice"]
         else:
             # get standard prediction


### PR DESCRIPTION
I studied the project structure in more detail and came to the conclusion that when aggregating, you should not immediately get the result in to_coco_annotations , because this closes the path for expansion in other parts of the project. I also added the use_bbox_agg_thrsh parameter to the predict function so that I can get ordered bboxes along with the predict