### PR TITLE
refctor coco to yolo conversion, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Object detection and instance segmentation are by far the most important applica
 | [coco fiftyone](https://github.com/obss/sahi/blob/main/docs/cli.md#coco-fiftyone-command-usage)  | explore multiple prediction results on your COCO dataset with [fiftyone ui](https://github.com/voxel51/fiftyone) ordered by number of misdetections |
 | [coco evaluate](https://github.com/obss/sahi/blob/main/docs/cli.md#coco-evaluate-command-usage)  | evaluate classwise COCO AP and AR for given predictions and ground truth |
 | [coco analyse](https://github.com/obss/sahi/blob/main/docs/cli.md#coco-analyse-command-usage)  | calculate and export many error analysis plots |
-| [coco yolov5](https://github.com/obss/sahi/blob/main/docs/cli.md#coco-yolov5-command-usage)  | automatically convert any COCO dataset to [ultralytics](https://github.com/ultralytics/ultralytics) format |
+| [coco yolo](https://github.com/obss/sahi/blob/main/docs/cli.md#coco-yolo-command-usage)  | automatically convert any COCO dataset to [ultralytics](https://github.com/ultralytics/ultralytics) format |
 
 ## <div align="center">Quick Start Examples</div>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,69 @@
+# SAHI Documentation
+
+Welcome to the SAHI documentation! This directory contains detailed guides and tutorials for using SAHI's various features. Below is an overview of each documentation file and what you'll find in it.
+
+## Core Documentation Files
+
+### [Prediction Utilities](predict.md)
+- Detailed guide for performing object detection inference
+- Standard and sliced inference examples
+- Batch prediction usage
+- Class exclusion during inference
+- Visualization parameters and export formats
+- Interactive examples with various model integrations (YOLOv8, MMDetection, etc.)
+
+### [Slicing Utilities](slicing.md)
+- Guide for slicing large images and datasets
+- Image slicing examples
+- COCO dataset slicing examples
+- Interactive demo notebook reference
+
+### [COCO Utilities](coco.md)
+- Comprehensive guide for working with COCO format datasets
+- Dataset creation and manipulation
+- Slicing COCO datasets
+- Dataset splitting (train/val)
+- Category filtering and updates
+- Area-based filtering
+- Dataset merging
+- Format conversion (COCO ↔ YOLO)
+- Dataset sampling utilities
+- Statistics calculation
+- Result validation
+
+### [CLI Commands](cli.md)
+- Complete reference for SAHI command-line interface
+- Prediction commands
+- FiftyOne integration
+- COCO dataset operations
+- Environment information
+- Version checking
+- Custom script usage
+
+### [FiftyOne Integration](fiftyone.md)
+- Guide for visualizing and analyzing predictions with FiftyOne
+- Dataset visualization
+- Result exploration
+- Interactive analysis
+
+## Interactive Examples
+
+All documentation files are complemented by interactive Jupyter notebooks in the [demo directory](../demo/):
+- `slicing.ipynb` - Slicing operations demonstration
+- `inference_for_ultralytics.ipynb` - YOLOv8/YOLO11/YOLO12 integration
+- `inference_for_yolov5.ipynb` - YOLOv5 integration
+- `inference_for_mmdetection.ipynb` - MMDetection integration
+- `inference_for_huggingface.ipynb` - HuggingFace models integration
+- `inference_for_torchvision.ipynb` - TorchVision models integration
+- `inference_for_rtdetr.ipynb` - RT-DETR integration
+- `inference_for_sparse_yolov5.ipynb` - DeepSparse optimized inference
+
+## Getting Started
+
+If you're new to SAHI:
+
+1. Start with the [prediction utilities](predict.md) to understand basic inference
+2. Explore the [slicing utilities](slicing.md) to learn about processing large images
+3. Check out the [CLI commands](cli.md) for command-line usage
+4. Dive into [COCO utilities](coco.md) for dataset operations
+5. Try the interactive notebooks in the [demo directory](../demo/) for hands-on experience

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -11,16 +11,16 @@ will perform sliced inference on default parameters and export the prediction vi
 - It also supports video input:
 
 ```bash
->>sahi predict --model_path yolov5s.pt --model_type yolov5 --source video.mp4
-``` 
+>>sahi predict --model_path yolo11s.pt --model_type ultralytics --source video.mp4
+```
 
 You can also view video render during video inference with `--view_video`:
 
 ```bash
->>sahi predict --model_path yolov5s.pt --model_type yolov5 --source video.mp4 --view_video
-``` 
+>>sahi predict --model_path yolo11s.pt --model_type ultralytics --source video.mp4 --view_video
+```
 
-- To `forward 100 frames`, on opened window press key `D `
+- To `forward 100 frames`, on opened window press key `D`
 - To `revert 100 frames`, on opened window press key `A`
 - To `forward 20 frames`, on opened window press key `G`
 - To `revert 20 frames`, on opened window press key `F`
@@ -34,7 +34,7 @@ You can specify additional sliced prediction parameters as:
 >>sahi predict --slice_width 512 --slice_height 512 --overlap_height_ratio 0.1 --overlap_width_ratio 0.1 --model_confidence_threshold 0.25 --source image/file/or/folder --model_path path/to/model --model_config_path path/to/config
 ```
 
-- Specify detection framework as `--model_type mmdet` for MMDetection or `--model_type yolov5` for YOLOv5, to match with your model weight
+- Specify detection framework as `--model_type mmdet` for MMDetection or `--model_type ultralytics` for Ultralytics, to match with your model weight file
 
 - Specify postprocess type as `--postprocess_type GREEDYNMM` or `--postprocess_type NMS` to be applied over sliced predictions
 
@@ -88,15 +88,15 @@ Specify slice overlap ratio for height/width size as `--overlap_ratio 0.2`.
 
 If you want to ignore images with annotations set it add `--ignore_negative_samples` argument.
 
-## `coco yolov5` command usage:
+## `coco yolo` command usage:
 
 (In Windows be sure to open anaconda cmd prompt/windows cmd `as admin` to be able to create symlinks properly.)
 
 ```bash
->>sahi coco yolov5 --image_dir dir/to/images --dataset_json_path dataset.json  --train_split 0.9
+>>sahi coco yolo --image_dir dir/to/images --dataset_json_path dataset.json  --train_split 0.9
 ```
 
-will convert given coco dataset to yolov5 format and export to runs/coco2yolov5/exp folder.
+will convert given coco dataset to yolo format and export to runs/coco2yolo/exp folder.
 
 ## `coco evaluate` command usage:
 
@@ -116,7 +116,7 @@ If you want to specify max detections, set it as `--proposal_nums "[10 100 500]"
 
 If you want to specify a psecific IOU threshold, set it as `--iou_thrs 0.5`. Default includes `0.50:0.95` and `0.5` scores.
 
-If you want to specify export directory, set it as `--out_dir output/folder/directory `.
+If you want to specify export directory, set it as `--out_dir output/folder/directory`.
 
 ## `coco analyse` command usage:
 
@@ -140,14 +140,11 @@ Print related package versions in the current env as:
 
 ```bash
 >>sahi env
-06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   torch version 1.11.0 is available.
-06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   torchvision version 0.12.0 is available.
-06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   yolov5 version 6.1.3 is available.
-06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   mmdet version 2.25.0 is available.
-06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   mmcv version 1.5.3 is available.
-06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   detectron2 version 0.6+cpu is available.
-06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   transformers version 4.20.0 is available.
-06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   timm version 0.4.12 is available.
+06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   torch version 2.1.2 is available.
+06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   torchvision version 0.16.2 is available.
+06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   ultralytics version 8.3.86 is available.
+06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   transformers version 4.49.0 is available.
+06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   timm version 0.9.1 is available.
 06/19/2022 21:24:52 - INFO - sahi.utils.import_utils -   fiftyone version 0.14.2 is available.
 ```
 
@@ -157,7 +154,7 @@ Print your SAHI verison as:
 
 ```bash
 >>sahi version
-0.10.0
+0.11.22
 ```
 
 ## Custom scripts

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -164,3 +164,13 @@ All scripts can be downloaded from [scripts directory](https://github.com/obss/s
 ```bash
 python script_name.py
 ```
+
+# Additional Resources
+Looking to dive deeper? Here are some helpful resources:
+
+- For a detailed walkthrough of prediction parameters and visualization, check out our [prediction utilities documentation](predict.md)
+- To understand slicing operations in depth, explore our [slicing utilities guide](slicing.md)
+- For hands-on examples with COCO format operations, see our [COCO utilities documentation](coco.md)
+- Want to see these CLI commands in action? Try our interactive notebooks in the [demo directory](../demo/)
+
+These resources provide comprehensive examples and explanations to help you make the most of SAHI's command-line interface.

--- a/docs/coco.md
+++ b/docs/coco.md
@@ -48,6 +48,7 @@ coco_image.add_annotation(
   )
 )
 ```
+
 - add predictions to coco image:
 
 ```python
@@ -88,6 +89,7 @@ from sahi.utils.file import save_json
 
 save_json(coco_json, "coco_dataset.json")
 ```
+
 - you can also export prediction array in coco prediction format and save it as json :
 
 ```python
@@ -96,6 +98,7 @@ from sahi.utils.file import save_json
 predictions_array = coco.prediction_array
 save_json = save_json(predictions_array, "coco_predictions.json")
 ```
+
 - this prediction array can be used to get standard coco metrics for the predictions using official pycocotool api :
 
 ```python
@@ -111,8 +114,6 @@ coco_evaluator.evaluate()
 coco_evaluator.accumulate()
 coco_evaluator.summarize()
 ```
-
-
 
 </details>
 
@@ -133,6 +134,7 @@ coco_dict, coco_path = slice_coco(
     overlap_width_ratio=0.2,
 )
 ```
+
 </details>
 
 <details closed>
@@ -159,6 +161,7 @@ result = coco.split_coco_as_train_val(
 save_json(result["train_coco"].json, "train_split.json")
 save_json(result["val_coco"].json, "val_split.json")
 ```
+
 </details>
 
 <details closed>
@@ -184,6 +187,7 @@ coco.update_categories(desired_name2id)
 # export updated/filtered COCO dataset
 save_json(coco.json, "updated_coco.json")
 ```
+
 </details>
 
 <details closed>
@@ -212,6 +216,7 @@ area_filtered_coco = coco.get_area_filtered_coco(intervals_per_category=interval
 # export filtered COCO dataset
 save_json(area_filtered_coco.json, "area_filtered_coco.json")
 ```
+
 </details>
 
 <details closed>
@@ -222,10 +227,11 @@ save_json(area_filtered_coco.json, "area_filtered_coco.json")
 ```python
 from sahi.utils.coco import Coco
 
-# set ignore_negative_samples as False if you want images without annotations present in json and yolov5 exports
+# set ignore_negative_samples as False if you want images without annotations present in json and YOLO exports
 coco = Coco.from_coco_dict_or_path("coco.json", ignore_negative_samples=False)
 
 ```
+
 </details>
 
 <details closed>
@@ -247,11 +253,12 @@ coco_1.merge(coco_2)
 # export merged COCO dataset
 save_json(coco_1.json, "merged_coco.json")
 ```
+
 </details>
 
 <details closed>
 <summary>
-<big><b>Convert COCO dataset to ultralytics/yolov5 format:</b></big>
+<big><b>Convert COCO dataset to ultralytics/YOLO format:</b></big>
 </summary>
 
 ```python
@@ -260,35 +267,35 @@ from sahi.utils.coco import Coco
 # init Coco object
 coco = Coco.from_coco_dict_or_path("coco.json", image_dir="coco_images/")
 
-# export converted YoloV5 formatted dataset into given output_dir with a 85% train/15% val split
-coco.export_as_yolov5(
+# export converted YOLO formatted dataset into given output_dir with a 85% train/15% val split
+coco.export_as_yolo(
   output_dir="output/folder/dir",
   train_split_rate=0.85
 )
-
 ```
+
 </details>
 
 <details closed>
 <summary>
-<big><b>Convert train/val COCO dataset to ultralytics/yolov5 format:</b></big>
+<big><b>Convert train/val COCO dataset to ultralytics/YOLO format:</b></big>
 </summary>
 
 ```python
-from sahi.utils.coco import Coco, export_coco_as_yolov5
+from sahi.utils.coco import Coco, export_coco_as_yolo
 
 # init Coco object
 train_coco = Coco.from_coco_dict_or_path("train_coco.json", image_dir="coco_images/")
 val_coco = Coco.from_coco_dict_or_path("val_coco.json", image_dir="coco_images/")
 
-# export converted YoloV5 formatted dataset into given output_dir with given train/val split
-data_yml_path = export_coco_as_yolov5(
+# export converted YOLO formatted dataset into given output_dir with given train/val split
+data_yml_path = export_coco_as_yolo(
   output_dir="output/folder/dir",
   train_coco=train_coco,
   val_coco=val_coco
 )
-
 ```
+
 </details>
 
 <details closed>

--- a/docs/coco.md
+++ b/docs/coco.md
@@ -436,3 +436,13 @@ coco = coco.get_coco_with_clipped_bboxes()
 save_json(coco.json, "coco.json")
 ```
 </details>
+
+# Interactive Examples and Additional Resources
+
+Want to see these COCO utilities in action? Here are some helpful resources:
+
+- For hands-on examples of COCO dataset slicing, check out our [slicing demo notebook](../demo/slicing.ipynb)
+- To learn about prediction and visualization with COCO datasets, explore our model-specific notebooks in the [demo directory](../demo/)
+- For command-line operations with COCO datasets, refer to our [CLI documentation](cli.md)
+
+These resources provide practical examples and detailed explanations to help you work effectively with COCO datasets using SAHI.

--- a/docs/predict.md
+++ b/docs/predict.md
@@ -97,3 +97,62 @@ result = get_sliced_prediction(
 )
 
 ```
+
+- Visualization parameters and export formats:
+
+```python
+from sahi.predict import get_prediction
+from sahi import AutoDetectionModel
+from PIL import Image
+
+# init a model
+detection_model = AutoDetectionModel.from_pretrained(...)
+
+# get prediction result
+result = get_prediction(
+    image,
+    detection_model,
+)
+
+# Export with custom visualization parameters
+result.export_visuals(
+    export_dir="outputs/",
+    text_size=1.0,  # Size of the class label text
+    rect_th=2,      # Thickness of bounding box lines
+    text_th=2,      # Thickness of the text
+    hide_labels=False,  # Set True to hide class labels
+    hide_conf=False,    # Set True to hide confidence scores
+    color=(255, 0, 0),  # Custom color in RGB format (red in this example)
+    file_name="custom_visualization",
+    export_format="jpg"  # Supports 'jpg' and 'png'
+)
+
+# Export as COCO format annotations
+coco_annotations = result.to_coco_annotations()
+# Example output: [{'image_id': None, 'bbox': [x, y, width, height], 'category_id': 0, 'area': width*height, ...}]
+
+# Export as COCO predictions (includes confidence scores)
+coco_predictions = result.to_coco_predictions(image_id=1)
+# Example output: [{'image_id': 1, 'bbox': [x, y, width, height], 'score': 0.98, 'category_id': 0, ...}]
+
+# Export as imantics format
+imantics_annotations = result.to_imantics_annotations()
+# For use with imantics library: https://github.com/jsbroks/imantics
+
+# Export for FiftyOne visualization
+fiftyone_detections = result.to_fiftyone_detections()
+# For use with FiftyOne: https://github.com/voxel51/fiftyone
+```
+
+# Interactive Demos and Examples
+Want to see these prediction utilities in action? We have several interactive notebooks that demonstrate different model integrations:
+
+- For YOLOv8/YOLO11/YOLO12 models, explore our [Ultralytics integration notebook](../demo/inference_for_ultralytics.ipynb)
+- For YOLOv5 models, check out our [YOLOv5 integration notebook](../demo/inference_for_yolov5.ipynb)
+- For MMDetection models, try our [MMDetection integration notebook](../demo/inference_for_mmdetection.ipynb)
+- For HuggingFace models, see our [HuggingFace integration notebook](../demo/inference_for_huggingface.ipynb)
+- For TorchVision models, explore our [TorchVision integration notebook](../demo/inference_for_torchvision.ipynb)
+- For RT-DETR models, check out our [RT-DETR integration notebook](../demo/inference_for_rtdetr.ipynb)
+- For optimized inference with DeepSparse, see our [DeepSparse integration notebook](../demo/inference_for_sparse_yolov5.ipynb)
+
+These notebooks provide hands-on examples and allow you to experiment with different parameters and settings.

--- a/docs/predict.md
+++ b/docs/predict.md
@@ -8,7 +8,7 @@ from sahi import AutoDetectionModel
 
 # init any model
 detection_model = AutoDetectionModel.from_pretrained(model_type='mmdet',...) # for MMDetection models
-detection_model = AutoDetectionModel.from_pretrained(model_type='yolov5',...) # for YOLOv5 models
+detection_model = AutoDetectionModel.from_pretrained(model_type='ultralytics',...) # for YOLOv8/YOLO11/YOLO12 models
 detection_model = AutoDetectionModel.from_pretrained(model_type='huggingface',...) # for HuggingFace detection models
 detection_model = AutoDetectionModel.from_pretrained(model_type='torchvision',...) # for Torchvision detection models
 
@@ -52,9 +52,9 @@ detection_model = AutoDetectionModel.from_pretrained(...)
 
 # get batch predict result
 result = predict(
-    model_type=..., # one of 'yolov5', 'mmdet', 'detectron2'
+    model_type=..., # one of 'ultralytics', 'mmdet', 'huggingface'
     model_path=..., # path to model weight file
-    model_config_path=..., # for detectron2 and mmdet models
+    model_config_path=..., # for mmdet models
     model_confidence_threshold=0.5,
     model_device='cpu', # or 'cuda:0'
     source=..., # image or folder path

--- a/docs/slicing.md
+++ b/docs/slicing.md
@@ -30,3 +30,7 @@ coco_dict, coco_path = slice_coco(
     overlap_width_ratio=0.2,
 )
 ```
+
+# Interactive Demo
+
+Want to experiment with different slicing parameters and see their effects? Check out our [interactive Jupyter notebook](../demo/slicing.ipynb) that demonstrates these slicing operations in action.

--- a/sahi/cli.py
+++ b/sahi/cli.py
@@ -3,7 +3,7 @@ import fire
 from sahi import __version__ as sahi_version
 from sahi.predict import predict, predict_fiftyone
 from sahi.scripts.coco2fiftyone import main as coco2fiftyone
-from sahi.scripts.coco2yolov5 import main as coco2yolov5
+from sahi.scripts.coco2yolo import main as coco2yolo
 from sahi.scripts.coco_error_analysis import analyse
 from sahi.scripts.coco_evaluation import evaluate
 from sahi.scripts.slice_coco import slice
@@ -14,7 +14,8 @@ coco_app = {
     "analyse": analyse,
     "fiftyone": coco2fiftyone,
     "slice": slice,
-    "yolov5": coco2yolov5,
+    "yolo": coco2yolo,
+    "yolov5": coco2yolo,
 }
 
 sahi_app = {

--- a/sahi/models/huggingface.py
+++ b/sahi/models/huggingface.py
@@ -2,6 +2,7 @@
 # Code written by Fatih C Akyon and Devrim Cavusoglu, 2022.
 
 import logging
+import os
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -69,7 +70,8 @@ class HuggingfaceDetectionModel(DetectionModel):
     def load_model(self):
         from transformers import AutoModelForObjectDetection, AutoProcessor
 
-        model = AutoModelForObjectDetection.from_pretrained(self.model_path, token=self._token)
+        hf_token = os.getenv("HF_TOKEN", self._token)
+        model = AutoModelForObjectDetection.from_pretrained(self.model_path, token=hf_token)
         if self.image_size is not None:
             if model.base_model_prefix == "rt_detr_v2":
                 size = {"height": self.image_size, "width": self.image_size}
@@ -77,10 +79,10 @@ class HuggingfaceDetectionModel(DetectionModel):
                 size = {"shortest_edge": self.image_size, "longest_edge": None}
             # use_fast=True raises error: AttributeError: 'SizeDict' object has no attribute 'keys'
             processor = AutoProcessor.from_pretrained(
-                self.model_path, size=size, do_resize=True, use_fast=False, token=self._token
+                self.model_path, size=size, do_resize=True, use_fast=False, token=hf_token
             )
         else:
-            processor = AutoProcessor.from_pretrained(self.model_path, use_fast=False, token=self._token)
+            processor = AutoProcessor.from_pretrained(self.model_path, use_fast=False, token=hf_token)
         self.set_model(model, processor)
 
     def set_model(self, model: Any, processor: Any = None):

--- a/sahi/scripts/coco2yolo.py
+++ b/sahi/scripts/coco2yolo.py
@@ -10,7 +10,7 @@ def main(
     image_dir: str,
     dataset_json_path: str,
     train_split: Union[int, float] = 0.9,
-    project: str = "runs/coco2yolov5",
+    project: str = "runs/coco2yolo",
     name: str = "exp",
     seed: int = 1,
     disable_symlink=False,
@@ -33,15 +33,15 @@ def main(
         coco_dict_or_path=dataset_json_path,
         image_dir=image_dir,
     )
-    # export as yolov5
-    coco.export_as_yolov5(
+    # export as YOLO
+    coco.export_as_yolo(
         output_dir=str(save_dir),
         train_split_rate=train_split,
         numpy_seed=seed,
         disable_symlink=disable_symlink,
     )
 
-    print(f"COCO to YOLOv5 conversion results are successfully exported to {save_dir}")
+    print(f"COCO to YOLO conversion results are successfully exported to {save_dir}")
 
 
 if __name__ == "__main__":

--- a/sahi/utils/coco.py
+++ b/sahi/utils/coco.py
@@ -1357,9 +1357,7 @@ class Coco:
         try:
             import yaml
         except ImportError:
-            raise ImportError(
-                'Please run "pip install -U pyyaml" to install yaml first for yolo formatted exporting.'
-            )
+            raise ImportError('Please run "pip install -U pyyaml" to install yaml first for yolo formatted exporting.')
 
         # set split_mode
         if 0 < train_split_rate and train_split_rate < 1:
@@ -2401,7 +2399,7 @@ def remove_invalid_coco_results(
     return fixed_result_list
 
 
-def export_coco_as_yolov5(    
+def export_coco_as_yolov5(
     output_dir: str,
     train_coco: Optional[Coco] = None,
     val_coco: Optional[Coco] = None,
@@ -2518,6 +2516,7 @@ def export_coco_as_yolo(
         yaml.dump(data, outfile, default_flow_style=False)
 
     return yaml_path
+
 
 def export_coco_as_yolov5_via_yml(
     yml_path: str, output_dir: str, train_split_rate: float = 0.9, numpy_seed=0, disable_symlink=False

--- a/sahi/utils/coco.py
+++ b/sahi/utils/coco.py
@@ -1312,7 +1312,31 @@ class Coco:
         disable_symlink: bool = False,
     ):
         """
-        Exports current COCO dataset in ultralytics/yolov5 format.
+        Deprecated. Please use export_as_yolo instead.
+        Calls export_as_yolo with the same arguments.
+        """
+        warnings.warn(
+            "export_as_yolov5 is deprecated. Please use export_as_yolo instead.",
+            DeprecationWarning,
+        )
+        self.export_as_yolo(
+            output_dir=output_dir,
+            train_split_rate=train_split_rate,
+            numpy_seed=numpy_seed,
+            mp=mp,
+            disable_symlink=disable_symlink,
+        )
+
+    def export_as_yolo(
+        self,
+        output_dir: Union[str, Path],
+        train_split_rate: float = 1.0,
+        numpy_seed: int = 0,
+        mp: bool = False,
+        disable_symlink: bool = False,
+    ):
+        """
+        Exports current COCO dataset in ultralytics/yolo format.
         Creates train val folders with image symlinks and txt files and a data yaml file.
 
         Args:
@@ -1334,7 +1358,7 @@ class Coco:
             import yaml
         except ImportError:
             raise ImportError(
-                'Please run "pip install -U pyyaml" to install yaml first for yolov5 formatted exporting.'
+                'Please run "pip install -U pyyaml" to install yaml first for yolo formatted exporting.'
             )
 
         # set split_mode
@@ -1374,7 +1398,7 @@ class Coco:
 
         # create image symlinks and annotation txts
         if split_mode in ["TRAINVAL", "TRAIN"]:
-            export_yolov5_images_and_txts_from_coco_object(
+            export_yolo_images_and_txts_from_coco_object(
                 output_dir=train_dir,
                 coco=train_coco,
                 ignore_negative_samples=self.ignore_negative_samples,
@@ -1382,7 +1406,7 @@ class Coco:
                 disable_symlink=disable_symlink,
             )
         if split_mode in ["TRAINVAL", "VAL"]:
-            export_yolov5_images_and_txts_from_coco_object(
+            export_yolo_images_and_txts_from_coco_object(
                 output_dir=val_dir,
                 coco=val_coco,
                 ignore_negative_samples=self.ignore_negative_samples,
@@ -1591,7 +1615,7 @@ class Coco:
         return coco
 
 
-def export_yolov5_images_and_txts_from_coco_object(
+def export_yolo_images_and_txts_from_coco_object(
     output_dir, coco, ignore_negative_samples=False, mp=False, disable_symlink=False
 ):
     """
@@ -1610,7 +1634,7 @@ def export_yolov5_images_and_txts_from_coco_object(
         disable_symlink: bool
             If True, symlinks are not created. Instead images are copied.
     """
-    logger.info("generating image symlinks and annotation files for yolov5...")
+    logger.info("generating image symlinks and annotation files for yolo...")
     # symlink is not supported in colab
     if is_colab() and not disable_symlink:
         logger.warning("symlink is not supported in colab, disabling it...")
@@ -1622,21 +1646,21 @@ def export_yolov5_images_and_txts_from_coco_object(
                 for coco_image in coco.images
             ]
             pool.starmap(
-                export_single_yolov5_image_and_corresponding_txt,
+                export_single_yolo_image_and_corresponding_txt,
                 tqdm(args, total=len(args)),
             )
     else:
         for coco_image in tqdm(coco.images):
-            export_single_yolov5_image_and_corresponding_txt(
+            export_single_yolo_image_and_corresponding_txt(
                 coco_image, coco.image_dir, output_dir, ignore_negative_samples, disable_symlink
             )
 
 
-def export_single_yolov5_image_and_corresponding_txt(
+def export_single_yolo_image_and_corresponding_txt(
     coco_image, coco_image_dir, output_dir, ignore_negative_samples=False, disable_symlink=False
 ):
     """
-    Generates yolov5 formatted image symlink and annotation txt file.
+    Generates YOLO formatted image symlink and annotation txt file.
 
     Args:
         coco_image: sahi.utils.coco.CocoImage
@@ -1670,7 +1694,7 @@ def export_single_yolov5_image_and_corresponding_txt(
         coco_image_path = os.path.abspath(coco_image.file_name)
     else:
         if coco_image_dir is None:
-            raise ValueError("You have to specify image_dir of Coco object for yolov5 conversion.")
+            raise ValueError("You have to specify image_dir of Coco object for yolo conversion.")
 
         coco_image_path = os.path.abspath(str(Path(coco_image_dir) / coco_image.file_name))
 
@@ -2377,7 +2401,7 @@ def remove_invalid_coco_results(
     return fixed_result_list
 
 
-def export_coco_as_yolov5(
+def export_coco_as_yolov5(    
     output_dir: str,
     train_coco: Optional[Coco] = None,
     val_coco: Optional[Coco] = None,
@@ -2386,7 +2410,33 @@ def export_coco_as_yolov5(
     disable_symlink=False,
 ):
     """
-    Exports current COCO dataset in ultralytics/yolov5 format.
+    Deprecated. Please use export_coco_as_yolo instead.
+    Calls export_coco_as_yolo with the same arguments.
+    """
+    warnings.warn(
+        "export_coco_as_yolov5 is deprecated. Please use export_coco_as_yolo instead.",
+        DeprecationWarning,
+    )
+    export_coco_as_yolo(
+        output_dir=output_dir,
+        train_coco=train_coco,
+        val_coco=val_coco,
+        train_split_rate=train_split_rate,
+        numpy_seed=numpy_seed,
+        disable_symlink=disable_symlink,
+    )
+
+
+def export_coco_as_yolo(
+    output_dir: str,
+    train_coco: Optional[Coco] = None,
+    val_coco: Optional[Coco] = None,
+    train_split_rate: float = 0.9,
+    numpy_seed=0,
+    disable_symlink=False,
+):
+    """
+    Exports current COCO dataset in ultralytics/YOLO format.
     Creates train val folders with image symlinks and txt files and a data yaml file.
 
     Args:
@@ -2405,12 +2455,12 @@ def export_coco_as_yolov5(
 
     Returns:
         yaml_path: str
-            Path for the exported yolov5 data.yml
+            Path for the exported YOLO data.yml
     """
     try:
         import yaml
     except ImportError:
-        raise ImportError('Please run "pip install -U pyyaml" to install yaml first for yolov5 formatted exporting.')
+        raise ImportError('Please run "pip install -U pyyaml" to install yaml first for YOLO formatted exporting.')
 
     # set split_mode
     if train_coco and not val_coco:
@@ -2440,7 +2490,7 @@ def export_coco_as_yolov5(
     val_dir.mkdir(parents=True, exist_ok=True)  # create dir
 
     # create image symlinks and annotation txts
-    export_yolov5_images_and_txts_from_coco_object(
+    export_yolo_images_and_txts_from_coco_object(
         output_dir=train_dir,
         coco=train_coco,
         ignore_negative_samples=train_coco.ignore_negative_samples,
@@ -2448,7 +2498,7 @@ def export_coco_as_yolov5(
         disable_symlink=disable_symlink,
     )
     assert val_coco, "Validation Coco object not set"
-    export_yolov5_images_and_txts_from_coco_object(
+    export_yolo_images_and_txts_from_coco_object(
         output_dir=val_dir,
         coco=val_coco,
         ignore_negative_samples=val_coco.ignore_negative_samples,
@@ -2469,12 +2519,31 @@ def export_coco_as_yolov5(
 
     return yaml_path
 
-
 def export_coco_as_yolov5_via_yml(
     yml_path: str, output_dir: str, train_split_rate: float = 0.9, numpy_seed=0, disable_symlink=False
 ):
     """
-    Exports current COCO dataset in ultralytics/yolov5 format.
+    Deprecated. Please use export_coco_as_yolo_via_yml instead.
+    Calls export_coco_as_yolo_via_yml with the same arguments.
+    """
+    warnings.warn(
+        "export_coco_as_yolov5_via_yml is deprecated. Please use export_coco_as_yolo_via_yml instead.",
+        DeprecationWarning,
+    )
+    export_coco_as_yolo_via_yml(
+        yml_path=yml_path,
+        output_dir=output_dir,
+        train_split_rate=train_split_rate,
+        numpy_seed=numpy_seed,
+        disable_symlink=disable_symlink,
+    )
+
+
+def export_coco_as_yolo_via_yml(
+    yml_path: str, output_dir: str, train_split_rate: float = 0.9, numpy_seed=0, disable_symlink=False
+):
+    """
+    Exports current COCO dataset in ultralytics/YOLO format.
     Creates train val folders with image symlinks and txt files and a data yaml file.
     Uses a yml file as input.
 
@@ -2496,12 +2565,12 @@ def export_coco_as_yolov5_via_yml(
 
     Returns:
         yaml_path: str
-            Path for the exported yolov5 data.yml
+            Path for the exported YOLO data.yml
     """
     try:
         import yaml
     except ImportError:
-        raise ImportError('Please run "pip install -U pyyaml" to install yaml first for yolov5 formatted exporting.')
+        raise ImportError('Please run "pip install -U pyyaml" to install yaml first for YOLO formatted exporting.')
 
     with open(yml_path, "r") as stream:
         config_dict = yaml.safe_load(stream)
@@ -2522,7 +2591,7 @@ def export_coco_as_yolov5_via_yml(
     else:
         val_coco = None
 
-    yaml_path = export_coco_as_yolov5(
+    yaml_path = export_coco_as_yolo(
         output_dir=output_dir,
         train_coco=train_coco,
         val_coco=val_coco,

--- a/tests/test_cocoutils.py
+++ b/tests/test_cocoutils.py
@@ -688,8 +688,7 @@ class TestCocoUtils(unittest.TestCase):
         pass
 
     def test_bbox_clipping(self):
-        from sahi.utils.coco import (Coco, CocoAnnotation, CocoCategory,
-                                     CocoImage)
+        from sahi.utils.coco import Coco, CocoAnnotation, CocoCategory, CocoImage
 
         coco = Coco()
         coco.add_category(CocoCategory(id=0, name="box", supercategory="box"))

--- a/tests/test_cocoutils.py
+++ b/tests/test_cocoutils.py
@@ -351,7 +351,7 @@ class TestCocoUtils(unittest.TestCase):
         if os.path.isdir(output_dir):
             shutil.rmtree(output_dir, ignore_errors=True)
         coco = Coco.from_coco_dict_or_path(coco_dict_path, image_dir=image_dir)
-        coco.export_as_yolov5(output_dir=output_dir, train_split_rate=0.5, numpy_seed=0)
+        coco.export_as_yolo(output_dir=output_dir, train_split_rate=0.5, numpy_seed=0)
 
     def test_update_categories(self):
         coco_path = "tests/data/coco_utils/terrain2_coco.json"
@@ -672,7 +672,7 @@ class TestCocoUtils(unittest.TestCase):
         self.assertEqual(area_filtered_coco.stats["num_annotations"], len(area_filtered_coco.json["annotations"]))
 
     def test_export_coco_as_yolov5(self):
-        from sahi.utils.coco import Coco, export_coco_as_yolov5
+        from sahi.utils.coco import Coco, export_coco_as_yolo
 
         coco_dict_path = "tests/data/coco_utils/combined_coco.json"
         image_dir = "tests/data/coco_utils/"
@@ -680,7 +680,7 @@ class TestCocoUtils(unittest.TestCase):
         if os.path.isdir(output_dir):
             shutil.rmtree(output_dir, ignore_errors=True)
         coco = Coco.from_coco_dict_or_path(coco_dict_path, image_dir=image_dir)
-        export_coco_as_yolov5(output_dir=output_dir, train_coco=coco, val_coco=coco, numpy_seed=0)
+        export_coco_as_yolo(output_dir=output_dir, train_coco=coco, val_coco=coco, numpy_seed=0)
 
     def test_cocovid(self):
         # from sahi.utils.coco import CocoVid
@@ -688,7 +688,8 @@ class TestCocoUtils(unittest.TestCase):
         pass
 
     def test_bbox_clipping(self):
-        from sahi.utils.coco import Coco, CocoAnnotation, CocoCategory, CocoImage
+        from sahi.utils.coco import (Coco, CocoAnnotation, CocoCategory,
+                                     CocoImage)
 
         coco = Coco()
         coco.add_category(CocoCategory(id=0, name="box", supercategory="box"))


### PR DESCRIPTION
- Rename `coco yolov5` command to `coco yolo`
- Update CLI, documentation, and utility functions to support Ultralytics YOLO models
- Deprecate YOLOv5-specific methods in favor of more generic YOLO support
- Update README, CLI, and documentation references to reflect new naming
- Improve compatibility with latest Ultralytics versions