### PR TITLE
docs: include YOLO26 in CLI model list

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -72,7 +72,7 @@ sahi predict --slice_width 512 --slice_height 512 \
 **Detection Framework:**
 
 - `--model_type mmdet` - For MMDetection models
-- `--model_type ultralytics` - For Ultralytics/YOLOv5/YOLO11 models
+- `--model_type ultralytics` - For Ultralytics/YOLOv5/YOLO11/YOLO26 models
 - `--model_type huggingface` - For HuggingFace models
 - `--model_type torchvision` - For Torchvision models
 

--- a/docs/zh/cli.md
+++ b/docs/zh/cli.md
@@ -70,7 +70,7 @@ sahi predict --slice_width 512 --slice_height 512 \
 ## 检测框架：
 
 - `--model_type mmdet` - 用于 MMDetection 模型
-- `--model_type ultralytics` - 用于 Ultralytics/YOLOv5/YOLO11 模型
+- `--model_type ultralytics` - 用于 Ultralytics/YOLOv5/YOLO11/YOLO26 模型
 - `--model_type huggingface` - 用于 HuggingFace 模型
 - `--model_type torchvision` - 用于 Torchvision 模型
 


### PR DESCRIPTION
## What

Updates the CLI documentation to list YOLO26 alongside the other Ultralytics model families.

## Why

SAHI already supports YOLO26 via the Ultralytics model type, and other docs/examples reference `yolo26n.pt`. The CLI docs still listed only YOLOv5/YOLO11 in the model type summary.

## How tested

- `git diff --check`

## Notes

Documentation-only change.
