### PR TITLE
Mmdet TensorRT support

### DIFF
--- a/sahi/models/base.py
+++ b/sahi/models/base.py
@@ -15,6 +15,7 @@ class DetectionModel:
         model_path: Optional[str] = None,
         model: Optional[Any] = None,
         config_path: Optional[str] = None,
+        deploy_config_path: Optional[str] = None,
         device: Optional[str] = None,
         mask_threshold: float = 0.5,
         confidence_threshold: float = 0.3,
@@ -27,9 +28,11 @@ class DetectionModel:
         Init object detection/instance segmentation model.
         Args:
             model_path: str
-                Path for the instance segmentation model weight
+                Path for the instance segmentation model weight, .engine file if it's tensorrt
             config_path: str
                 Path for the mmdetection instance segmentation model config file
+            deploy_config_path: str
+                Path for the mmdetection detection/instance segmentation deployment config file
             device: str
                 Torch device, "cpu" or "cuda"
             mask_threshold: float
@@ -47,6 +50,7 @@ class DetectionModel:
         """
         self.model_path = model_path
         self.config_path = config_path
+        self.deploy_config_path = deploy_config_path
         self.model = None
         self.device = device
         self.mask_threshold = mask_threshold


### PR DESCRIPTION
* TensorRT model wrapper for both instance seg. and object detector added to **mmdet.py** 

GPU Info: NVIDIA GeForce RTX 3090

Model used: [rtmdet_l_8xb32-300e_coco.py](https://github.com/open-mmlab/mmdetection/blob/main/configs/rtmdet/rtmdet_l_8xb32-300e_coco.py)

Deployment cfg file used: detection_tensorrt-fp16_static-640x640.py -> you may find examples [here](https://github.com/open-mmlab/mmdeploy/tree/1.x/configs/mmdet/detection)

Average inference times(Just the \__call\__ method of the wrappers used):
* Vanilla model ~ 28 ms
* TensorRT model ~ 14 ms

Average inference times(get_sliced_prediction function):
* image used with a size of (height=1432, width=4089, 3) and slice used with a size of (height=640,width=640)
* Vanilla model ~ 1.4 s
* TensorRT model ~ 1 s

The difference was around 400 ms but it might yield significant speed improvement for edge devices such as jetson.

Disclaimer: This implementation is not perfect as it could be generalized to work for other frameworks(yolo, detectron2, etc.). I needed this for my current project and wanted to share it as a base for anyone interested.

Example usage:
```python
deploy_config_path = None
category_mapping = None
path_detector = "detection.pth"
if trt:
  path_detector = "end2end.engine"
  deploy_config_path = "detection_tensorrt-fp16_static-640x640.py"
  category_mapping = {id:class} #Class mapping needed

model = AutoDetectionModel.from_pretrained(
            model_type="mmdet",
            model_path=path_detector,
            deploy_config_path=deploy_config_path,
            config_path="rtmdet_l_8xb32-300e_coco.py",
            category_mapping=category_mapping,
            device=device,
        )
```