### PR TITLE
Use PyPI 4.9 opencv-python version in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python<=4.9
+opencv-python<=4.9.0.80
 shapely>=1.8.0
 tqdm>=4.48.2
 pillow>=8.2.0


### PR DESCRIPTION
PyPI version of `opencv-python` package is 4.9.0.80.

Previous relaxation of opencv-python version (#1035) is not allowing SAHI to be used alongside `albumentations` package, that has a `MIN_OPENCV_VERSION = "4.9.0.80"` ([setup.py](https://github.com/albumentations-team/albumentations/blob/main/setup.py)).

So I propose to use this version in pip requirements to be able to actually utilize a pre-built opencv-python package.