### PR TITLE
feat: 🚀 allow per-call confidence_threshold override in prediction APIs

### DIFF
--- a/sahi/predict.py
+++ b/sahi/predict.py
@@ -83,6 +83,7 @@ def get_prediction(
     verbose: int = 0,
     exclude_classes_by_name: list[str] | None = None,
     exclude_classes_by_id: list[int] | None = None,
+    confidence_threshold: float | None = None,
 ) -> PredictionResult:
     """Function for performing prediction for given image using given detection_model.
 
@@ -105,31 +106,31 @@ def get_prediction(
         exclude_classes_by_id: Optional[List[int]]
             None: if no classes are excluded
             List[int]: set of classes to exclude using one or more IDs
+        confidence_threshold: float, optional
+            Override the model's confidence threshold for this call only.
+            The model's original threshold is restored after the call.
     Returns:
         A dict with fields:
             object_prediction_list: a list of ObjectPrediction
             durations_in_seconds: a dict containing elapsed times for profiling
     """
-    durations_in_seconds = dict()
+    original_confidence_threshold = detection_model.confidence_threshold
+    if confidence_threshold is not None:
+        detection_model.confidence_threshold = confidence_threshold
 
-    # read image as pil
+    durations_in_seconds = dict()
     image_as_pil = read_image_as_pil(image)
-    # get prediction
-    # ensure shift_amount is a list instance (avoid mutable default arg)
+
     if shift_amount is None:
         shift_amount = [0, 0]
-
-    time_start = time.perf_counter()
-    detection_model.perform_inference(np.ascontiguousarray(image_as_pil))
-    time_end = time.perf_counter() - time_start
-    durations_in_seconds["prediction"] = time_end
-
     if full_shape is None:
         full_shape = [image_as_pil.height, image_as_pil.width]
 
-    # process prediction
     time_start = time.perf_counter()
-    # works only with 1 batch
+    detection_model.perform_inference(np.ascontiguousarray(image_as_pil))
+    durations_in_seconds["prediction"] = time.perf_counter() - time_start
+
+    time_start = time.perf_counter()
     detection_model.convert_original_predictions(
         shift_amount=shift_amount,  # type: ignore[arg-type]
         full_shape=full_shape,  # type: ignore[arg-type]
@@ -137,19 +138,15 @@ def get_prediction(
     object_prediction_list: list[ObjectPrediction] = detection_model.object_prediction_list
     object_prediction_list = filter_predictions(object_prediction_list, exclude_classes_by_name, exclude_classes_by_id)
 
-    # postprocess matching predictions
     if postprocess is not None:
         object_prediction_list = postprocess(object_prediction_list)
 
-    time_end = time.perf_counter() - time_start
-    durations_in_seconds["postprocess"] = time_end
+    durations_in_seconds["postprocess"] = time.perf_counter() - time_start
 
     if verbose == 1:
-        print(
-            "Prediction performed in",
-            durations_in_seconds["prediction"],
-            "seconds.",
-        )
+        print("Prediction performed in", durations_in_seconds["prediction"], "seconds.")
+
+    detection_model.confidence_threshold = original_confidence_threshold
 
     return PredictionResult(
         image=image, object_prediction_list=object_prediction_list, durations_in_seconds=durations_in_seconds
@@ -179,6 +176,7 @@ def get_sliced_prediction(
     progress_callback: Callable | None = None,
     batch_size: int = 1,
     force_postprocess_type: bool = False,
+    confidence_threshold: float | None = None,
 ) -> PredictionResult:
     """Function for slice image + get predicion for each slice + combine predictions in full image.
 
@@ -248,6 +246,9 @@ def get_sliced_prediction(
             below LOW_MODEL_CONFIDENCE (0.1), the postprocess type will be
             automatically switched to NMS/IOU to avoid bounding box enlargement
             from merge operations. Default: False.
+        confidence_threshold: float, optional
+            Override the model's confidence threshold for this call only.
+            The model's original threshold is restored after the call.
 
     Returns:
         A Dict with fields:
@@ -259,7 +260,10 @@ def get_sliced_prediction(
     if detection_model is None:
         raise ValueError("detection_model must be provided for sliced prediction")
 
-    # for profiling
+    original_confidence_threshold = detection_model.confidence_threshold
+    if confidence_threshold is not None:
+        detection_model.confidence_threshold = confidence_threshold
+
     durations_in_seconds = dict()
 
     # create slices from full image
@@ -277,8 +281,7 @@ def get_sliced_prediction(
     from sahi.models.ultralytics import UltralyticsDetectionModel
 
     num_slices = len(slice_image_result)
-    time_end = time.perf_counter() - time_start
-    durations_in_seconds["slice"] = time_end
+    durations_in_seconds["slice"] = time.perf_counter() - time_start
 
     # auto postprocess type switch for low confidence thresholds
     if (
@@ -297,7 +300,6 @@ def get_sliced_prediction(
         # Only NMS is supported for OBB model outputs
         postprocess_type = "NMS"
 
-    # init match postprocess instance
     if postprocess_type not in POSTPROCESS_NAME_TO_CLASS.keys():
         raise ValueError(
             f"postprocess_type should be one of {list(POSTPROCESS_NAME_TO_CLASS.keys())} "
@@ -327,7 +329,6 @@ def get_sliced_prediction(
     ]
     object_prediction_list = []
     slices_processed = 0
-    # perform sliced prediction
     for batch_ind in slice_iterator:
         batch_start = batch_ind * batch_size
         batch_end = min(batch_start + batch_size, num_slices)
@@ -337,33 +338,28 @@ def get_sliced_prediction(
         ]
         current_batch_size = len(batch_images)
 
-        # perform batch inference
         detection_model.perform_batch_inference([np.ascontiguousarray(img) for img in batch_images])
         detection_model.convert_original_predictions(
             shift_amount=batch_shifts,
             full_shape=[full_shape] * current_batch_size,
         )
 
-        # collect and shift predictions from all images in this batch
         for image_preds in detection_model.object_prediction_list_per_image:
             filtered_preds = filter_predictions(image_preds, exclude_classes_by_name, exclude_classes_by_id)
             for object_prediction in filtered_preds:
-                if object_prediction:  # if not empty
+                if object_prediction:
                     object_prediction_list.append(object_prediction.get_shifted_object_prediction())
 
         slices_processed += current_batch_size
 
-        # merge matching predictions during sliced prediction
         if merge_buffer_length is not None and len(object_prediction_list) > merge_buffer_length:
             postprocess_time_start = time.time()
             object_prediction_list = postprocess(object_prediction_list)
             postprocess_time += time.time() - postprocess_time_start
 
-        # Call progress callback if provided
         if progress_callback is not None:
             progress_callback(slices_processed, num_slices)
 
-    # perform standard prediction
     if num_slices > 1 and perform_standard_pred:
         prediction_result = get_prediction(
             image=image,
@@ -379,7 +375,6 @@ def get_sliced_prediction(
         )
         object_prediction_list.extend(prediction_result.object_prediction_list)
 
-    # merge matching predictions
     if len(object_prediction_list) > 1:
         postprocess_time_start = time.time()
         object_prediction_list = postprocess(object_prediction_list)
@@ -390,21 +385,11 @@ def get_sliced_prediction(
     durations_in_seconds["postprocess"] = postprocess_time
 
     if verbose == 2:
-        print(
-            "Slicing performed in",
-            durations_in_seconds["slice"],
-            "seconds.",
-        )
-        print(
-            "Prediction performed in",
-            durations_in_seconds["prediction"],
-            "seconds.",
-        )
-        print(
-            "Postprocessing performed in",
-            durations_in_seconds["postprocess"],
-            "seconds.",
-        )
+        print("Slicing performed in", durations_in_seconds["slice"], "seconds.")
+        print("Prediction performed in", durations_in_seconds["prediction"], "seconds.")
+        print("Postprocessing performed in", durations_in_seconds["postprocess"], "seconds.")
+
+    detection_model.confidence_threshold = original_confidence_threshold
 
     return PredictionResult(
         image=image, object_prediction_list=object_prediction_list, durations_in_seconds=durations_in_seconds

--- a/sahi/predict.py
+++ b/sahi/predict.py
@@ -109,6 +109,19 @@ def get_prediction(
         confidence_threshold: float, optional
             Override the model's confidence threshold for this call only.
             The model's original threshold is restored after the call.
+
+    Example:
+        >>> from sahi import AutoDetectionModel
+        >>> from sahi.predict import get_prediction
+        >>> model = AutoDetectionModel.from_pretrained(
+        ...     model_type="ultralytics",
+        ...     model_path="yolo11n.pt",
+        ...     confidence_threshold=0.3,
+        ... )
+        >>> # run with a different threshold without changing the model
+        >>> result = get_prediction("image.jpg", model, confidence_threshold=0.7)
+        >>> print(model.confidence_threshold)  # still 0.3
+
     Returns:
         A dict with fields:
             object_prediction_list: a list of ObjectPrediction
@@ -249,6 +262,20 @@ def get_sliced_prediction(
         confidence_threshold: float, optional
             Override the model's confidence threshold for this call only.
             The model's original threshold is restored after the call.
+
+    Example:
+        >>> from sahi import AutoDetectionModel
+        >>> from sahi.predict import get_sliced_prediction
+        >>> model = AutoDetectionModel.from_pretrained(
+        ...     model_type="ultralytics",
+        ...     model_path="yolo11n.pt",
+        ...     confidence_threshold=0.3,
+        ... )
+        >>> # sweep thresholds without recreating the model
+        >>> for thresh in [0.3, 0.5, 0.7]:
+        ...     result = get_sliced_prediction("image.jpg", model, confidence_threshold=thresh)
+        ...     print(thresh, len(result.object_prediction_list))
+        >>> print(model.confidence_threshold)  # still 0.3
 
     Returns:
         A Dict with fields:

--- a/sahi/predict.py
+++ b/sahi/predict.py
@@ -131,35 +131,38 @@ def get_prediction(
     if confidence_threshold is not None:
         detection_model.confidence_threshold = confidence_threshold
 
-    durations_in_seconds = dict()
-    image_as_pil = read_image_as_pil(image)
+    try:
+        durations_in_seconds = dict()
+        image_as_pil = read_image_as_pil(image)
 
-    if shift_amount is None:
-        shift_amount = [0, 0]
-    if full_shape is None:
-        full_shape = [image_as_pil.height, image_as_pil.width]
+        if shift_amount is None:
+            shift_amount = [0, 0]
+        if full_shape is None:
+            full_shape = [image_as_pil.height, image_as_pil.width]
 
-    time_start = time.perf_counter()
-    detection_model.perform_inference(np.ascontiguousarray(image_as_pil))
-    durations_in_seconds["prediction"] = time.perf_counter() - time_start
+        time_start = time.perf_counter()
+        detection_model.perform_inference(np.ascontiguousarray(image_as_pil))
+        durations_in_seconds["prediction"] = time.perf_counter() - time_start
 
-    time_start = time.perf_counter()
-    detection_model.convert_original_predictions(
-        shift_amount=shift_amount,  # type: ignore[arg-type]
-        full_shape=full_shape,  # type: ignore[arg-type]
-    )
-    object_prediction_list: list[ObjectPrediction] = detection_model.object_prediction_list
-    object_prediction_list = filter_predictions(object_prediction_list, exclude_classes_by_name, exclude_classes_by_id)
+        time_start = time.perf_counter()
+        detection_model.convert_original_predictions(
+            shift_amount=shift_amount,  # type: ignore[arg-type]
+            full_shape=full_shape,  # type: ignore[arg-type]
+        )
+        object_prediction_list: list[ObjectPrediction] = detection_model.object_prediction_list
+        object_prediction_list = filter_predictions(
+            object_prediction_list, exclude_classes_by_name, exclude_classes_by_id
+        )
 
-    if postprocess is not None:
-        object_prediction_list = postprocess(object_prediction_list)
+        if postprocess is not None:
+            object_prediction_list = postprocess(object_prediction_list)
 
-    durations_in_seconds["postprocess"] = time.perf_counter() - time_start
+        durations_in_seconds["postprocess"] = time.perf_counter() - time_start
 
-    if verbose == 1:
-        print("Prediction performed in", durations_in_seconds["prediction"], "seconds.")
-
-    detection_model.confidence_threshold = original_confidence_threshold
+        if verbose == 1:
+            print("Prediction performed in", durations_in_seconds["prediction"], "seconds.")
+    finally:
+        detection_model.confidence_threshold = original_confidence_threshold
 
     return PredictionResult(
         image=image, object_prediction_list=object_prediction_list, durations_in_seconds=durations_in_seconds
@@ -291,132 +294,133 @@ def get_sliced_prediction(
     if confidence_threshold is not None:
         detection_model.confidence_threshold = confidence_threshold
 
-    durations_in_seconds = dict()
+    try:
+        durations_in_seconds = dict()
 
-    # create slices from full image
-    time_start = time.perf_counter()
-    slice_image_result = slice_image(
-        image=image,
-        output_file_name=slice_export_prefix,
-        output_dir=slice_dir,
-        slice_height=slice_height,
-        slice_width=slice_width,
-        overlap_height_ratio=overlap_height_ratio,
-        overlap_width_ratio=overlap_width_ratio,
-        auto_slice_resolution=auto_slice_resolution,
-    )
-    from sahi.models.ultralytics import UltralyticsDetectionModel
-
-    num_slices = len(slice_image_result)
-    durations_in_seconds["slice"] = time.perf_counter() - time_start
-
-    # auto postprocess type switch for low confidence thresholds
-    if (
-        not force_postprocess_type
-        and detection_model.confidence_threshold < LOW_MODEL_CONFIDENCE
-        and postprocess_type != "NMS"
-    ):
-        logger.warning(
-            f"Switching postprocess type/metric to NMS/IOU since model confidence "
-            f"threshold is low ({detection_model.confidence_threshold})."
+        # create slices from full image
+        time_start = time.perf_counter()
+        slice_image_result = slice_image(
+            image=image,
+            output_file_name=slice_export_prefix,
+            output_dir=slice_dir,
+            slice_height=slice_height,
+            slice_width=slice_width,
+            overlap_height_ratio=overlap_height_ratio,
+            overlap_width_ratio=overlap_width_ratio,
+            auto_slice_resolution=auto_slice_resolution,
         )
-        postprocess_type = "NMS"
-        postprocess_match_metric = "IOU"
+        from sahi.models.ultralytics import UltralyticsDetectionModel
 
-    if isinstance(detection_model, UltralyticsDetectionModel) and detection_model.is_obb:
-        # Only NMS is supported for OBB model outputs
-        postprocess_type = "NMS"
+        num_slices = len(slice_image_result)
+        durations_in_seconds["slice"] = time.perf_counter() - time_start
 
-    if postprocess_type not in POSTPROCESS_NAME_TO_CLASS.keys():
-        raise ValueError(
-            f"postprocess_type should be one of {list(POSTPROCESS_NAME_TO_CLASS.keys())} "
-            f"but given as {postprocess_type}"
+        # auto postprocess type switch for low confidence thresholds
+        if (
+            not force_postprocess_type
+            and detection_model.confidence_threshold < LOW_MODEL_CONFIDENCE
+            and postprocess_type != "NMS"
+        ):
+            logger.warning(
+                f"Switching postprocess type/metric to NMS/IOU since model confidence "
+                f"threshold is low ({detection_model.confidence_threshold})."
+            )
+            postprocess_type = "NMS"
+            postprocess_match_metric = "IOU"
+
+        if isinstance(detection_model, UltralyticsDetectionModel) and detection_model.is_obb:
+            # Only NMS is supported for OBB model outputs
+            postprocess_type = "NMS"
+
+        if postprocess_type not in POSTPROCESS_NAME_TO_CLASS.keys():
+            raise ValueError(
+                f"postprocess_type should be one of {list(POSTPROCESS_NAME_TO_CLASS.keys())} "
+                f"but given as {postprocess_type}"
+            )
+        postprocess_constructor = POSTPROCESS_NAME_TO_CLASS[postprocess_type]
+        postprocess = postprocess_constructor(
+            match_threshold=postprocess_match_threshold,
+            match_metric=postprocess_match_metric,
+            class_agnostic=postprocess_class_agnostic,
         )
-    postprocess_constructor = POSTPROCESS_NAME_TO_CLASS[postprocess_type]
-    postprocess = postprocess_constructor(
-        match_threshold=postprocess_match_threshold,
-        match_metric=postprocess_match_metric,
-        class_agnostic=postprocess_class_agnostic,
-    )
 
-    postprocess_time = 0.0
-    time_start = time.perf_counter()
-    num_batches = (num_slices + batch_size - 1) // batch_size
-    if verbose == 1 or verbose == 2:
-        tqdm.write(f"Performing prediction on {num_slices} slices.")
+        postprocess_time = 0.0
+        time_start = time.perf_counter()
+        num_batches = (num_slices + batch_size - 1) // batch_size
+        if verbose == 1 or verbose == 2:
+            tqdm.write(f"Performing prediction on {num_slices} slices.")
 
-    if progress_bar:
-        slice_iterator = tqdm(range(num_batches), desc="Processing slices", total=num_batches)
-    else:
-        slice_iterator = range(num_batches)
+        if progress_bar:
+            slice_iterator = tqdm(range(num_batches), desc="Processing slices", total=num_batches)
+        else:
+            slice_iterator = range(num_batches)
 
-    full_shape: list[int | float] = [
-        slice_image_result.original_image_height,
-        slice_image_result.original_image_width,
-    ]
-    object_prediction_list = []
-    slices_processed = 0
-    for batch_ind in slice_iterator:
-        batch_start = batch_ind * batch_size
-        batch_end = min(batch_start + batch_size, num_slices)
-        batch_images = [slice_image_result.images[i] for i in range(batch_start, batch_end)]
-        batch_shifts: list[list[int | float]] = [
-            list(slice_image_result.starting_pixels[i]) for i in range(batch_start, batch_end)
+        full_shape: list[int | float] = [
+            slice_image_result.original_image_height,
+            slice_image_result.original_image_width,
         ]
-        current_batch_size = len(batch_images)
+        object_prediction_list = []
+        slices_processed = 0
+        for batch_ind in slice_iterator:
+            batch_start = batch_ind * batch_size
+            batch_end = min(batch_start + batch_size, num_slices)
+            batch_images = [slice_image_result.images[i] for i in range(batch_start, batch_end)]
+            batch_shifts: list[list[int | float]] = [
+                list(slice_image_result.starting_pixels[i]) for i in range(batch_start, batch_end)
+            ]
+            current_batch_size = len(batch_images)
 
-        detection_model.perform_batch_inference([np.ascontiguousarray(img) for img in batch_images])
-        detection_model.convert_original_predictions(
-            shift_amount=batch_shifts,
-            full_shape=[full_shape] * current_batch_size,
-        )
+            detection_model.perform_batch_inference([np.ascontiguousarray(img) for img in batch_images])
+            detection_model.convert_original_predictions(
+                shift_amount=batch_shifts,
+                full_shape=[full_shape] * current_batch_size,
+            )
 
-        for image_preds in detection_model.object_prediction_list_per_image:
-            filtered_preds = filter_predictions(image_preds, exclude_classes_by_name, exclude_classes_by_id)
-            for object_prediction in filtered_preds:
-                if object_prediction:
-                    object_prediction_list.append(object_prediction.get_shifted_object_prediction())
+            for image_preds in detection_model.object_prediction_list_per_image:
+                filtered_preds = filter_predictions(image_preds, exclude_classes_by_name, exclude_classes_by_id)
+                for object_prediction in filtered_preds:
+                    if object_prediction:
+                        object_prediction_list.append(object_prediction.get_shifted_object_prediction())
 
-        slices_processed += current_batch_size
+            slices_processed += current_batch_size
 
-        if merge_buffer_length is not None and len(object_prediction_list) > merge_buffer_length:
+            if merge_buffer_length is not None and len(object_prediction_list) > merge_buffer_length:
+                postprocess_time_start = time.time()
+                object_prediction_list = postprocess(object_prediction_list)
+                postprocess_time += time.time() - postprocess_time_start
+
+            if progress_callback is not None:
+                progress_callback(slices_processed, num_slices)
+
+        if num_slices > 1 and perform_standard_pred:
+            prediction_result = get_prediction(
+                image=image,
+                detection_model=detection_model,
+                shift_amount=[0, 0],
+                full_shape=[
+                    slice_image_result.original_image_height,
+                    slice_image_result.original_image_width,
+                ],
+                postprocess=None,
+                exclude_classes_by_name=exclude_classes_by_name,
+                exclude_classes_by_id=exclude_classes_by_id,
+            )
+            object_prediction_list.extend(prediction_result.object_prediction_list)
+
+        if len(object_prediction_list) > 1:
             postprocess_time_start = time.time()
             object_prediction_list = postprocess(object_prediction_list)
             postprocess_time += time.time() - postprocess_time_start
 
-        if progress_callback is not None:
-            progress_callback(slices_processed, num_slices)
+        time_end = time.perf_counter() - time_start
+        durations_in_seconds["prediction"] = time_end - postprocess_time
+        durations_in_seconds["postprocess"] = postprocess_time
 
-    if num_slices > 1 and perform_standard_pred:
-        prediction_result = get_prediction(
-            image=image,
-            detection_model=detection_model,
-            shift_amount=[0, 0],
-            full_shape=[
-                slice_image_result.original_image_height,
-                slice_image_result.original_image_width,
-            ],
-            postprocess=None,
-            exclude_classes_by_name=exclude_classes_by_name,
-            exclude_classes_by_id=exclude_classes_by_id,
-        )
-        object_prediction_list.extend(prediction_result.object_prediction_list)
-
-    if len(object_prediction_list) > 1:
-        postprocess_time_start = time.time()
-        object_prediction_list = postprocess(object_prediction_list)
-        postprocess_time += time.time() - postprocess_time_start
-
-    time_end = time.perf_counter() - time_start
-    durations_in_seconds["prediction"] = time_end - postprocess_time
-    durations_in_seconds["postprocess"] = postprocess_time
-
-    if verbose == 2:
-        print("Slicing performed in", durations_in_seconds["slice"], "seconds.")
-        print("Prediction performed in", durations_in_seconds["prediction"], "seconds.")
-        print("Postprocessing performed in", durations_in_seconds["postprocess"], "seconds.")
-
-    detection_model.confidence_threshold = original_confidence_threshold
+        if verbose == 2:
+            print("Slicing performed in", durations_in_seconds["slice"], "seconds.")
+            print("Prediction performed in", durations_in_seconds["prediction"], "seconds.")
+            print("Postprocessing performed in", durations_in_seconds["postprocess"], "seconds.")
+    finally:
+        detection_model.confidence_threshold = original_confidence_threshold
 
     return PredictionResult(
         image=image, object_prediction_list=object_prediction_list, durations_in_seconds=durations_in_seconds

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -16,7 +16,7 @@ from sahi.predict import get_prediction, get_sliced_prediction, predict
 from sahi.utils.cv import read_image
 from sahi.utils.file import download_from_url
 
-from .utils.ultralytics import UltralyticsConstants, download_yolo11n_model
+from .utils.ultralytics import UltralyticsConstants, download_yolo11n_model, download_yolo26n_model
 
 MODEL_DEVICE = "cpu"
 CONFIDENCE_THRESHOLD = 0.5
@@ -353,6 +353,61 @@ def test_get_sliced_prediction_yolo11() -> None:
         if object_prediction.category.name == "car":
             num_car += 1
     assert num_car > 0
+
+
+def test_confidence_threshold_override_yolo26() -> None:
+    """Per-call confidence_threshold override takes effect and is always restored."""
+    download_yolo26n_model()
+
+    model = UltralyticsDetectionModel(
+        model_path=UltralyticsConstants.YOLO26N_MODEL_PATH,
+        confidence_threshold=0.3,
+        device=MODEL_DEVICE,
+        category_remapping=None,
+        load_at_init=False,
+        image_size=IMAGE_SIZE,
+    )
+    model.load_model()
+    original = model.confidence_threshold
+
+    image_path = "tests/data/small-vehicles1.jpeg"
+
+    # override filters more aggressively than the baseline
+    baseline = get_prediction(image=image_path, detection_model=model, postprocess=None)
+    high = get_prediction(image=image_path, detection_model=model, confidence_threshold=0.99, postprocess=None)
+    assert len(high.object_prediction_list) <= len(baseline.object_prediction_list)
+    assert model.confidence_threshold == original
+
+    # sliced path: threshold sweep should be monotonically non-increasing in count
+    counts = []
+    for thresh in (0.2, 0.5, 0.9):
+        res = get_sliced_prediction(
+            image=image_path,
+            detection_model=model,
+            confidence_threshold=thresh,
+            slice_height=512,
+            slice_width=512,
+            overlap_height_ratio=0.1,
+            overlap_width_ratio=0.2,
+            perform_standard_pred=False,
+        )
+        counts.append(len(res.object_prediction_list))
+        assert model.confidence_threshold == original
+    assert counts == sorted(counts, reverse=True)
+
+    # threshold must be restored even if inference raises
+    original_perform_inference = model.perform_inference
+
+    def boom(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("inference failure")
+
+    model.perform_inference = boom  # type: ignore[assignment]
+    try:
+        with pytest.raises(RuntimeError):
+            get_prediction(image=image_path, detection_model=model, confidence_threshold=0.123, postprocess=None)
+        assert model.confidence_threshold == original
+    finally:
+        model.perform_inference = original_perform_inference  # type: ignore[assignment]
 
 
 def test_get_sliced_prediction_batch_size() -> None:

--- a/tests/utils/ultralytics.py
+++ b/tests/utils/ultralytics.py
@@ -11,6 +11,7 @@ from tqdm import tqdm
 YOLO11N_WEIGHTS_URL = "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n.pt"
 YOLO11N_SEG_WEIGHTS_URL = "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n-seg.pt"
 YOLO11N_OBB_WEIGHTS_URL = "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n-obb.pt"
+YOLO26N_WEIGHTS_URL = "https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26n.pt"
 
 
 class UltralyticsConstants:
@@ -20,6 +21,7 @@ class UltralyticsConstants:
     YOLO11N_SEG_MODEL_PATH = "tests/data/models/yolo11n-seg.pt"
     YOLO11N_OBB_MODEL_PATH = "tests/data/models/yolo11n-obb.pt"
     YOLO11N_ONNX_MODEL_PATH = "tests/data/models/yolo11/yolo11n.onnx"
+    YOLO26N_MODEL_PATH = "tests/data/models/yolo26n.pt"
 
 
 def download_file(url: str, save_path: str, chunk_size: int = 8192) -> None:
@@ -75,6 +77,16 @@ def download_yolo11n_obb_model(destination_path: str | None = None) -> str:
 
     if not os.path.exists(destination_path):
         download_file(YOLO11N_OBB_WEIGHTS_URL, destination_path)
+    return destination_path
+
+
+def download_yolo26n_model(destination_path: str | None = None) -> str:
+    """Downloads YOLO26n model if not already downloaded."""
+    if destination_path is None:
+        destination_path = UltralyticsConstants.YOLO26N_MODEL_PATH
+
+    if not os.path.exists(destination_path):
+        download_file(YOLO26N_WEIGHTS_URL, destination_path)
     return destination_path
 
 


### PR DESCRIPTION
`AutoDetectionModel.from_pretrained()` has always accepted `confidence_threshold`, but `get_prediction()` and `get_sliced_prediction()` had no way to override it without mutating the model object directly. This made dynamic threshold usage (e.g. sweeping thresholds, per-image tuning) awkward.

Both functions now accept an optional confidence_threshold parameter. When provided, it overrides `detection_model.confidence_threshold` for that call and restores the original value before returning, so the model state is unchanged after the call.

```python
result = get_sliced_prediction(image, model, confidence_threshold=0.7)
# model.confidence_threshold is unchanged after this call
```

Related discussion topic: https://github.com/obss/sahi/discussions/1269