### PR TITLE
fix: Update inference method to use 'threshold' instead of 'confidence'

### DIFF
--- a/sahi/models/roboflow.py
+++ b/sahi/models/roboflow.py
@@ -147,7 +147,7 @@ class RoboflowDetectionModel(DetectionModel):
         if self._use_universe:
             self._original_predictions = self.model.infer(image, confidence=self.confidence_threshold)
         else:
-            self._original_predictions = [self.model.predict(image, confidence=self.confidence_threshold)]
+            self._original_predictions = [self.model.predict(image, threshold=self.confidence_threshold)]
 
     def _create_object_prediction_list_from_original_predictions(
         self,


### PR DESCRIPTION
Hello @fcakyon, today I discovered a minor bug in my recent contribution. While testing with a small interactive Gradio app I built for sharing (comming days), I noticed a slight discrepancy between the inference and rfdetr packages regarding the parameter set of the predict method.

* [`sahi/models/roboflow.py`](diffhunk://#diff-74f3a01464f072466c6e7fd5cb49ef747e31488601730d920bb44967b8f72d2cL150-R150): Changed the parameter from `confidence` to `threshold` in the `predict` method call to ensure compatibility with the model's interface.

Apologies for the small PRs ... just trying to keep things tidy. 🙏 