### PR TITLE
🐛  Update category remapping logic to work with immutable categories

### DIFF
--- a/sahi/models/base.py
+++ b/sahi/models/base.py
@@ -1,3 +1,4 @@
+import dataclasses
 from typing import Any, Dict, List, Optional
 
 import numpy as np
@@ -156,7 +157,7 @@ class DetectionModel:
             for object_prediction in object_prediction_list:
                 old_category_id_str = str(object_prediction.category.id)
                 new_category_id_int = self.category_remapping[old_category_id_str]
-                object_prediction.category.id = new_category_id_int
+                object_prediction.category = dataclasses.replace(object_prediction.category, id=new_category_id_int)
 
     def convert_original_predictions(
         self,


### PR DESCRIPTION
The label remapping logic didn't work with the introduced immutable categories, now it does.
Also added a test for the remapping.

Discussed in:
https://github.com/obss/sahi/discussions/1231#