### PR TITLE
handles when bbox is empty

### DIFF
--- a/sahi/slicing.py
+++ b/sahi/slicing.py
@@ -103,7 +103,12 @@ def annotation_inside_slice(annotation: Dict, slice_bbox: List[int]) -> bool:
     Returns:
         (bool): True if any annotation coordinate lies inside slice.
     """
-    left, top, width, height = annotation["bbox"]
+    bbox = annotation["bbox"]
+    if len(bbox) == 0:
+        # if the bbox is empty, skips.
+        return False
+    else:
+        left, top, width, height = bbox    
 
     right = left + width
     bottom = top + height


### PR DESCRIPTION
## Error case
When empty bbox is fed to the function.
```
output_coco_path = sahi_slice(
ValueError: not enough values to unpack (expected 4, got 0)
```

annotation
```
{'image_id': None, 'bbox': [], 'category_id': 1, 'segmentation': [], 'iscrowd': 0, 'area': 0}
```