### PR TITLE
Language-based object detectors (GLIP, Grounding DINO) support for MMDetection

### DIFF
--- a/sahi/utils/mmdet.py
+++ b/sahi/utils/mmdet.py
@@ -24,7 +24,10 @@ class MmdetTestConstants:
     MMDET_RETINANET_MODEL_PATH = "tests/data/models/mmdet/retinanet/retinanet_r50_fpn_2x_coco_20200131-fdb43119.pth"
     MMDET_YOLOX_TINY_MODEL_URL = "https://download.openmmlab.com/mmdetection/v2.0/yolox/yolox_tiny_8x8_300e_coco/yolox_tiny_8x8_300e_coco_20211124_171234-b4047906.pth"
     MMDET_YOLOX_TINY_MODEL_PATH = "tests/data/models/mmdet/yolox/yolox_tiny_8x8_300e_coco_20211124_171234-b4047906.pth"
+    MMDET_GLIP_TINY_MODEL_URL = "https://download.openmmlab.com/mmdetection/v3.0/glip/glip_tiny_a_mmdet-b3654169.pth"
+    MMDET_GLIP_TINY_MODEL_PATH = "tests/data/models/mmdet/glip/glip_tiny_a_mmdet-b3654169.pth"
 
+    MMDET_GLIP_TINY_CONFIG_PATH = "tests/data/models/mmdet/glip/glip_atss_swin-t_a_fpn_dyhead_pretrain_obj365.py"
     MMDET_CASCADEMASKRCNN_CONFIG_PATH = "tests/data/models/mmdet/cascade_mask_rcnn/cascade-mask-rcnn_r50_fpn_1x_coco.py"
     MMDET_RETINANET_CONFIG_PATH = "tests/data/models/mmdet/retinanet/retinanet_r50_fpn_1x_coco.py"
     MMDET_YOLOX_TINY_CONFIG_PATH = "tests/data/models/mmdet/yolox/yolox_tiny_8xb8-300e_coco.py"
@@ -55,6 +58,15 @@ def download_mmdet_yolox_tiny_model(destination_path: Optional[str] = None):
     Path(destination_path).parent.mkdir(parents=True, exist_ok=True)
 
     download_from_url(MmdetTestConstants.MMDET_YOLOX_TINY_MODEL_URL, destination_path)
+
+
+def download_mmdet_GLIP_tiny_model(destination_path: Optional[str] = None):
+    if destination_path is None:
+        destination_path = MmdetTestConstants.MMDET_GLIP_TINY_MODEL_PATH
+
+    Path(destination_path).parent.mkdir(parents=True, exist_ok=True)
+
+    download_from_url(MmdetTestConstants.MMDET_GLIP_TINY_MODEL_URL, destination_path)
 
 
 def download_mmdet_config(

--- a/tests/data/models/mmdet/glip/glip_atss_swin-t_a_fpn_dyhead_pretrain_obj365.py
+++ b/tests/data/models/mmdet/glip/glip_atss_swin-t_a_fpn_dyhead_pretrain_obj365.py
@@ -1,0 +1,76 @@
+_base_ = ["../_base_/datasets/coco_detection.py", "../_base_/schedules/schedule_1x.py", "../_base_/default_runtime.py"]
+
+lang_model_name = "bert-base-uncased"
+
+model = dict(
+    type="GLIP",
+    data_preprocessor=dict(
+        type="DetDataPreprocessor",
+        mean=[103.53, 116.28, 123.675],
+        std=[57.375, 57.12, 58.395],
+        bgr_to_rgb=False,
+        pad_size_divisor=32,
+    ),
+    backbone=dict(
+        type="SwinTransformer",
+        embed_dims=96,
+        depths=[2, 2, 6, 2],
+        num_heads=[3, 6, 12, 24],
+        window_size=7,
+        mlp_ratio=4,
+        qkv_bias=True,
+        qk_scale=None,
+        drop_rate=0.0,
+        attn_drop_rate=0.0,
+        drop_path_rate=0.2,
+        patch_norm=True,
+        out_indices=(1, 2, 3),
+        with_cp=False,
+        convert_weights=False,
+    ),
+    neck=dict(
+        type="FPN",
+        in_channels=[192, 384, 768],
+        out_channels=256,
+        start_level=0,
+        relu_before_extra_convs=True,
+        add_extra_convs="on_output",
+        num_outs=5,
+    ),
+    bbox_head=dict(
+        type="ATSSVLFusionHead",
+        lang_model_name=lang_model_name,
+        num_classes=80,
+        in_channels=256,
+        feat_channels=256,
+        anchor_generator=dict(
+            type="AnchorGenerator",
+            ratios=[1.0],
+            octave_base_scale=8,
+            scales_per_octave=1,
+            strides=[8, 16, 32, 64, 128],
+            center_offset=0.5,
+        ),
+        bbox_coder=dict(
+            type="DeltaXYWHBBoxCoderForGLIP", target_means=[0.0, 0.0, 0.0, 0.0], target_stds=[0.1, 0.1, 0.2, 0.2]
+        ),
+    ),
+    language_model=dict(type="BertModel", name=lang_model_name),
+    train_cfg=dict(assigner=dict(type="ATSSAssigner", topk=9), allowed_border=-1, pos_weight=-1, debug=False),
+    test_cfg=dict(
+        nms_pre=1000, min_bbox_size=0, score_thr=0.05, nms=dict(type="nms", iou_threshold=0.6), max_per_img=100
+    ),
+)
+
+test_pipeline = [
+    dict(type="LoadImageFromFile", backend_args=_base_.backend_args, imdecode_backend="pillow"),
+    dict(type="FixScaleResize", scale=(800, 1333), keep_ratio=True, backend="pillow"),
+    dict(type="LoadAnnotations", with_bbox=True),
+    dict(
+        type="PackDetInputs",
+        meta_keys=("img_id", "img_path", "ori_shape", "img_shape", "scale_factor", "text", "custom_entities"),
+    ),
+]
+
+val_dataloader = dict(dataset=dict(pipeline=test_pipeline, return_classes=True))
+test_dataloader = val_dataloader


### PR DESCRIPTION
Hello ! I've added support of language-based object detectors ([GLIP](https://github.com/open-mmlab/mmdetection/tree/main/configs/glip), [Grounding DINO](https://github.com/open-mmlab/mmdetection/tree/main/configs/grounding_dino)) from the latest release of MMdetection which require a text prompt in order to work. I've also included a test and download utils.

Users can provide a custom text prompt using `--text` argument. If none is provided the class names are used as the text prompt.