### PR TITLE
Add mmdet3 support

### DIFF
--- a/sahi/auto_model.py
+++ b/sahi/auto_model.py
@@ -5,6 +5,7 @@ from sahi.utils.file import import_model_class
 MODEL_TYPE_TO_MODEL_CLASS_NAME = {
     "yolov8": "Yolov8DetectionModel",
     "mmdet": "MmdetDetectionModel",
+    "mmdet3": "Mmdet3DetectionModel",
     "yolov5": "Yolov5DetectionModel",
     "detectron2": "Detectron2DetectionModel",
     "huggingface": "HuggingfaceDetectionModel",

--- a/sahi/models/mmdet3.py
+++ b/sahi/models/mmdet3.py
@@ -1,0 +1,218 @@
+# OBSS SAHI Tool
+# Code written by Fatih C Akyon, 2020.
+
+import logging
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import pycocotools
+from sahi.models.base import DetectionModel
+from sahi.prediction import ObjectPrediction
+from sahi.utils.compatibility import fix_full_shape_list, fix_shift_amount_list
+from sahi.utils.cv import get_bbox_from_bool_mask
+from sahi.utils.import_utils import check_requirements
+
+logger = logging.getLogger(__name__)
+
+
+class Mmdet3DetectionModel(DetectionModel):
+
+    def __init__(
+        self,
+        model_path: Optional[str] = None,
+        model: Optional[Any] = None,
+        config_path: Optional[str] = None,
+        device: Optional[str] = None,
+        mask_threshold: float = 0.5,
+        confidence_threshold: float = 0.3,
+        category_mapping: Optional[Dict] = None,
+        category_remapping: Optional[Dict] = None,
+        load_at_init: bool = True,
+        image_size: int = None,
+        scope: str = "mmdet",
+    ):
+        self.scope = scope
+        super().__init__(
+            model_path, model, config_path, device, mask_threshold, confidence_threshold, category_mapping, category_remapping,
+            load_at_init, image_size
+        )
+
+    def check_dependencies(self):
+        check_requirements(["torch", "mmdet", "mmcv"])
+
+    def load_model(self):
+        """
+        Detection model is initialized and set to self.model.
+        """
+        from mmdet.apis.det_inferencer import DetInferencer
+
+        # create model
+        model = DetInferencer(self.config_path, self.model_path, device=self.device, scope=self.scope)
+
+        # update model image size
+        if self.image_size is not None:
+            raise ValueError("Updating the image_size is not supported, modify the config file.")
+
+        self.set_model(model)
+
+    def set_model(self, model: Any):
+        """
+        Sets the underlying MMDetection model.
+        Args:
+            model: Any
+                A MMDetection model
+        """
+
+        # set self.model
+        self.model = model
+
+        # set category_mapping
+        if not self.category_mapping:
+            category_mapping = {str(ind): category_name for ind, category_name in enumerate(self.category_names)}
+            self.category_mapping = category_mapping
+
+    def perform_inference(self, image: np.ndarray):
+        """
+        Prediction is performed using self.model and the prediction result is set to self._original_predictions.
+        Args:
+            image: np.ndarray
+                A numpy array that contains the image to be predicted. 3 channel image should be in RGB order.
+        """
+
+        # Confirm model is loaded
+        if self.model is None:
+            raise ValueError("Model is not loaded, load it by calling .load_model()")
+
+        # Supports only batch of 1
+
+        # perform inference
+        if isinstance(image, np.ndarray):
+            # https://github.com/obss/sahi/issues/265
+            image = image[:, :, ::-1]
+        # compatibility with sahi v0.8.15
+        if not isinstance(image, list):
+            image = [image]
+        prediction_result = self.model(image)
+
+        self._original_predictions = prediction_result['predictions']
+
+    @property
+    def num_categories(self):
+        """
+        Returns number of categories
+        """
+        return len(self.category_names)
+
+    @property
+    def has_mask(self):
+        """
+        Returns if model output contains segmentation mask
+        """
+        has_mask = self.model.model.with_mask
+        return has_mask
+
+    @property
+    def category_names(self):
+        classes = self.model.model.dataset_meta['classes']
+        if type(classes) == str:
+            # https://github.com/open-mmlab/mmdetection/pull/4973
+            return (classes,)
+        else:
+            return classes
+
+    def _create_object_prediction_list_from_original_predictions(
+        self,
+        shift_amount_list: Optional[List[List[int]]] = [[0, 0]],
+        full_shape_list: Optional[List[List[int]]] = None,
+    ):
+        """
+        self._original_predictions is converted to a list of prediction.ObjectPrediction and set to
+        self._object_prediction_list_per_image.
+        Args:
+            shift_amount_list: list of list
+                To shift the box and mask predictions from sliced image to full sized image, should
+                be in the form of List[[shift_x, shift_y],[shift_x, shift_y],...]
+            full_shape_list: list of list
+                Size of the full image after shifting, should be in the form of
+                List[[height, width],[height, width],...]
+        """
+        original_predictions = self._original_predictions
+        category_mapping = self.category_mapping
+
+        # compatilibty for sahi v0.8.15
+        shift_amount_list = fix_shift_amount_list(shift_amount_list)
+        full_shape_list = fix_full_shape_list(full_shape_list)
+
+        # parse boxes and masks from predictions
+        object_prediction_list_per_image = []
+        for image_ind, original_prediction in enumerate(original_predictions):
+            shift_amount = shift_amount_list[image_ind]
+            full_shape = None if full_shape_list is None else full_shape_list[image_ind]
+
+            boxes = original_prediction['bboxes']
+            scores = original_prediction['scores']
+            labels = original_prediction['labels']
+            if self.has_mask:
+                masks = original_prediction['masks']
+
+            object_prediction_list = []
+
+            n_detects = len(labels)
+            # process predictions
+            for i in range(n_detects):
+                if self.has_mask:
+                    mask = masks[i]
+
+                bbox = boxes[i]
+                score = scores[i]
+                category_id = labels[i]
+                category_name = category_mapping[str(category_id)]
+
+                # ignore low scored predictions
+                if score < self.confidence_threshold:
+                    continue
+
+                # parse prediction mask
+                if self.has_mask:
+                    if "counts" in mask:
+                        bool_mask = pycocotools.mask.decode(mask)
+                    else:
+                        bool_mask = mask
+
+                    # check if mask is valid
+                    # https://github.com/obss/sahi/discussions/696
+                    if get_bbox_from_bool_mask(bool_mask) is None:
+                        continue
+                else:
+                    bool_mask = None
+
+                # fix negative box coords
+                bbox[0] = max(0, bbox[0])
+                bbox[1] = max(0, bbox[1])
+                bbox[2] = max(0, bbox[2])
+                bbox[3] = max(0, bbox[3])
+
+                # fix out of image box coords
+                if full_shape is not None:
+                    bbox[0] = min(full_shape[1], bbox[0])
+                    bbox[1] = min(full_shape[0], bbox[1])
+                    bbox[2] = min(full_shape[1], bbox[2])
+                    bbox[3] = min(full_shape[0], bbox[3])
+
+                # ignore invalid predictions
+                if not (bbox[0] < bbox[2]) or not (bbox[1] < bbox[3]):
+                    logger.warning(f"ignoring invalid prediction with bbox: {bbox}")
+                    continue
+
+                object_prediction = ObjectPrediction(
+                    bbox=bbox,
+                    category_id=category_id,
+                    score=score,
+                    bool_mask=bool_mask,
+                    category_name=category_name,
+                    shift_amount=shift_amount,
+                    full_shape=full_shape,
+                )
+                object_prediction_list.append(object_prediction)
+            object_prediction_list_per_image.append(object_prediction_list)
+        self._object_prediction_list_per_image = object_prediction_list_per_image

--- a/tests/data/mmdet3/configs/_base_/datasets/coco_detection.py
+++ b/tests/data/mmdet3/configs/_base_/datasets/coco_detection.py
@@ -1,0 +1,95 @@
+# dataset settings
+dataset_type = 'CocoDataset'
+data_root = 'data/coco/'
+
+# Example to use different file client
+# Method 1: simply set the data root and let the file I/O module
+# automatically infer from prefix (not support LMDB and Memcache yet)
+
+# data_root = 's3://openmmlab/datasets/detection/coco/'
+
+# Method 2: Use `backend_args`, `file_client_args` in versions before 3.0.0rc6
+# backend_args = dict(
+#     backend='petrel',
+#     path_mapping=dict({
+#         './data/': 's3://openmmlab/datasets/detection/',
+#         'data/': 's3://openmmlab/datasets/detection/'
+#     }))
+backend_args = None
+
+train_pipeline = [
+    dict(type='LoadImageFromFile', backend_args=backend_args),
+    dict(type='LoadAnnotations', with_bbox=True),
+    dict(type='Resize', scale=(1333, 800), keep_ratio=True),
+    dict(type='RandomFlip', prob=0.5),
+    dict(type='PackDetInputs')
+]
+test_pipeline = [
+    dict(type='LoadImageFromFile', backend_args=backend_args),
+    dict(type='Resize', scale=(1333, 800), keep_ratio=True),
+    # If you don't have a gt annotation, delete the pipeline
+    dict(type='LoadAnnotations', with_bbox=True),
+    dict(
+        type='PackDetInputs',
+        meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',
+                   'scale_factor'))
+]
+train_dataloader = dict(
+    batch_size=2,
+    num_workers=2,
+    persistent_workers=True,
+    sampler=dict(type='DefaultSampler', shuffle=True),
+    batch_sampler=dict(type='AspectRatioBatchSampler'),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/instances_train2017.json',
+        data_prefix=dict(img='train2017/'),
+        filter_cfg=dict(filter_empty_gt=True, min_size=32),
+        pipeline=train_pipeline,
+        backend_args=backend_args))
+val_dataloader = dict(
+    batch_size=1,
+    num_workers=2,
+    persistent_workers=True,
+    drop_last=False,
+    sampler=dict(type='DefaultSampler', shuffle=False),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/instances_val2017.json',
+        data_prefix=dict(img='val2017/'),
+        test_mode=True,
+        pipeline=test_pipeline,
+        backend_args=backend_args))
+test_dataloader = val_dataloader
+
+val_evaluator = dict(
+    type='CocoMetric',
+    ann_file=data_root + 'annotations/instances_val2017.json',
+    metric='bbox',
+    format_only=False,
+    backend_args=backend_args)
+test_evaluator = val_evaluator
+
+# inference on test dataset and
+# format the output results for submission.
+# test_dataloader = dict(
+#     batch_size=1,
+#     num_workers=2,
+#     persistent_workers=True,
+#     drop_last=False,
+#     sampler=dict(type='DefaultSampler', shuffle=False),
+#     dataset=dict(
+#         type=dataset_type,
+#         data_root=data_root,
+#         ann_file=data_root + 'annotations/image_info_test-dev2017.json',
+#         data_prefix=dict(img='test2017/'),
+#         test_mode=True,
+#         pipeline=test_pipeline))
+# test_evaluator = dict(
+#     type='CocoMetric',
+#     metric='bbox',
+#     format_only=True,
+#     ann_file=data_root + 'annotations/image_info_test-dev2017.json',
+#     outfile_prefix='./work_dirs/coco_detection/test')

--- a/tests/data/mmdet3/configs/_base_/datasets/coco_instance.py
+++ b/tests/data/mmdet3/configs/_base_/datasets/coco_instance.py
@@ -1,0 +1,95 @@
+# dataset settings
+dataset_type = 'CocoDataset'
+data_root = 'data/coco/'
+
+# Example to use different file client
+# Method 1: simply set the data root and let the file I/O module
+# automatically infer from prefix (not support LMDB and Memcache yet)
+
+# data_root = 's3://openmmlab/datasets/detection/coco/'
+
+# Method 2: Use `backend_args`, `file_client_args` in versions before 3.0.0rc6
+# backend_args = dict(
+#     backend='petrel',
+#     path_mapping=dict({
+#         './data/': 's3://openmmlab/datasets/detection/',
+#         'data/': 's3://openmmlab/datasets/detection/'
+#     }))
+backend_args = None
+
+train_pipeline = [
+    dict(type='LoadImageFromFile', backend_args=backend_args),
+    dict(type='LoadAnnotations', with_bbox=True, with_mask=True),
+    dict(type='Resize', scale=(1333, 800), keep_ratio=True),
+    dict(type='RandomFlip', prob=0.5),
+    dict(type='PackDetInputs')
+]
+test_pipeline = [
+    dict(type='LoadImageFromFile', backend_args=backend_args),
+    dict(type='Resize', scale=(1333, 800), keep_ratio=True),
+    # If you don't have a gt annotation, delete the pipeline
+    dict(type='LoadAnnotations', with_bbox=True, with_mask=True),
+    dict(
+        type='PackDetInputs',
+        meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',
+                   'scale_factor'))
+]
+train_dataloader = dict(
+    batch_size=2,
+    num_workers=2,
+    persistent_workers=True,
+    sampler=dict(type='DefaultSampler', shuffle=True),
+    batch_sampler=dict(type='AspectRatioBatchSampler'),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/instances_train2017.json',
+        data_prefix=dict(img='train2017/'),
+        filter_cfg=dict(filter_empty_gt=True, min_size=32),
+        pipeline=train_pipeline,
+        backend_args=backend_args))
+val_dataloader = dict(
+    batch_size=1,
+    num_workers=2,
+    persistent_workers=True,
+    drop_last=False,
+    sampler=dict(type='DefaultSampler', shuffle=False),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/instances_val2017.json',
+        data_prefix=dict(img='val2017/'),
+        test_mode=True,
+        pipeline=test_pipeline,
+        backend_args=backend_args))
+test_dataloader = val_dataloader
+
+val_evaluator = dict(
+    type='CocoMetric',
+    ann_file=data_root + 'annotations/instances_val2017.json',
+    metric=['bbox', 'segm'],
+    format_only=False,
+    backend_args=backend_args)
+test_evaluator = val_evaluator
+
+# inference on test dataset and
+# format the output results for submission.
+# test_dataloader = dict(
+#     batch_size=1,
+#     num_workers=2,
+#     persistent_workers=True,
+#     drop_last=False,
+#     sampler=dict(type='DefaultSampler', shuffle=False),
+#     dataset=dict(
+#         type=dataset_type,
+#         data_root=data_root,
+#         ann_file=data_root + 'annotations/image_info_test-dev2017.json',
+#         data_prefix=dict(img='test2017/'),
+#         test_mode=True,
+#         pipeline=test_pipeline))
+# test_evaluator = dict(
+#     type='CocoMetric',
+#     metric=['bbox', 'segm'],
+#     format_only=True,
+#     ann_file=data_root + 'annotations/image_info_test-dev2017.json',
+#     outfile_prefix='./work_dirs/coco_instance/test')

--- a/tests/data/mmdet3/configs/_base_/default_runtime.py
+++ b/tests/data/mmdet3/configs/_base_/default_runtime.py
@@ -1,0 +1,24 @@
+default_scope = 'mmdet'
+
+default_hooks = dict(
+    timer=dict(type='IterTimerHook'),
+    logger=dict(type='LoggerHook', interval=50),
+    param_scheduler=dict(type='ParamSchedulerHook'),
+    checkpoint=dict(type='CheckpointHook', interval=1),
+    sampler_seed=dict(type='DistSamplerSeedHook'),
+    visualization=dict(type='DetVisualizationHook'))
+
+env_cfg = dict(
+    cudnn_benchmark=False,
+    mp_cfg=dict(mp_start_method='fork', opencv_num_threads=0),
+    dist_cfg=dict(backend='nccl'),
+)
+
+vis_backends = [dict(type='LocalVisBackend')]
+visualizer = dict(
+    type='DetLocalVisualizer', vis_backends=vis_backends, name='visualizer')
+log_processor = dict(type='LogProcessor', window_size=50, by_epoch=True)
+
+log_level = 'INFO'
+load_from = None
+resume = False

--- a/tests/data/mmdet3/configs/_base_/models/cascade-mask-rcnn_r50_fpn.py
+++ b/tests/data/mmdet3/configs/_base_/models/cascade-mask-rcnn_r50_fpn.py
@@ -1,0 +1,203 @@
+# model settings
+model = dict(
+    type='CascadeRCNN',
+    data_preprocessor=dict(
+        type='DetDataPreprocessor',
+        mean=[123.675, 116.28, 103.53],
+        std=[58.395, 57.12, 57.375],
+        bgr_to_rgb=True,
+        pad_mask=True,
+        pad_size_divisor=32),
+    backbone=dict(
+        type='ResNet',
+        depth=50,
+        num_stages=4,
+        out_indices=(0, 1, 2, 3),
+        frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
+        norm_eval=True,
+        style='pytorch',
+        init_cfg=dict(type='Pretrained', checkpoint='torchvision://resnet50')),
+    neck=dict(
+        type='FPN',
+        in_channels=[256, 512, 1024, 2048],
+        out_channels=256,
+        num_outs=5),
+    rpn_head=dict(
+        type='RPNHead',
+        in_channels=256,
+        feat_channels=256,
+        anchor_generator=dict(
+            type='AnchorGenerator',
+            scales=[8],
+            ratios=[0.5, 1.0, 2.0],
+            strides=[4, 8, 16, 32, 64]),
+        bbox_coder=dict(
+            type='DeltaXYWHBBoxCoder',
+            target_means=[.0, .0, .0, .0],
+            target_stds=[1.0, 1.0, 1.0, 1.0]),
+        loss_cls=dict(
+            type='CrossEntropyLoss', use_sigmoid=True, loss_weight=1.0),
+        loss_bbox=dict(type='SmoothL1Loss', beta=1.0 / 9.0, loss_weight=1.0)),
+    roi_head=dict(
+        type='CascadeRoIHead',
+        num_stages=3,
+        stage_loss_weights=[1, 0.5, 0.25],
+        bbox_roi_extractor=dict(
+            type='SingleRoIExtractor',
+            roi_layer=dict(type='RoIAlign', output_size=7, sampling_ratio=0),
+            out_channels=256,
+            featmap_strides=[4, 8, 16, 32]),
+        bbox_head=[
+            dict(
+                type='Shared2FCBBoxHead',
+                in_channels=256,
+                fc_out_channels=1024,
+                roi_feat_size=7,
+                num_classes=80,
+                bbox_coder=dict(
+                    type='DeltaXYWHBBoxCoder',
+                    target_means=[0., 0., 0., 0.],
+                    target_stds=[0.1, 0.1, 0.2, 0.2]),
+                reg_class_agnostic=True,
+                loss_cls=dict(
+                    type='CrossEntropyLoss',
+                    use_sigmoid=False,
+                    loss_weight=1.0),
+                loss_bbox=dict(type='SmoothL1Loss', beta=1.0,
+                               loss_weight=1.0)),
+            dict(
+                type='Shared2FCBBoxHead',
+                in_channels=256,
+                fc_out_channels=1024,
+                roi_feat_size=7,
+                num_classes=80,
+                bbox_coder=dict(
+                    type='DeltaXYWHBBoxCoder',
+                    target_means=[0., 0., 0., 0.],
+                    target_stds=[0.05, 0.05, 0.1, 0.1]),
+                reg_class_agnostic=True,
+                loss_cls=dict(
+                    type='CrossEntropyLoss',
+                    use_sigmoid=False,
+                    loss_weight=1.0),
+                loss_bbox=dict(type='SmoothL1Loss', beta=1.0,
+                               loss_weight=1.0)),
+            dict(
+                type='Shared2FCBBoxHead',
+                in_channels=256,
+                fc_out_channels=1024,
+                roi_feat_size=7,
+                num_classes=80,
+                bbox_coder=dict(
+                    type='DeltaXYWHBBoxCoder',
+                    target_means=[0., 0., 0., 0.],
+                    target_stds=[0.033, 0.033, 0.067, 0.067]),
+                reg_class_agnostic=True,
+                loss_cls=dict(
+                    type='CrossEntropyLoss',
+                    use_sigmoid=False,
+                    loss_weight=1.0),
+                loss_bbox=dict(type='SmoothL1Loss', beta=1.0, loss_weight=1.0))
+        ],
+        mask_roi_extractor=dict(
+            type='SingleRoIExtractor',
+            roi_layer=dict(type='RoIAlign', output_size=14, sampling_ratio=0),
+            out_channels=256,
+            featmap_strides=[4, 8, 16, 32]),
+        mask_head=dict(
+            type='FCNMaskHead',
+            num_convs=4,
+            in_channels=256,
+            conv_out_channels=256,
+            num_classes=80,
+            loss_mask=dict(
+                type='CrossEntropyLoss', use_mask=True, loss_weight=1.0))),
+    # model training and testing settings
+    train_cfg=dict(
+        rpn=dict(
+            assigner=dict(
+                type='MaxIoUAssigner',
+                pos_iou_thr=0.7,
+                neg_iou_thr=0.3,
+                min_pos_iou=0.3,
+                match_low_quality=True,
+                ignore_iof_thr=-1),
+            sampler=dict(
+                type='RandomSampler',
+                num=256,
+                pos_fraction=0.5,
+                neg_pos_ub=-1,
+                add_gt_as_proposals=False),
+            allowed_border=0,
+            pos_weight=-1,
+            debug=False),
+        rpn_proposal=dict(
+            nms_pre=2000,
+            max_per_img=2000,
+            nms=dict(type='nms', iou_threshold=0.7),
+            min_bbox_size=0),
+        rcnn=[
+            dict(
+                assigner=dict(
+                    type='MaxIoUAssigner',
+                    pos_iou_thr=0.5,
+                    neg_iou_thr=0.5,
+                    min_pos_iou=0.5,
+                    match_low_quality=False,
+                    ignore_iof_thr=-1),
+                sampler=dict(
+                    type='RandomSampler',
+                    num=512,
+                    pos_fraction=0.25,
+                    neg_pos_ub=-1,
+                    add_gt_as_proposals=True),
+                mask_size=28,
+                pos_weight=-1,
+                debug=False),
+            dict(
+                assigner=dict(
+                    type='MaxIoUAssigner',
+                    pos_iou_thr=0.6,
+                    neg_iou_thr=0.6,
+                    min_pos_iou=0.6,
+                    match_low_quality=False,
+                    ignore_iof_thr=-1),
+                sampler=dict(
+                    type='RandomSampler',
+                    num=512,
+                    pos_fraction=0.25,
+                    neg_pos_ub=-1,
+                    add_gt_as_proposals=True),
+                mask_size=28,
+                pos_weight=-1,
+                debug=False),
+            dict(
+                assigner=dict(
+                    type='MaxIoUAssigner',
+                    pos_iou_thr=0.7,
+                    neg_iou_thr=0.7,
+                    min_pos_iou=0.7,
+                    match_low_quality=False,
+                    ignore_iof_thr=-1),
+                sampler=dict(
+                    type='RandomSampler',
+                    num=512,
+                    pos_fraction=0.25,
+                    neg_pos_ub=-1,
+                    add_gt_as_proposals=True),
+                mask_size=28,
+                pos_weight=-1,
+                debug=False)
+        ]),
+    test_cfg=dict(
+        rpn=dict(
+            nms_pre=1000,
+            max_per_img=1000,
+            nms=dict(type='nms', iou_threshold=0.7),
+            min_bbox_size=0),
+        rcnn=dict(
+            score_thr=0.05,
+            nms=dict(type='nms', iou_threshold=0.5),
+            max_per_img=100,
+            mask_thr_binary=0.5)))

--- a/tests/data/mmdet3/configs/_base_/schedules/schedule_1x.py
+++ b/tests/data/mmdet3/configs/_base_/schedules/schedule_1x.py
@@ -1,0 +1,28 @@
+# training schedule for 1x
+train_cfg = dict(type='EpochBasedTrainLoop', max_epochs=12, val_interval=1)
+val_cfg = dict(type='ValLoop')
+test_cfg = dict(type='TestLoop')
+
+# learning rate
+param_scheduler = [
+    dict(
+        type='LinearLR', start_factor=0.001, by_epoch=False, begin=0, end=500),
+    dict(
+        type='MultiStepLR',
+        begin=0,
+        end=12,
+        by_epoch=True,
+        milestones=[8, 11],
+        gamma=0.1)
+]
+
+# optimizer
+optim_wrapper = dict(
+    type='OptimWrapper',
+    optimizer=dict(type='SGD', lr=0.02, momentum=0.9, weight_decay=0.0001))
+
+# Default setting for scaling LR automatically
+#   - `enable` means enable scaling LR automatically
+#       or not by default.
+#   - `base_batch_size` = (8 GPUs) x (2 samples per GPU).
+auto_scale_lr = dict(enable=False, base_batch_size=16)

--- a/tests/data/mmdet3/configs/cascade_rcnn/cascade-mask-rcnn_r50_fpn_1x_coco.py
+++ b/tests/data/mmdet3/configs/cascade_rcnn/cascade-mask-rcnn_r50_fpn_1x_coco.py
@@ -1,0 +1,5 @@
+_base_ = [
+    '../_base_/models/cascade-mask-rcnn_r50_fpn.py',
+    '../_base_/datasets/coco_instance.py',
+    '../_base_/schedules/schedule_1x.py', '../_base_/default_runtime.py'
+]

--- a/tests/data/mmdet3/configs/yolox/yolox_s_8xb8-300e_coco.py
+++ b/tests/data/mmdet3/configs/yolox/yolox_s_8xb8-300e_coco.py
@@ -1,0 +1,250 @@
+_base_ = [
+    '../_base_/schedules/schedule_1x.py', '../_base_/default_runtime.py',
+    './yolox_tta.py'
+]
+
+img_scale = (640, 640)  # width, height
+
+# model settings
+model = dict(
+    type='YOLOX',
+    data_preprocessor=dict(
+        type='DetDataPreprocessor',
+        pad_size_divisor=32,
+        batch_augments=[
+            dict(
+                type='BatchSyncRandomResize',
+                random_size_range=(480, 800),
+                size_divisor=32,
+                interval=10)
+        ]),
+    backbone=dict(
+        type='CSPDarknet',
+        deepen_factor=0.33,
+        widen_factor=0.5,
+        out_indices=(2, 3, 4),
+        use_depthwise=False,
+        spp_kernal_sizes=(5, 9, 13),
+        norm_cfg=dict(type='BN', momentum=0.03, eps=0.001),
+        act_cfg=dict(type='Swish'),
+    ),
+    neck=dict(
+        type='YOLOXPAFPN',
+        in_channels=[128, 256, 512],
+        out_channels=128,
+        num_csp_blocks=1,
+        use_depthwise=False,
+        upsample_cfg=dict(scale_factor=2, mode='nearest'),
+        norm_cfg=dict(type='BN', momentum=0.03, eps=0.001),
+        act_cfg=dict(type='Swish')),
+    bbox_head=dict(
+        type='YOLOXHead',
+        num_classes=80,
+        in_channels=128,
+        feat_channels=128,
+        stacked_convs=2,
+        strides=(8, 16, 32),
+        use_depthwise=False,
+        norm_cfg=dict(type='BN', momentum=0.03, eps=0.001),
+        act_cfg=dict(type='Swish'),
+        loss_cls=dict(
+            type='CrossEntropyLoss',
+            use_sigmoid=True,
+            reduction='sum',
+            loss_weight=1.0),
+        loss_bbox=dict(
+            type='IoULoss',
+            mode='square',
+            eps=1e-16,
+            reduction='sum',
+            loss_weight=5.0),
+        loss_obj=dict(
+            type='CrossEntropyLoss',
+            use_sigmoid=True,
+            reduction='sum',
+            loss_weight=1.0),
+        loss_l1=dict(type='L1Loss', reduction='sum', loss_weight=1.0)),
+    train_cfg=dict(assigner=dict(type='SimOTAAssigner', center_radius=2.5)),
+    # In order to align the source code, the threshold of the val phase is
+    # 0.01, and the threshold of the test phase is 0.001.
+    test_cfg=dict(score_thr=0.01, nms=dict(type='nms', iou_threshold=0.65)))
+
+# dataset settings
+data_root = 'data/coco/'
+dataset_type = 'CocoDataset'
+
+# Example to use different file client
+# Method 1: simply set the data root and let the file I/O module
+# automatically infer from prefix (not support LMDB and Memcache yet)
+
+# data_root = 's3://openmmlab/datasets/detection/coco/'
+
+# Method 2: Use `backend_args`, `file_client_args` in versions before 3.0.0rc6
+# backend_args = dict(
+#     backend='petrel',
+#     path_mapping=dict({
+#         './data/': 's3://openmmlab/datasets/detection/',
+#         'data/': 's3://openmmlab/datasets/detection/'
+#     }))
+backend_args = None
+
+train_pipeline = [
+    dict(type='Mosaic', img_scale=img_scale, pad_val=114.0),
+    dict(
+        type='RandomAffine',
+        scaling_ratio_range=(0.1, 2),
+        # img_scale is (width, height)
+        border=(-img_scale[0] // 2, -img_scale[1] // 2)),
+    dict(
+        type='MixUp',
+        img_scale=img_scale,
+        ratio_range=(0.8, 1.6),
+        pad_val=114.0),
+    dict(type='YOLOXHSVRandomAug'),
+    dict(type='RandomFlip', prob=0.5),
+    # According to the official implementation, multi-scale
+    # training is not considered here but in the
+    # 'mmdet/models/detectors/yolox.py'.
+    # Resize and Pad are for the last 15 epochs when Mosaic,
+    # RandomAffine, and MixUp are closed by YOLOXModeSwitchHook.
+    dict(type='Resize', scale=img_scale, keep_ratio=True),
+    dict(
+        type='Pad',
+        pad_to_square=True,
+        # If the image is three-channel, the pad value needs
+        # to be set separately for each channel.
+        pad_val=dict(img=(114.0, 114.0, 114.0))),
+    dict(type='FilterAnnotations', min_gt_bbox_wh=(1, 1), keep_empty=False),
+    dict(type='PackDetInputs')
+]
+
+train_dataset = dict(
+    # use MultiImageMixDataset wrapper to support mosaic and mixup
+    type='MultiImageMixDataset',
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/instances_train2017.json',
+        data_prefix=dict(img='train2017/'),
+        pipeline=[
+            dict(type='LoadImageFromFile', backend_args=backend_args),
+            dict(type='LoadAnnotations', with_bbox=True)
+        ],
+        filter_cfg=dict(filter_empty_gt=False, min_size=32),
+        backend_args=backend_args),
+    pipeline=train_pipeline)
+
+test_pipeline = [
+    dict(type='LoadImageFromFile', backend_args=backend_args),
+    dict(type='Resize', scale=img_scale, keep_ratio=True),
+    dict(
+        type='Pad',
+        pad_to_square=True,
+        pad_val=dict(img=(114.0, 114.0, 114.0))),
+    dict(type='LoadAnnotations', with_bbox=True),
+    dict(
+        type='PackDetInputs',
+        meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',
+                   'scale_factor'))
+]
+
+train_dataloader = dict(
+    batch_size=8,
+    num_workers=4,
+    persistent_workers=True,
+    sampler=dict(type='DefaultSampler', shuffle=True),
+    dataset=train_dataset)
+val_dataloader = dict(
+    batch_size=8,
+    num_workers=4,
+    persistent_workers=True,
+    drop_last=False,
+    sampler=dict(type='DefaultSampler', shuffle=False),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='annotations/instances_val2017.json',
+        data_prefix=dict(img='val2017/'),
+        test_mode=True,
+        pipeline=test_pipeline,
+        backend_args=backend_args))
+test_dataloader = val_dataloader
+
+val_evaluator = dict(
+    type='CocoMetric',
+    ann_file=data_root + 'annotations/instances_val2017.json',
+    metric='bbox',
+    backend_args=backend_args)
+test_evaluator = val_evaluator
+
+# training settings
+max_epochs = 300
+num_last_epochs = 15
+interval = 10
+
+train_cfg = dict(max_epochs=max_epochs, val_interval=interval)
+
+# optimizer
+# default 8 gpu
+base_lr = 0.01
+optim_wrapper = dict(
+    type='OptimWrapper',
+    optimizer=dict(
+        type='SGD', lr=base_lr, momentum=0.9, weight_decay=5e-4,
+        nesterov=True),
+    paramwise_cfg=dict(norm_decay_mult=0., bias_decay_mult=0.))
+
+# learning rate
+param_scheduler = [
+    dict(
+        # use quadratic formula to warm up 5 epochs
+        # and lr is updated by iteration
+        # TODO: fix default scope in get function
+        type='mmdet.QuadraticWarmupLR',
+        by_epoch=True,
+        begin=0,
+        end=5,
+        convert_to_iter_based=True),
+    dict(
+        # use cosine lr from 5 to 285 epoch
+        type='CosineAnnealingLR',
+        eta_min=base_lr * 0.05,
+        begin=5,
+        T_max=max_epochs - num_last_epochs,
+        end=max_epochs - num_last_epochs,
+        by_epoch=True,
+        convert_to_iter_based=True),
+    dict(
+        # use fixed lr during last 15 epochs
+        type='ConstantLR',
+        by_epoch=True,
+        factor=1,
+        begin=max_epochs - num_last_epochs,
+        end=max_epochs,
+    )
+]
+
+default_hooks = dict(
+    checkpoint=dict(
+        interval=interval,
+        max_keep_ckpts=3  # only keep latest 3 checkpoints
+    ))
+
+custom_hooks = [
+    dict(
+        type='YOLOXModeSwitchHook',
+        num_last_epochs=num_last_epochs,
+        priority=48),
+    dict(type='SyncNormHook', priority=48),
+    dict(
+        type='EMAHook',
+        ema_type='ExpMomentumEMA',
+        momentum=0.0001,
+        update_buffers=True,
+        priority=49)
+]
+
+# NOTE: `auto_scale_lr` is for automatically scaling LR,
+# USER SHOULD NOT CHANGE ITS VALUES.
+# base_batch_size = (8 GPUs) x (8 samples per GPU)
+auto_scale_lr = dict(base_batch_size=64)

--- a/tests/data/mmdet3/configs/yolox/yolox_tiny_8xb8-300e_coco.py
+++ b/tests/data/mmdet3/configs/yolox/yolox_tiny_8xb8-300e_coco.py
@@ -1,0 +1,54 @@
+_base_ = './yolox_s_8xb8-300e_coco.py'
+
+# model settings
+model = dict(
+    data_preprocessor=dict(batch_augments=[
+        dict(
+            type='BatchSyncRandomResize',
+            random_size_range=(320, 640),
+            size_divisor=32,
+            interval=10)
+    ]),
+    backbone=dict(deepen_factor=0.33, widen_factor=0.375),
+    neck=dict(in_channels=[96, 192, 384], out_channels=96),
+    bbox_head=dict(in_channels=96, feat_channels=96))
+
+img_scale = (640, 640)  # width, height
+
+train_pipeline = [
+    dict(type='Mosaic', img_scale=img_scale, pad_val=114.0),
+    dict(
+        type='RandomAffine',
+        scaling_ratio_range=(0.5, 1.5),
+        # img_scale is (width, height)
+        border=(-img_scale[0] // 2, -img_scale[1] // 2)),
+    dict(type='YOLOXHSVRandomAug'),
+    dict(type='RandomFlip', prob=0.5),
+    # Resize and Pad are for the last 15 epochs when Mosaic and
+    # RandomAffine are closed by YOLOXModeSwitchHook.
+    dict(type='Resize', scale=img_scale, keep_ratio=True),
+    dict(
+        type='Pad',
+        pad_to_square=True,
+        pad_val=dict(img=(114.0, 114.0, 114.0))),
+    dict(type='FilterAnnotations', min_gt_bbox_wh=(1, 1), keep_empty=False),
+    dict(type='PackDetInputs')
+]
+
+test_pipeline = [
+    dict(type='LoadImageFromFile', backend_args={{_base_.backend_args}}),
+    dict(type='Resize', scale=(416, 416), keep_ratio=True),
+    dict(
+        type='Pad',
+        pad_to_square=True,
+        pad_val=dict(img=(114.0, 114.0, 114.0))),
+    dict(type='LoadAnnotations', with_bbox=True),
+    dict(
+        type='PackDetInputs',
+        meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',
+                   'scale_factor'))
+]
+
+train_dataloader = dict(dataset=dict(pipeline=train_pipeline))
+val_dataloader = dict(dataset=dict(pipeline=test_pipeline))
+test_dataloader = val_dataloader

--- a/tests/data/mmdet3/configs/yolox/yolox_tta.py
+++ b/tests/data/mmdet3/configs/yolox/yolox_tta.py
@@ -1,0 +1,36 @@
+tta_model = dict(
+    type='DetTTAModel',
+    tta_cfg=dict(nms=dict(type='nms', iou_threshold=0.65), max_per_img=100))
+
+img_scales = [(640, 640), (320, 320), (960, 960)]
+tta_pipeline = [
+    dict(type='LoadImageFromFile', backend_args=None),
+    dict(
+        type='TestTimeAug',
+        transforms=[
+            [
+                dict(type='Resize', scale=s, keep_ratio=True)
+                for s in img_scales
+            ],
+            [
+                # ``RandomFlip`` must be placed before ``Pad``, otherwise
+                # bounding box coordinates after flipping cannot be
+                # recovered correctly.
+                dict(type='RandomFlip', prob=1.),
+                dict(type='RandomFlip', prob=0.)
+            ],
+            [
+                dict(
+                    type='Pad',
+                    pad_to_square=True,
+                    pad_val=dict(img=(114.0, 114.0, 114.0))),
+            ],
+            [dict(type='LoadAnnotations', with_bbox=True)],
+            [
+                dict(
+                    type='PackDetInputs',
+                    meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',
+                               'scale_factor', 'flip', 'flip_direction'))
+            ]
+        ])
+]

--- a/tests/data/models/mmdet-yolox-tiny/yolox_tiny_8x8_300e_coco.py
+++ b/tests/data/models/mmdet-yolox-tiny/yolox_tiny_8x8_300e_coco.py
@@ -1,0 +1,163 @@
+optimizer = dict(
+    type="SGD",
+    lr=0.01,
+    momentum=0.9,
+    weight_decay=0.0005,
+    nesterov=True,
+    paramwise_cfg=dict(norm_decay_mult=0.0, bias_decay_mult=0.0),
+)
+optimizer_config = dict(grad_clip=None)
+lr_config = dict(
+    policy="YOLOX",
+    warmup="exp",
+    by_epoch=False,
+    warmup_by_epoch=True,
+    warmup_ratio=1,
+    warmup_iters=5,
+    num_last_epochs=15,
+    min_lr_ratio=0.05,
+)
+runner = dict(type="EpochBasedRunner", max_epochs=300)
+checkpoint_config = dict(interval=10)
+log_config = dict(interval=50, hooks=[dict(type="TextLoggerHook")])
+custom_hooks = [
+    dict(type="YOLOXModeSwitchHook", num_last_epochs=15, priority=48),
+    dict(type="SyncNormHook", num_last_epochs=15, interval=10, priority=48),
+    dict(type="ExpMomentumEMAHook", resume_from=None, momentum=0.0001, priority=49),
+]
+dist_params = dict(backend="nccl")
+log_level = "INFO"
+load_from = None
+resume_from = None
+workflow = [("train", 1)]
+img_scale = (640, 640)
+model = dict(
+    type="YOLOX",
+    input_size=(640, 640),
+    random_size_range=(10, 20),
+    random_size_interval=10,
+    backbone=dict(type="CSPDarknet", deepen_factor=0.33, widen_factor=0.375),
+    neck=dict(type="YOLOXPAFPN", in_channels=[96, 192, 384], out_channels=96, num_csp_blocks=1),
+    bbox_head=dict(type="YOLOXHead", num_classes=80, in_channels=96, feat_channels=96),
+    train_cfg=dict(assigner=dict(type="SimOTAAssigner", center_radius=2.5)),
+    test_cfg=dict(score_thr=0.01, nms=dict(type="nms", iou_threshold=0.65)),
+)
+data_root = "data/coco/"
+dataset_type = "CocoDataset"
+train_pipeline = [
+    dict(type="Mosaic", img_scale=(640, 640), pad_val=114.0),
+    dict(type="RandomAffine", scaling_ratio_range=(0.5, 1.5), border=(-320, -320)),
+    dict(type="YOLOXHSVRandomAug"),
+    dict(type="RandomFlip", flip_ratio=0.5),
+    dict(type="Resize", img_scale=(640, 640), keep_ratio=True),
+    dict(type="Pad", pad_to_square=True, pad_val=dict(img=(114.0, 114.0, 114.0))),
+    dict(type="FilterAnnotations", min_gt_bbox_wh=(1, 1), keep_empty=False),
+    dict(type="DefaultFormatBundle"),
+    dict(type="Collect", keys=["img", "gt_bboxes", "gt_labels"]),
+]
+train_dataset = dict(
+    type="MultiImageMixDataset",
+    dataset=dict(
+        type="CocoDataset",
+        ann_file="data/coco/annotations/instances_train2017.json",
+        img_prefix="data/coco/train2017/",
+        pipeline=[dict(type="LoadImageFromFile"), dict(type="LoadAnnotations", with_bbox=True)],
+        filter_empty_gt=False,
+    ),
+    pipeline=[
+        dict(type="Mosaic", img_scale=(640, 640), pad_val=114.0),
+        dict(type="RandomAffine", scaling_ratio_range=(0.5, 1.5), border=(-320, -320)),
+        dict(type="YOLOXHSVRandomAug"),
+        dict(type="RandomFlip", flip_ratio=0.5),
+        dict(type="Resize", img_scale=(640, 640), keep_ratio=True),
+        dict(type="Pad", pad_to_square=True, pad_val=dict(img=(114.0, 114.0, 114.0))),
+        dict(type="FilterAnnotations", min_gt_bbox_wh=(1, 1), keep_empty=False),
+        dict(type="DefaultFormatBundle"),
+        dict(type="Collect", keys=["img", "gt_bboxes", "gt_labels"]),
+    ],
+)
+test_pipeline = [
+    dict(type="LoadImageFromFile"),
+    dict(
+        type="MultiScaleFlipAug",
+        img_scale=(416, 416),
+        flip=False,
+        transforms=[
+            dict(type="Resize", keep_ratio=True),
+            dict(type="RandomFlip"),
+            dict(type="Pad", pad_to_square=True, pad_val=dict(img=(114.0, 114.0, 114.0))),
+            dict(type="DefaultFormatBundle"),
+            dict(type="Collect", keys=["img"]),
+        ],
+    ),
+]
+data = dict(
+    samples_per_gpu=8,
+    workers_per_gpu=4,
+    persistent_workers=True,
+    train=dict(
+        type="MultiImageMixDataset",
+        dataset=dict(
+            type="CocoDataset",
+            ann_file="data/coco/annotations/instances_train2017.json",
+            img_prefix="data/coco/train2017/",
+            pipeline=[dict(type="LoadImageFromFile"), dict(type="LoadAnnotations", with_bbox=True)],
+            filter_empty_gt=False,
+        ),
+        pipeline=[
+            dict(type="Mosaic", img_scale=(640, 640), pad_val=114.0),
+            dict(type="RandomAffine", scaling_ratio_range=(0.5, 1.5), border=(-320, -320)),
+            dict(type="YOLOXHSVRandomAug"),
+            dict(type="RandomFlip", flip_ratio=0.5),
+            dict(type="Resize", img_scale=(640, 640), keep_ratio=True),
+            dict(type="Pad", pad_to_square=True, pad_val=dict(img=(114.0, 114.0, 114.0))),
+            dict(type="FilterAnnotations", min_gt_bbox_wh=(1, 1), keep_empty=False),
+            dict(type="DefaultFormatBundle"),
+            dict(type="Collect", keys=["img", "gt_bboxes", "gt_labels"]),
+        ],
+    ),
+    val=dict(
+        type="CocoDataset",
+        ann_file="data/coco/annotations/instances_val2017.json",
+        img_prefix="data/coco/val2017/",
+        pipeline=[
+            dict(type="LoadImageFromFile"),
+            dict(
+                type="MultiScaleFlipAug",
+                img_scale=(416, 416),
+                flip=False,
+                transforms=[
+                    dict(type="Resize", keep_ratio=True),
+                    dict(type="RandomFlip"),
+                    dict(type="Pad", pad_to_square=True, pad_val=dict(img=(114.0, 114.0, 114.0))),
+                    dict(type="DefaultFormatBundle"),
+                    dict(type="Collect", keys=["img"]),
+                ],
+            ),
+        ],
+    ),
+    test=dict(
+        type="CocoDataset",
+        ann_file="data/coco/annotations/instances_val2017.json",
+        img_prefix="data/coco/val2017/",
+        pipeline=[
+            dict(type="LoadImageFromFile"),
+            dict(
+                type="MultiScaleFlipAug",
+                img_scale=(416, 416),
+                flip=False,
+                transforms=[
+                    dict(type="Resize", keep_ratio=True),
+                    dict(type="RandomFlip"),
+                    dict(type="Pad", pad_to_square=True, pad_val=dict(img=(114.0, 114.0, 114.0))),
+                    dict(type="DefaultFormatBundle"),
+                    dict(type="Collect", keys=["img"]),
+                ],
+            ),
+        ],
+    ),
+)
+max_epochs = 300
+num_last_epochs = 15
+interval = 10
+evaluation = dict(save_best="auto", interval=10, dynamic_intervals=[(285, 1)], metric="bbox")

--- a/tests/test_mmdetection3model.py
+++ b/tests/test_mmdetection3model.py
@@ -1,0 +1,256 @@
+# OBSS SAHI Tool
+# Code written by Fatih C Akyon, 2020.
+
+import unittest
+
+import numpy as np
+import pycocotools
+from sahi.utils.cv import read_image
+from sahi.utils.file import download_from_url
+
+MODEL_DEVICE = "cpu"
+CONFIDENCE_THRESHOLD = 0.5
+IMAGE_SIZE = 320
+
+WITH_MASK_CONFIG_PATH = "tests/data/mmdet3/configs/cascade_rcnn/cascade-mask-rcnn_r50_fpn_1x_coco.py"
+WITH_MASK_MODEL_URL = "https://download.openmmlab.com/mmdetection/v2.0/cascade_rcnn/cascade_mask_rcnn_r50_fpn_1x_coco/cascade_mask_rcnn_r50_fpn_1x_coco_20200203-9d4dcb24.pth"
+
+WITHOUT_MASK_CONFIG_PATH = "tests/data/mmdet3/configs/yolox/yolox_tiny_8xb8-300e_coco.py"
+WITHOUT_MASK_MODEL_URL = "https://download.openmmlab.com/mmdetection/v2.0/yolox/yolox_tiny_8x8_300e_coco/yolox_tiny_8x8_300e_coco_20211124_171234-b4047906.pth"
+
+IMAGE_PATH = "tests/data/small-vehicles1.jpeg"
+
+
+def get_dummy_predictions(image_shape, mask_type=None):
+    h, w = image_shape[:2]
+    bbox1 = [10, 20, 30, 40]  # xywh: 10, 20, 10, 20
+    bbox2 = [100, 100, 200, 150]  # xywh: 100, 100, 100, 50
+    mask1 = np.zeros((h, w), dtype=bool)
+    x0, y0, x1, y1 = bbox1
+    mask1[y0:y1 + 1, x0:x1 + 1] = True
+    mask2 = np.zeros((h, w), dtype=bool)
+    x0, y0, x1, y1 = bbox2
+    mask2[y0:y1 + 1, x0:x1 + 1] = True
+
+    bin_masks = [mask1, mask2]
+    rle_masks = [pycocotools.mask.encode(np.asfortranarray(m)) for m in [mask1, mask2]]
+    preds = dict(
+        predictions=[
+            dict(
+                bboxes=[bbox1, bbox2],
+                labels=[2, 2],
+                scores=[0.3, 0.8],
+            ),
+        ]
+    )
+    if mask_type is not None:
+        for pred in preds["predictions"]:
+            pred["masks"] = bin_masks if mask_type == "bin" else rle_masks
+    return preds
+
+
+class TestMmdet3DetectionModel(unittest.TestCase):
+
+    def test_load_model(self):
+        from sahi.models.mmdet3 import Mmdet3DetectionModel
+
+        mmdet_detection_model = Mmdet3DetectionModel(
+            model_path=WITH_MASK_MODEL_URL,
+            config_path=WITH_MASK_CONFIG_PATH,
+            confidence_threshold=CONFIDENCE_THRESHOLD,
+            device=MODEL_DEVICE,
+            category_remapping=None,
+            load_at_init=True,
+        )
+
+        self.assertNotEqual(mmdet_detection_model.model, None)
+
+    def test_perform_inference_with_mask_output(self):
+        from sahi.models.mmdet3 import Mmdet3DetectionModel
+
+        # init model
+        mmdet_detection_model = Mmdet3DetectionModel(
+            model_path=WITH_MASK_MODEL_URL,
+            config_path=WITH_MASK_CONFIG_PATH,
+            confidence_threshold=CONFIDENCE_THRESHOLD,
+            device=MODEL_DEVICE,
+            category_remapping=None,
+            load_at_init=True,
+        )
+
+        # check has mask and coco classes
+        self.assertTrue(mmdet_detection_model.has_mask)
+        self.assertTrue(mmdet_detection_model.num_categories == 80)
+
+        # prepare image
+        image = read_image(IMAGE_PATH)
+
+        # perform inference
+        mmdet_detection_model.perform_inference(image)
+        original_predictions = mmdet_detection_model.original_predictions
+
+        # check actual prediction structures
+        pred = original_predictions[0]
+        self.assertTrue("bboxes" in pred)
+        self.assertTrue("masks" in pred)
+        self.assertTrue("scores" in pred)
+        self.assertTrue("labels" in pred)
+
+        # all annotations have the same length
+        n_preds = len(pred["bboxes"])
+        self.assertTrue(len(pred["bboxes"]) == n_preds)
+        self.assertTrue(len(pred["masks"]) == n_preds)
+        self.assertTrue(len(pred["labels"]) == n_preds)
+        self.assertTrue(len(pred["scores"]) == n_preds)
+
+        # The following checks are data dependent.
+        # The tests can fail if model weight or input are changed.
+
+        # check all scores in (0.0, 1.0)
+        self.assertTrue(all([0 <= score <= 1.0 for score in pred["scores"]]))
+
+        # bbox has 4 coordinates
+        self.assertTrue(len(pred["bboxes"][0]) == 4)
+
+
+    def test_convert_original_predictions_with_mask_output(self):
+        from sahi.models.mmdet3 import Mmdet3DetectionModel
+
+        # init model
+        mmdet_detection_model = Mmdet3DetectionModel(
+            model_path=WITH_MASK_MODEL_URL,
+            config_path=WITH_MASK_CONFIG_PATH,
+            confidence_threshold=CONFIDENCE_THRESHOLD,
+            device=MODEL_DEVICE,
+            category_remapping=None,
+            load_at_init=True,
+        )
+
+        # prepare image
+        image = read_image(IMAGE_PATH)
+
+        # prepare mocked model
+        inferencer = unittest.mock.MagicMock()
+        inferencer.model.with_mask = True
+        inferencer.model.dataset_meta = {"classes": mmdet_detection_model.category_names}
+        inferencer.return_value = get_dummy_predictions(image.shape, mask_type="rle")
+        mmdet_detection_model.model = inferencer
+
+        # perform inference
+        mmdet_detection_model.perform_inference(image)
+
+        # convert predictions to ObjectPrediction list
+        mmdet_detection_model.convert_original_predictions()
+        object_predictions = mmdet_detection_model.object_prediction_list
+
+        # compare
+        self.assertEqual(len(object_predictions), 1)
+        self.assertEqual(object_predictions[0].category.id, 2)
+        self.assertEqual(object_predictions[0].category.name, "car")
+        self.assertEqual(
+            object_predictions[0].bbox.to_xywh(),
+            [100, 100, 100, 50],
+        )
+
+        for object_prediction in object_predictions:
+            self.assertGreaterEqual(object_prediction.score.value, CONFIDENCE_THRESHOLD)
+
+    def test_convert_original_predictions_without_mask_output(self):
+        from sahi.models.mmdet3 import Mmdet3DetectionModel
+
+        # init model
+        mmdet_detection_model = Mmdet3DetectionModel(
+            model_path=WITHOUT_MASK_MODEL_URL,
+            config_path=WITHOUT_MASK_CONFIG_PATH,
+            confidence_threshold=CONFIDENCE_THRESHOLD,
+            device=MODEL_DEVICE,
+            category_remapping=None,
+            load_at_init=True,
+        )
+
+        # no mask
+        self.assertFalse(mmdet_detection_model.has_mask)
+
+        # prepare image
+        image = read_image(IMAGE_PATH)
+
+        # perform inference
+        mmdet_detection_model.perform_inference(image)
+        original_predictions = mmdet_detection_model.original_predictions
+
+        # check actual prediction structures
+        pred = original_predictions[0]
+        self.assertTrue("bboxes" in pred)
+        self.assertTrue("masks" not in pred)
+        self.assertTrue("scores" in pred)
+        self.assertTrue("labels" in pred)
+
+        # all annotations have the same length
+        n_preds = len(pred["bboxes"])
+        self.assertTrue(len(pred["bboxes"]) == n_preds)
+        self.assertTrue(len(pred["labels"]) == n_preds)
+        self.assertTrue(len(pred["scores"]) == n_preds)
+
+        # prepare mocked model
+        inferencer = unittest.mock.MagicMock()
+        inferencer.model.with_mask = False
+        inferencer.model.dataset_meta = {"classes": mmdet_detection_model.category_names}
+        inferencer.return_value = get_dummy_predictions(image.shape, mask_type=None)
+        mmdet_detection_model.model = inferencer
+
+        # perform inference
+        mmdet_detection_model.perform_inference(image)
+
+        # convert predictions to ObjectPrediction list
+        mmdet_detection_model.convert_original_predictions()
+        object_predictions = mmdet_detection_model.object_prediction_list
+
+        # compare
+        self.assertEqual(len(object_predictions), 1)
+        self.assertEqual(object_predictions[0].category.id, 2)
+        self.assertEqual(object_predictions[0].category.name, "car")
+        np.testing.assert_almost_equal(object_predictions[0].bbox.to_xywh(), [100, 100, 100, 50], decimal=1)
+        for object_prediction in object_predictions:
+            self.assertGreaterEqual(object_prediction.score.value, CONFIDENCE_THRESHOLD)
+
+    def test_perform_inference_without_mask_output_with_automodel(self):
+        from sahi import AutoDetectionModel
+
+        # init model
+        mmdet_detection_model = AutoDetectionModel.from_pretrained(
+            model_type="mmdet3",
+            model_path=None,
+            config_path=WITHOUT_MASK_CONFIG_PATH,
+            confidence_threshold=CONFIDENCE_THRESHOLD,
+            category_remapping=None,
+            load_at_init=True,
+        )
+
+        # prepare image
+        image = read_image(IMAGE_PATH)
+
+        # prepare mocked model
+        inferencer = unittest.mock.MagicMock()
+        inferencer.model.with_mask = False
+        inferencer.model.dataset_meta = {"classes": mmdet_detection_model.category_names}
+        inferencer.return_value = get_dummy_predictions(image.shape, mask_type=None)
+        mmdet_detection_model.model = inferencer
+
+        # perform inference
+        mmdet_detection_model.perform_inference(image)
+        original_predictions = mmdet_detection_model.original_predictions
+        boxes = original_predictions[0]["bboxes"]
+        scores = original_predictions[0]["scores"]
+
+        n_boxes = len(boxes)
+        for i in range(n_boxes):
+            if scores[i] > 0.5:
+                break
+        box = boxes[i]
+
+        # compare
+        self.assertEqual(box, [100, 100, 200, 150])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation
The current mmdet model looks to be based on the mmdetection v2.
Recently the mmdetection v3 was rolled out which have some incompatibility with v2.
So, in this PR, I would like to add support for the mmdetection v3.

I added some mmdet configs under the tests/data/mmdet3 to make some unit tests self-consistent.
I would appreciate it if you review this.