### PR TITLE
Fix: Models always loaded on "cuda:0" when working inside subprocesses on multi-GPU setups

### DIFF
--- a/sahi/utils/torch_utils.py
+++ b/sahi/utils/torch_utils.py
@@ -68,7 +68,7 @@ def select_device(device: Optional[str] = None) -> "torch.device":
     valid_cuda_id = bool(re.fullmatch(cuda_id_pattern, device))
 
     if not cpu and not mps and torch.cuda.is_available() and valid_cuda_id:  # prefer GPU if available
-        arg = "cuda:" + (device if int(device) < torch.cuda.device_count() else "0")
+        arg = f"cuda:{device}" if device else "cuda:0"
     elif mps and getattr(torch, "has_mps", False) and torch.backends.mps.is_available():  # prefer MPS if available
         arg = "mps"
     else:  # revert to CPU


### PR DESCRIPTION
## Problem

When using and importing torch and **SAHI** inside a **multiprocessing subprocess** in a multi-GPU environment, sometimes
only a single GPU is visible thus torch.cuda.device_count() returns 1. In that case I was having problems loading the model to the correct device. SAHI performs an extra verification: it checks that the requested CUDA device index is < total CUDA devices.
In a subprocess that only sees one GPU (even if the system has multiple GPUs), torch.cuda.device_count() returns 1.
If the code tries to load on "cuda:1" or higher, the verification fails, and SAHI falls back to cuda:0 (the default).

In line 88 of utils/torch_utils.py:
```python
arg = "cuda:" + (device if int(device) < torch.cuda.device_count() else "0")
```
I changed it to remove that extra-verification that prevented loading the model to the right GPU:

```python
arg = f"cuda:{device}" if device else "cuda:0"
```

**Key change:**

* Skip the global check against torch.cuda.device_count().

* Trust the device string/int provided by the user ("cuda:0", 0, "cuda:1", etc.).

* This makes SAHI compatible with the standard multi-GPU pattern where each worker process is pinned to a GPU using CUDA_VISIBLE_DEVICES.

