### PR TITLE
Use immutable arguments for bounding boxes

### DIFF
--- a/sahi/annotation.py
+++ b/sahi/annotation.py
@@ -3,7 +3,7 @@
 
 import copy
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 
@@ -23,8 +23,7 @@ class BoundingBox:
     Bounding box of the annotation.
     """
 
-    # TODO: Better use tuple not lists for data that has a defined length and should no mutate a lot
-    def __init__(self, box: List[float], shift_amount: List[int] = [0, 0]):
+    def __init__(self, box: Tuple[float, float, float, float], shift_amount: Tuple[int, int] = (0, 0)):
         """
         Args:
             box: List[float]

--- a/sahi/annotation.py
+++ b/sahi/annotation.py
@@ -26,9 +26,9 @@ class BoundingBox:
     def __init__(self, box: Tuple[float, float, float, float], shift_amount: Tuple[int, int] = (0, 0)):
         """
         Args:
-            box: List[float]
+            box: Tuple[float]
                 [minx, miny, maxx, maxy]
-            shift_amount: List[int]
+            shift_amount: Tuple[int]
                 To shift the box and mask predictions from sliced image
                 to full sized image, should be in the form of [shift_x, shift_y]
         """


### PR DESCRIPTION
Using mutable arguments, especially supplying mutable default arguments, is dangerous. 
Consider the following example:

```py
class A:
    def __init__(self, c=[0, 0]):
        self.c = c

a = A()
b = A()
a.c[0] = 99
print(b.c) 
print(A().c)
```

Will output:

    [99, 0]
    [99, 0]

I.e. changing the mutable default list of a class instance will change the default value for all subsequently created instances.