### PR TITLE
Improve support for latest yolov5-pip and ultralytics versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,11 +69,11 @@ ci = [
   "onnx>1.16;python_version>='3.12'",
   "onnxruntime;python_version>='3.12'",
   # These are available for all 
-  "yolov5>=7.0.13",
+  "yolov5>=7.0.14",
   # NOTE: Higher versions of transformers give different inference results of huggingface model
   "transformers==4.35.0",
   "pycocotools>=2.0.7",
-  "ultralytics>=8.3.50",
+  "ultralytics>=8.3.86",
   "scikit-image",
   "fiftyone",
 ]


### PR DESCRIPTION
Bump package versions:
- yolov5 from >=7.0.13 to >=7.0.14
- ultralytics from >=8.3.50 to >=8.3.86