### PR TITLE
Pin shapely>2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 opencv-python<=4.9.0.80
-shapely>=1.8.0
+shapely>=2.0.0
 tqdm>=4.48.2
 pillow>=8.2.0
 pybboxes==0.1.6


### PR DESCRIPTION
Changes in https://github.com/obss/sahi/pull/1047 means that `import sahi` won't work with `shapely=1.8` installed due to this line:

https://github.com/obss/sahi/blob/de405626dcd9b98e8148435476727a6045d74ff9/sahi/utils/coco.py#L17

Full error (copied from https://github.com/conda-forge/sahi-feedstock/pull/60#issuecomment-2495819447:

```python-traceback
import: 'sahi'
Traceback (most recent call last):
  File "/home/conda/feedstock_root/build_artifacts/sahi_1732418500825/test_tmp/run_test.py", line 2, in <module>
    import sahi
  File "/home/conda/feedstock_root/build_artifacts/sahi_1732418500825/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p/lib/python3.7/site-packages/sahi/__init__.py", line 3, in <module>
    from sahi.annotation import BoundingBox, Category, Mask
  File "/home/conda/feedstock_root/build_artifacts/sahi_1732418500825/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p/lib/python3.7/site-packages/sahi/annotation.py", line 9, in <module>
    from sahi.utils.coco import CocoAnnotation, CocoPrediction
  File "/home/conda/feedstock_root/build_artifacts/sahi_1732418500825/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p/lib/python3.7/site-packages/sahi/utils/coco.py", line 17, in <module>
    from shapely import GeometryCollection, MultiPolygon, Polygon
ImportError: cannot import name 'GeometryCollection' from 'shapely' (/home/conda/feedstock_root/build_artifacts/sahi_1732418500825/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p/lib/python3.7/site-packages/shapely/__init__.py)
```

Solution is to pin to `shapely>2.0.0` as suggested at https://github.com/obss/sahi/discussions/1061#discussioncomment-10045950