### PR TITLE
Fix empty bbox because of empty shapely_annotation.multipolygon

### DIFF
--- a/sahi/utils/shapely.py
+++ b/sahi/utils/shapely.py
@@ -38,7 +38,10 @@ def get_shapely_multipolygon(coco_segmentation: List[List]) -> MultiPolygon:
         elif isinstance(geometry, MultiPolygon):
             return geometry
         elif isinstance(geometry, GeometryCollection):
-            polygons = [geom for geom in geometry.geoms if isinstance(geom, Polygon)]
+            polygons = [
+                geom.geoms if isinstance(geom, MultiPolygon) else geom
+                for geom in geometry.geoms if isinstance(geom, (Polygon, MultiPolygon))
+            ]
             return MultiPolygon(polygons) if polygons else MultiPolygon()
         return MultiPolygon()
 


### PR DESCRIPTION
Basically, the idea of this "if" section is to filter things like LineString from geometry.geoms but geometry.geoms can contain not only Polygon but MultiPolygon as well. Might be related to #1094, #1118, #1138.

![image](https://github.com/user-attachments/assets/bc773fed-91ea-4393-bc84-db14c6884a51)
