### PR TITLE
fix for using bgr image in inference instead of rgb

### DIFF
--- a/sahi/models/mmdet.py
+++ b/sahi/models/mmdet.py
@@ -16,7 +16,6 @@ logger = logging.getLogger(__name__)
 
 
 try:
-
     check_requirements(["torch", "mmdet", "mmcv", "mmengine"])
 
     from mmdet.apis.det_inferencer import DetInferencer
@@ -104,7 +103,6 @@ class MmdetDetectionModel(DetectionModel):
         image_size: int = None,
         scope: str = "mmdet",
     ):
-
         if not IMPORT_MMDET_V3:
             raise ImportError("Failed to import `DetInferencer`. Please confirm you have installed 'mmdet>=3.0.0'")
 

--- a/sahi/predict.py
+++ b/sahi/predict.py
@@ -670,7 +670,7 @@ def predict(
                 export_format=visual_export_format,
             )
             if not novisual and source_is_video:  # export video
-                output_video_writer.write(result["image"])
+                output_video_writer.write(cv2.cvtColor(result["image"], cv2.COLOR_RGB2BGR))
 
         # render video inference
         if view_video:

--- a/sahi/utils/cv.py
+++ b/sahi/utils/cv.py
@@ -338,7 +338,7 @@ def get_video_reader(
                 if not ret:
                     print("\n=========================== Video Ended ===========================")
                     break
-                yield Image.fromarray(frame)
+                yield Image.fromarray(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
 
         else:
             while video_capture.isOpened:
@@ -349,7 +349,7 @@ def get_video_reader(
                 if not ret:
                     print("\n=========================== Video Ended ===========================")
                     break
-                yield Image.fromarray(frame)
+                yield Image.fromarray(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
 
     if export_visual:
         # get video properties and create VideoWriter object


### PR DESCRIPTION
# Summary
I was using "predict" cli tool for video inference and realized this issue after weird inference results. When I checked the implementation I noticed the colro space conversion from BGR2RGB is not done for video inputs, while it is done for image inputs. As a result it provides 2 different results 
* when you chop a video to frames and give the folder path of images as input
* when you give the video path as input

Here is my command:
`sahi predict --slice_width 1080 --slice_height 1080 --overlap_height_ratio 0.2 --overlap_width_ratio 0.2 --model_confidence_threshold 0.25 --model_path "<my-yolo-model>.pt" --model_type yolov5 --source "20240315_145057000_iOS.mp4" --export_crop`

# Details:
1. When you provide the an image directory or image path to the tool, sahi reads images with cv2 and does color space conversion from BGR to RGB(since cv2 reads images with BGR color space).
2. Then RGB image is fed into the inference with yolo model
3. After the annotations, again a color space is changed from RGB to BGR and saved
4. However when you provide a video path, this RGB2BGR and BGR2RGB conversions are not performed. As a result, the inference is done with BGR image even if the model is trained with RGB color space
5. I noticed the issue when I see the detection crops which is saved after the colorspace conversion. However since the input image is not converted to BGR the conversion on `crop_object_predictions` function results an output image with incorrect color space.

# Reproduce:
You can reproduce the issue with any video and any yolo model (add --export_crop option to observe oddness on color space). 