### PR TITLE
Optimization of _create_object_prediction_list_from_original_predictions for Detectron2 model. Significant speed improvement.

### DIFF
--- a/sahi/models/detectron2.py
+++ b/sahi/models/detectron2.py
@@ -150,7 +150,7 @@ class Detectron2DetectionModel(DetectionModel):
             object_prediction_list = [
                 ObjectPrediction(
                     bbox=box.tolist() if mask is None else None,
-                    bool_mask=np.array(mask) if mask is not None else None,
+                    bool_mask=mask.detach().cpu().numpy() if mask is not None else None,
                     category_id=category_id.item(),
                     category_name=self.category_mapping[str(category_id.item())],
                     shift_amount=shift_amount,
@@ -158,7 +158,7 @@ class Detectron2DetectionModel(DetectionModel):
                     full_shape=full_shape,
                 )
                 for box, score, category_id, mask in zip(boxes, scores, category_ids, masks)
-                if mask is None or get_bbox_from_bool_mask(np.array(mask)) is not None
+                if mask is None or get_bbox_from_bool_mask(mask.detach().cpu().numpy()) is not None
             ]
         else:
             object_prediction_list = [


### PR DESCRIPTION
I found the function  `_create_object_prediction_list_from_original_predictions` for the Detectron2 model to be quite slow, particularly when working with large images (5400x2700). 

To improve performance, I have rewritten the function using list comprehension and have only moved necessary objects to the CPU, avoiding early use of tolist().

I managed to get inference time down from ~30sec/it to ~10sec/it
Performance comparison:

* Before optimization
![before](https://user-images.githubusercontent.com/21954206/233060711-43006066-e0da-493b-8a48-331e7aca53b0.png)

* After optimization
![after](https://user-images.githubusercontent.com/21954206/233058735-c01be36e-6d7d-404d-ad7c-2818d6c4dbea.png)