### PR TITLE
Deprecated interface fix: ultralytics Boxes.boxes is deprecated - replaced with Boxes.data

### DIFF
--- a/sahi/models/yolov8.py
+++ b/sahi/models/yolov8.py
@@ -60,7 +60,7 @@ class Yolov8DetectionModel(DetectionModel):
             raise ValueError("Model is not loaded, load it by calling .load_model()")
         prediction_result = self.model(image[:, :, ::-1], verbose=False)  # YOLOv8 expects numpy arrays to have BGR
         prediction_result = [
-            result.boxes.boxes[result.boxes.boxes[:, 4] >= self.confidence_threshold] for result in prediction_result
+            result.boxes.data[result.boxes.data[:, 4] >= self.confidence_threshold] for result in prediction_result
         ]
 
         self._original_predictions = prediction_result


### PR DESCRIPTION
While using `ultralytics` prediction interface, a warining is repeatedly printed:

` >WARNING ⚠️ 'Boxes.boxes' is deprecated. Use 'Boxes.data' instead.`

Replaced the `boxes.boxes` with `boxes.data` to suppress the warning. In my tests, nothing breaks.