### PR TITLE
Remove numpy<2 upper pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ fire
 terminaltables
 requests
 click
-numpy<2.0.0


### PR DESCRIPTION
Given sahi recently relaxed the upper pin on OpenCV to 4.10 at https://github.com/obss/sahi/pull/1106, we can probably revert https://github.com/obss/sahi/pull/1057 to support Numpy 2.0.

References:
- https://github.com/opencv/opencv/wiki/OpenCV-Change-Logs-v2.2%E2%80%90v4.10#version4100
- https://github.com/conda-forge/opencv-feedstock/pull/417
- https://github.com/conda-forge/sahi-feedstock/pull/58#discussion_r1674691543