### PR TITLE
Improve suppot for latest mmdet (v3.3.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
           # coco analyse
           sahi coco analyse --dataset_json_path tests/data/coco_evaluate/dataset.json --result_json_path tests/data/coco_evaluate/result.json --out_dir tests/data/coco_evaluate/
       - name: Test SAHI CLI with MMCV
+        if: ${{ matrix.python-version }} != '3.12'
         run: |
           source .venv/bin/activate
           set -e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
           # coco analyse
           sahi coco analyse --dataset_json_path tests/data/coco_evaluate/dataset.json --result_json_path tests/data/coco_evaluate/result.json --out_dir tests/data/coco_evaluate/
       - name: Test SAHI CLI with MMCV
-        if: ${{ matrix.python-version }} != '3.12'
+        if: matrix.python-version != '3.12'
         run: |
           source .venv/bin/activate
           set -e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,6 @@ jobs:
           # coco analyse
           sahi coco analyse --dataset_json_path tests/data/coco_evaluate/dataset.json --result_json_path tests/data/coco_evaluate/result.json --out_dir tests/data/coco_evaluate/
       - name: Test SAHI CLI with MMCV
-        if: matrix.python-version == '3.8' || matrix.python-version == '3.9' || matrix.python-version == '3.10'
         run: |
           source .venv/bin/activate
           set -e

--- a/README.md
+++ b/README.md
@@ -97,8 +97,6 @@ Object detection and instance segmentation are by far the most important applica
 
 - `MMDetection` + `SAHI` walkthrough: <a href="https://colab.research.google.com/github/obss/sahi/blob/main/demo/inference_for_mmdetection.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="sahi-mmdetection"></a>
 
-- `Detectron2` + `SAHI` walkthrough: <a href="https://colab.research.google.com/github/obss/sahi/blob/main/demo/inference_for_detectron2.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="sahi-detectron2"></a>
-
 - `TorchVision` + `SAHI` walkthrough: <a href="https://colab.research.google.com/github/obss/sahi/blob/main/demo/inference_for_torchvision.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="sahi-torchvision"></a>
 
 <a href="https://huggingface.co/spaces/fcakyon/sahi-yolox"><img width="600" src="https://user-images.githubusercontent.com/34196005/144092739-c1d9bade-a128-4346-947f-424ce00e5c4f.gif" alt="sahi-yolox"></a>
@@ -126,51 +124,41 @@ pip install sahi
 conda install -c conda-forge shapely
 ```
 
-- Install your desired version of pytorch and torchvision (cuda 11.3 for detectron2, cuda 11.7 for rest):
+- Install your desired version of pytorch and torchvision:
 
 ```console
-conda install pytorch=1.10.2 torchvision=0.11.3 cudatoolkit=11.3 -c pytorch
+pip install torch==2.6.0 torchvision==0.21.0 --index-url https://download.pytorch.org/whl/cu126
 ```
 
+(torch 2.1.2 is required for mmdet support):
+
 ```console
-conda install pytorch=1.13.1 torchvision=0.14.1 pytorch-cuda=11.7 -c pytorch -c nvidia
+pip install torch==2.1.2 torchvision==0.16.2 --index-url https://download.pytorch.org/whl/cu121
 ```
 
 - Install your desired detection framework (yolov5):
 
 ```console
-pip install yolov5==7.0.13
+pip install yolov5==7.0.14
 ```
 
 - Install your desired detection framework (ultralytics):
 
 ```console
-pip install ultralytics==8.3.50
+pip install ultralytics==8.3.86
 ```
 
 - Install your desired detection framework (mmdet):
 
 ```console
 pip install mim
-mim install mmdet==3.0.0
-```
-
-- Install your desired detection framework (detectron2):
-
-```console
-pip install detectron2 -f https://dl.fbaipublicfiles.com/detectron2/wheels/cu113/torch1.10/index.html
+mim install mmdet==3.3.0
 ```
 
 - Install your desired detection framework (huggingface):
 
 ```console
 pip install transformers timm
-```
-
-- Install your desired detection framework (super-gradients):
-
-```console
-pip install super-gradients==3.3.1
 ```
 
 </details>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Software Development :: Libraries",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
@@ -40,7 +41,7 @@ sahi = "sahi.cli:app"
 
 [tool.uv]
 find-links = [
-  "https://download.openmmlab.com/mmcv/dist/cpu/torch1.13.0/index.html",
+  "https://download.openmmlab.com/mmcv/dist/cpu/torch2.3.1/index.html"
 ]
 default-groups = ["dev", "ci"]
 
@@ -54,14 +55,11 @@ dev = [
 ]
 ci = [
   # pytorch should be present for all python versions
-  "torch==1.13.1;python_version<'3.11'",
-  "torch==2.6.0+cpu;python_version>='3.11'",
-  "torchvision>=0.14.1;python_version<'3.11'",
-  "torchvision==0.21.0+cpu;python_version>='3.11'",
-  # mmcv is available for python < 3.11
-  "mmengine==0.7.3;python_version<'3.11'",
-  "mmcv==2.0.0;python_version<'3.11'",
-  "mmdet==3.0.0;python_version<'3.11'",
+  "torch==2.3.1+cpu",
+  "torchvision==0.18.1+cpu",
+  "mmengine",
+  "mmcv>=2.2.0",
+  "mmdet>=3.3.0",
   # deepsparse is only available for python<3.12
   "deepsparse;python_version<'3.12'",
   "onnxruntime<1.20;python_version<'3.12'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ sahi = "sahi.cli:app"
 
 [tool.uv]
 find-links = [
-  "https://download.openmmlab.com/mmcv/dist/cpu/torch2.3.1/index.html"
+  "https://download.openmmlab.com/mmcv/dist/cpu/torch2.3.0/index.html"
 ]
 default-groups = ["dev", "ci"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ sahi = "sahi.cli:app"
 
 [tool.uv]
 find-links = [
-  "https://download.openmmlab.com/mmcv/dist/cpu/torch2.3.0/index.html"
+  "https://download.openmmlab.com/mmcv/dist/cpu/torch2.1.0/index.html"
 ]
 default-groups = ["dev", "ci"]
 
@@ -55,8 +55,11 @@ dev = [
 ]
 ci = [
   # pytorch should be present for all python versions
-  "torch==2.3.1+cpu",
-  "torchvision==0.18.1+cpu",
+  "torch==2.6.0+cpu;python_version>='3.12'",
+  "torchvision==0.21.0+cpu;python_version>='3.12'",
+  # mmdet is supported for python < 3.12
+  "torch==2.1.2+cpu;python_version<'3.12'",
+  "torchvision==0.16.2+cpu;python_version<'3.12'",
   "mmengine;python_version<'3.12'",
   "mmcv==2.1.0;python_version<'3.12'",
   "mmdet==3.3.0;python_version<'3.12'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,9 @@ ci = [
   # pytorch should be present for all python versions
   "torch==2.3.1+cpu",
   "torchvision==0.18.1+cpu",
-  "mmengine",
-  "mmcv>=2.2.0",
-  "mmdet>=3.3.0",
+  "mmengine;python_version<'3.12'",
+  "mmcv==2.1.0;python_version<'3.12'",
+  "mmdet==3.3.0;python_version<'3.12'",
   # deepsparse is only available for python<3.12
   "deepsparse;python_version<'3.12'",
   "onnxruntime<1.20;python_version<'3.12'",

--- a/sahi/models/mmdet.py
+++ b/sahi/models/mmdet.py
@@ -104,7 +104,7 @@ class MmdetDetectionModel(DetectionModel):
         scope: str = "mmdet",
     ):
         if not IMPORT_MMDET_V3:
-            raise ImportError("Failed to import `DetInferencer`. Please confirm you have installed 'mmdet>=3.0.0'")
+            raise ImportError("Failed to import `DetInferencer`. Please confirm you have installed 'mmdet==3.3.0 mmcv==2.1.0'")
 
         self.scope = scope
         self.image_size = image_size

--- a/sahi/models/mmdet.py
+++ b/sahi/models/mmdet.py
@@ -104,7 +104,9 @@ class MmdetDetectionModel(DetectionModel):
         scope: str = "mmdet",
     ):
         if not IMPORT_MMDET_V3:
-            raise ImportError("Failed to import `DetInferencer`. Please confirm you have installed 'mmdet==3.3.0 mmcv==2.1.0'")
+            raise ImportError(
+                "Failed to import `DetInferencer`. Please confirm you have installed 'mmdet==3.3.0 mmcv==2.1.0'"
+            )
 
         self.scope = scope
         self.image_size = image_size

--- a/tests/test_mmdetectionmodel.py
+++ b/tests/test_mmdetectionmodel.py
@@ -11,7 +11,7 @@ from sahi.prediction import ObjectPrediction
 from sahi.utils.cv import read_image
 from sahi.utils.mmdet import MmdetTestConstants, download_mmdet_cascade_mask_rcnn_model, download_mmdet_yolox_tiny_model
 
-pytestmark = pytest.mark.skipif(sys.version_info[:2] > (3, 10), reason="Requires Python 3.10 or lower")
+#pytestmark = pytest.mark.skipif(sys.version_info[:2] > (3, 10), reason="Requires Python 3.10 or lower")
 MODEL_DEVICE = "cpu"
 CONFIDENCE_THRESHOLD = 0.5
 IMAGE_SIZE = 320

--- a/tests/test_mmdetectionmodel.py
+++ b/tests/test_mmdetectionmodel.py
@@ -11,7 +11,7 @@ from sahi.prediction import ObjectPrediction
 from sahi.utils.cv import read_image
 from sahi.utils.mmdet import MmdetTestConstants, download_mmdet_cascade_mask_rcnn_model, download_mmdet_yolox_tiny_model
 
-# pytestmark = pytest.mark.skipif(sys.version_info[:2] > (3, 10), reason="Requires Python 3.10 or lower")
+pytestmark = pytest.mark.skipif(sys.version_info[:2] > (3, 11), reason="MMDet 3.3.0 requires Python 3.11 or lower")
 MODEL_DEVICE = "cpu"
 CONFIDENCE_THRESHOLD = 0.5
 IMAGE_SIZE = 320

--- a/tests/test_mmdetectionmodel.py
+++ b/tests/test_mmdetectionmodel.py
@@ -11,7 +11,7 @@ from sahi.prediction import ObjectPrediction
 from sahi.utils.cv import read_image
 from sahi.utils.mmdet import MmdetTestConstants, download_mmdet_cascade_mask_rcnn_model, download_mmdet_yolox_tiny_model
 
-#pytestmark = pytest.mark.skipif(sys.version_info[:2] > (3, 10), reason="Requires Python 3.10 or lower")
+# pytestmark = pytest.mark.skipif(sys.version_info[:2] > (3, 10), reason="Requires Python 3.10 or lower")
 MODEL_DEVICE = "cpu"
 CONFIDENCE_THRESHOLD = 0.5
 IMAGE_SIZE = 320


### PR DESCRIPTION
- Upgrade PyTorch to version 2.3.1
- Update torchvision to version 0.18.1
- Add Python 3.12 support in classifiers
- Update mmengine, mmcv, and mmdet to latest versions
- Remove version-specific dependencies