### PR TITLE
Fix: Predict cannot find TIF files in source directory

### DIFF
--- a/sahi/utils/cv.py
+++ b/sahi/utils/cv.py
@@ -18,7 +18,7 @@ from sahi.utils.file import Path
 logger = logging.getLogger("__name__")
 
 IMAGE_EXTENSIONS_LOSSY = [".jpg", ".jpeg"]
-IMAGE_EXTENSIONS_LOSSLESS = [".png", ".tiff", ".bmp"]
+IMAGE_EXTENSIONS_LOSSLESS = [".png", ".tif", ".tiff", ".bmp"]
 IMAGE_EXTENSIONS = IMAGE_EXTENSIONS_LOSSY + IMAGE_EXTENSIONS_LOSSLESS
 VIDEO_EXTENSIONS = [".mp4", ".mkv", ".flv", ".avi", ".ts", ".mpg", ".mov", "wmv"]
 


### PR DESCRIPTION
Add the short-hand TIFF file extension to the `IMAGE_EXTENSIONS_LOSSLESS` list.