### PR TITLE
Fix numba parity mismatches with numpy and torchvision

### DIFF
--- a/sahi/postprocess/_numba_backend.py
+++ b/sahi/postprocess/_numba_backend.py
@@ -143,10 +143,10 @@ def _greedy_nmm_numba_inner(
     areas: NDArray,
     match_threshold: float,
     use_iou: bool,
-) -> tuple[list[int], NDArray]:
+) -> tuple[list[int], NDArray, NDArray]:
     """Core greedy NMM loop — fully JIT-compiled.
 
-    Returns (keep_order, keeper_of) where keeper_of[i] = keeper index for box i, or -1 if keeper.
+    Returns (keep_order, keeper_of, sorted_idxs) where keeper_of[i] = keeper index for box i, or -1 if keeper.
     """
     n = len(scores)
     sorted_idxs = _argsort_descending(scores, x1, y1, x2, y2)
@@ -181,7 +181,7 @@ def _greedy_nmm_numba_inner(
                 suppressed[cand] = True
                 keeper_of[cand] = idx
 
-    return keep_order, keeper_of
+    return keep_order, keeper_of, sorted_idxs
 
 
 @numba.njit(cache=True)
@@ -242,7 +242,7 @@ def greedy_nmm_numba(
     scores = preds[:, 4]
     areas = (x2 - x1) * (y2 - y1)
 
-    keep_order, keeper_of = _greedy_nmm_numba_inner(
+    keep_order, keeper_of, sorted_idxs = _greedy_nmm_numba_inner(
         x1, y1, x2, y2, scores, areas, match_threshold, match_metric == "IOU"
     )
 
@@ -250,7 +250,7 @@ def greedy_nmm_numba(
     keep_to_merge: dict[int, list[int]] = {}
     for k in keep_order:
         keep_to_merge[int(k)] = []
-    for i in range(len(keeper_of)):
+    for i in sorted_idxs:
         if keeper_of[i] >= 0:
             keep_to_merge[int(keeper_of[i])].append(int(i))
 

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -497,6 +497,26 @@ class TestNumbaBackend:
         preds = np.array(PREDS_NMM, dtype=np.float32)
         assert greedy_nmm_numpy(preds, "IOU", 0.1) == greedy_nmm_numba(preds, "IOU", 0.1)
 
+    def test_greedy_nmm_merge_order_parity(self) -> None:
+        """Test numba preserves numpy greedy NMM merge ordering."""
+        from sahi.postprocess._numba_backend import greedy_nmm_numba
+        from sahi.postprocess._numpy_backend import greedy_nmm_numpy
+
+        preds = np.array(
+            [
+                make_pred(0, 0, 10, 10, 0.7, 1),
+                make_pred(0, 0, 10, 10, 0.8, 1),
+                make_pred(0, 0, 10, 10, 0.9, 1),
+            ],
+            dtype=np.float32,
+        )
+
+        expected = {2: [1, 0]}
+        assert greedy_nmm_numpy(preds, "IOU", 0.5) == expected
+        assert greedy_nmm_numba(preds, "IOU", 0.5) == expected
+        assert greedy_nmm_numpy(preds, "IOS", 0.5) == expected
+        assert greedy_nmm_numba(preds, "IOS", 0.5) == expected
+
     def test_nmm_parity(self) -> None:
         """Test numba and numpy NMM parity."""
         from sahi.postprocess._numba_backend import nmm_numba


### PR DESCRIPTION
## Summary

Fixes a GreedyNMM parity mismatch in the numba postprocess backend.

The numpy and torchvision GreedyNMM paths preserve score-sorted candidate order when building each keeper's merge list. The numba backend found candidates in score-sorted order, but reconstructed `keep_to_merge` by iterating over original prediction indices, which could produce a different merge order.

Since `_apply_merge()` applies merges sequentially and re-checks matches after each merge, merge order is part of the postprocess semantics.

## Changes

- Return `sorted_idxs` from the numba GreedyNMM inner loop.
- Reconstruct numba `keep_to_merge` using `sorted_idxs` order.
- Add a regression test covering merge-order parity for both IOU and IOS.

## Tests

```bash
PYTHONPATH=. python -m pytest -p no:rerunfailures tests/test_combine.py::TestNumbaBackend -q