### PR TITLE
Fix currently failing CI by adding a hatch build target

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,9 @@ requires = ["hatch-mkdocs", "hatch-pip-compile"]
 [tool.hatch.envs.docs]
 detached = false
 
+[tool.hatch.build.targets.wheel]
+packages = ["sahi"]
+
 [tool.hatch.envs.default.scripts]
 
 # Workaround for https://github.com/juftin/hatch-pip-compile/issues/85


### PR DESCRIPTION
Adding

    [tool.hatch.build.targets.wheel]
    packages = ["sahi"]

to the `pyproject.toml` should fix the current CI errors.