### PR TITLE
Improve yolov8 config

### DIFF
--- a/sahi/models/yolov8.py
+++ b/sahi/models/yolov8.py
@@ -59,25 +59,15 @@ class Yolov8DetectionModel(DetectionModel):
         if self.model is None:
             raise ValueError("Model is not loaded, load it by calling .load_model()")
 
-        kwargs = {
-            "cfg": self.config_path,
-            "verbose": False,
-            "conf": self.confidence_threshold,
-            "device": self.device
-        }
+        kwargs = {"cfg": self.config_path, "verbose": False, "conf": self.confidence_threshold, "device": self.device}
 
         if self.image_size is not None:
-            kwargs = {
-                "imgsz": self.image_size,
-                **kwargs
-            }
+            kwargs = {"imgsz": self.image_size, **kwargs}
 
         prediction_result = self.model(image[:, :, ::-1], **kwargs)  # YOLOv8 expects numpy arrays to have BGR
 
         # We do not filter results again as confidence threshold is already applied above
-        prediction_result = [
-            result.boxes.data for result in prediction_result
-        ]
+        prediction_result = [result.boxes.data for result in prediction_result]
 
         self._original_predictions = prediction_result
 

--- a/sahi/models/yolov8.py
+++ b/sahi/models/yolov8.py
@@ -58,16 +58,25 @@ class Yolov8DetectionModel(DetectionModel):
         # Confirm model is loaded
         if self.model is None:
             raise ValueError("Model is not loaded, load it by calling .load_model()")
-        if self.image_size is not None:  # ADDED IMAGE SIZE OPTION FOR YOLOV8 MODELS:
-            prediction_result = self.model(
-                image[:, :, ::-1], imgsz=self.image_size, verbose=False, device=self.device
-            )  # YOLOv8 expects numpy arrays to have BGR
-        else:
-            prediction_result = self.model(
-                image[:, :, ::-1], verbose=False, device=self.device
-            )  # YOLOv8 expects numpy arrays to have BGR
+
+        kwargs = {
+            "cfg": self.config_path,
+            "verbose": False,
+            "conf": self.confidence_threshold,
+            "device": self.device
+        }
+
+        if self.image_size is not None:
+            kwargs = {
+                "imgsz": self.image_size,
+                **kwargs
+            }
+
+        prediction_result = self.model(image[:, :, ::-1], **kwargs)  # YOLOv8 expects numpy arrays to have BGR
+
+        # We do not filter results again as confidence threshold is already applied above
         prediction_result = [
-            result.boxes.data[result.boxes.data[:, 4] >= self.confidence_threshold] for result in prediction_result
+            result.boxes.data for result in prediction_result
         ]
 
         self._original_predictions = prediction_result


### PR DESCRIPTION
- Allow user to pass custom yolo config through the standard yolo yaml config file
- Pass the confidence threshold to inner model to avoid prefiltering with default yolo threshold=0.25

For yolov8, the predict configuration is given at inference time.
We can pass full parameters using the "cfg" argument and a yaml configuration file.

Passing the "conf" argument using confidence_threshold also avoids to prefilter boxes in the underlying yolo model.

