### PR TITLE
Update has_mask method for mmdet models (handle ConcatDataset)

### DIFF
--- a/sahi/models/mmdet.py
+++ b/sahi/models/mmdet.py
@@ -188,15 +188,31 @@ class MmdetDetectionModel(DetectionModel):
     @property
     def has_mask(self):
         """
-        Returns if model output contains segmentation mask
+        Returns if model output contains segmentation mask.
+        Considers both single dataset and ConcatDataset scenarios.
         """
-        # has_mask = self.model.model.with_mask
-        train_pipeline = self.model.cfg["train_dataloader"]["dataset"]["pipeline"]
-        has_mask = any(
-            isinstance(item, dict) and any("mask" in key and value is True for key, value in item.items())
-            for item in train_pipeline
-        )
-        return has_mask
+
+        def check_pipeline_for_mask(pipeline):
+            return any(
+                isinstance(item, dict) and any("mask" in key and value is True for key, value in item.items())
+                for item in pipeline
+            )
+
+        # Access the dataset from the configuration
+        dataset_config = self.model.cfg["train_dataloader"]["dataset"]
+
+        if dataset_config["type"] == "ConcatDataset":
+            # If using ConcatDataset, check each dataset individually
+            datasets = dataset_config["datasets"]
+            for dataset in datasets:
+                if check_pipeline_for_mask(dataset["pipeline"]):
+                    return True
+        else:
+            # Otherwise, assume a single dataset with its own pipeline
+            if check_pipeline_for_mask(dataset_config["pipeline"]):
+                return True
+
+        return False
 
     @property
     def category_names(self):


### PR DESCRIPTION
```
train_dataloader = dict(
    batch_size=batch_size,
    num_workers=batch_size,
    persistent_workers=True,
    sampler=dict(type="DefaultSampler", shuffle=True),
    batch_sampler=dict(type="AspectRatioBatchSampler"),
    dataset=dict(type="ConcatDataset", datasets=train_datasets),
)
```

When `ConcatDatasaet` is used for train_dataloader, it throws an error.
```
File "/.../miniconda3/envs/mmdet2/lib/python3.8/site-packages/mmengine/config/config.py", line 105, in __missing__
    raise KeyError(name)
KeyError: 'pipeline'
```

```
self.model.cfg["train_dataloader"]['dataset']
{'datasets': [{...}, {...}], 'type': 'ConcatDataset'}

self.model.cfg["train_dataloader"]['dataset']['datasets']
[{'ann_file': 'annotations/instances_train.json', 'backend_args': None, 'data_prefix': {...}, 'data_root': '/mmdet/data/...', 'filter_cfg': {...}, 'metainfo': {...}, 'pipeline': [...], 'type': 'CocoDataset'}, {'ann_file': 'annotations/instances_train.json', 'backend_args': None, 'data_prefix': {...}, 'data_root': '/mmdet/data/...', 'filter_cfg': {...}, 'metainfo': {...}, 'pipeline': [...], 'type': 'CocoDataset'}]
```

This PR handles ConcatDatasaet case.
