### PR TITLE
Support local RF-DETR models by class name and fix Roboflow docs

### DIFF
--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -390,14 +390,36 @@ Use Roboflow's RF-DETR models for detection and segmentation.
 pip install rfdetr
 ```
 
-```python
-detection_model = AutoDetectionModel.from_pretrained(
-    model_type="roboflow",
-    model_path="rfdetr-base",
-    confidence_threshold=0.3,
-    device="cuda:0",
-)
+Pass the model with the `model` argument. A plain string is treated as a Roboflow Universe
+model id and requires an API key; an RF-DETR class name selects a local model instead.
 
+=== "Roboflow Universe (API key)"
+
+    ```python
+    detection_model = AutoDetectionModel.from_pretrained(
+        model_type="roboflow",
+        model="rfdetr-base",  # Universe model id
+        api_key="YOUR_API_KEY",  # or set ROBOFLOW_API_KEY
+        confidence_threshold=0.3,
+        device="cuda:0",
+    )
+    ```
+
+=== "Local weights (no API key)"
+
+    ```python
+    detection_model = AutoDetectionModel.from_pretrained(
+        model_type="roboflow",
+        model="RFDETRSegMedium",  # RF-DETR class name, or the class/instance itself
+        model_path="checkpoint.pth",  # your locally trained weights
+        category_mapping={"0": "cat", "1": "dog"},  # required for custom classes
+        image_size=640,  # must match the training resolution
+        confidence_threshold=0.3,
+        device="cuda:0",
+    )
+    ```
+
+```python
 result = get_sliced_prediction(
     "image.jpg",
     detection_model,
@@ -405,6 +427,12 @@ result = get_sliced_prediction(
     slice_width=512,
 )
 ```
+
+Available RF-DETR models: `RFDETRBase`, `RFDETRNano`, `RFDETRSmall`, `RFDETRMedium`, `RFDETRLarge`,
+`RFDETRSegNano`, `RFDETRSegSmall`, `RFDETRSegMedium`, `RFDETRSegLarge`, `RFDETRSegXLarge`, `RFDETRSeg2XLarge`.
+
+`category_mapping` determines `num_classes`, so a custom model needs it or the head will not match
+the checkpoint. `image_size` is only applied when `model_path` is set.
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/obss/sahi/blob/main/demo/inference_for_roboflow.ipynb)
 

--- a/sahi/models/roboflow.py
+++ b/sahi/models/roboflow.py
@@ -16,6 +16,20 @@ from sahi.prediction import ObjectPrediction
 from sahi.utils.compatibility import fix_full_shape_list, fix_shift_amount_list
 from sahi.utils.cv import get_bbox_from_bool_mask, get_coco_segmentation_from_bool_mask
 
+RFDETR_MODEL_NAMES = (
+    "RFDETRBase",
+    "RFDETRNano",
+    "RFDETRSmall",
+    "RFDETRMedium",
+    "RFDETRLarge",
+    "RFDETRSegNano",
+    "RFDETRSegSmall",
+    "RFDETRSegMedium",
+    "RFDETRSegLarge",
+    "RFDETRSegXLarge",
+    "RFDETRSeg2XLarge",
+)
+
 
 class RoboflowDetectionModel(DetectionModel):
     """Roboflow object detection model.
@@ -62,7 +76,9 @@ class RoboflowDetectionModel(DetectionModel):
             image_size: int
                 Inference input size.
         """
-        self._use_universe = model and isinstance(model, str)
+        # A string is a Roboflow Universe model id, except when it exactly names an
+        # RF-DETR class, which selects a local model and never contacts the API.
+        self._use_universe = bool(model) and isinstance(model, str) and model not in RFDETR_MODEL_NAMES
         self._model = model
         self._device = device
         self._api_key = api_key
@@ -126,47 +142,16 @@ class RoboflowDetectionModel(DetectionModel):
             )
 
         else:
-            from rfdetr.detr import (
-                RFDETRBase,
-                RFDETRLarge,
-                RFDETRMedium,
-                RFDETRNano,
-                RFDETRSeg2XLarge,
-                RFDETRSegLarge,
-                RFDETRSegMedium,
-                RFDETRSegNano,
-                RFDETRSegSmall,
-                RFDETRSegXLarge,
-                RFDETRSmall,
-            )
+            import rfdetr.detr
 
             model, model_path = self._model, self.model_path
-            model_names = (
-                "RFDETRBase",
-                "RFDETRNano",
-                "RFDETRSmall",
-                "RFDETRMedium",
-                "RFDETRLarge",
-                "RFDETRSegNano",
-                "RFDETRSegSmall",
-                "RFDETRSegMedium",
-                "RFDETRSegLarge",
-                "RFDETRSegXLarge",
-                "RFDETRSeg2XLarge",
-            )
-            model_types = (
-                RFDETRBase,
-                RFDETRNano,
-                RFDETRSmall,
-                RFDETRMedium,
-                RFDETRLarge,
-                RFDETRSegNano,
-                RFDETRSegSmall,
-                RFDETRSegMedium,
-                RFDETRSegLarge,
-                RFDETRSegXLarge,
-                RFDETRSeg2XLarge,
-            )
+            model_names = RFDETR_MODEL_NAMES
+            model_types = tuple(getattr(rfdetr.detr, name) for name in RFDETR_MODEL_NAMES)
+
+            # Accept the class name as a string so local models work without importing rfdetr.
+            if isinstance(model, str) and model in model_names:
+                model = getattr(rfdetr.detr, model)
+
             if hasattr(model, "__name__") and model.__name__ in model_names:
                 model_params = dict(
                     device=self._device,
@@ -182,7 +167,10 @@ class RoboflowDetectionModel(DetectionModel):
                 model = model
             else:
                 raise ValueError(
-                    f"Model must be a Roboflow model string or one of {model_names} models, got {self.model}."
+                    f"Could not resolve a local RF-DETR model from {self._model!r}. Pass `model` as one of "
+                    f"{model_names} (the class, an instance, or its name as a string) together with "
+                    "`model_path` for local weights. Note that any other string is treated as a Roboflow "
+                    "Universe model id and requires an API key."
                 )
 
         self.set_model(model)

--- a/tests/test_roboflow.py
+++ b/tests/test_roboflow.py
@@ -162,3 +162,42 @@ def test_rfdetr_seg() -> None:
 
         sliced_predictions = sliced_results.object_prediction_list
         assert len(sliced_predictions) > len(predictions)
+
+
+def test_rfdetr_seg_by_class_name() -> None:
+    """An RF-DETR class name string selects a local model instead of Roboflow Universe."""
+    from rfdetr.assets.coco_classes import COCO_CLASSES
+
+    model = AutoDetectionModel.from_pretrained(
+        model_type="roboflow",
+        model="RFDETRSegMedium",
+        confidence_threshold=0.5,
+        category_mapping=COCO_CLASSES,
+        image_size=432,
+        device="cpu",
+    )
+
+    assert model.has_mask
+
+    result = get_prediction(read_image("tests/data/small-vehicles1.jpeg"), model)
+    assert len(result.object_prediction_list) > 0
+
+
+def test_rfdetr_class_name_does_not_use_universe() -> None:
+    """Class-name strings must not be routed to the API, plain strings must be."""
+    from sahi.models.roboflow import RoboflowDetectionModel
+
+    local = RoboflowDetectionModel(model="RFDETRSegMedium", load_at_init=False)
+    assert local._use_universe is False
+
+    universe = RoboflowDetectionModel(model="rfdetr-base", load_at_init=False)
+    assert universe._use_universe is True
+
+
+def test_rfdetr_unresolvable_model_raises() -> None:
+    """An unusable local model reports how to pass a local RF-DETR model."""
+    from sahi.models.roboflow import RoboflowDetectionModel
+
+    detection_model = RoboflowDetectionModel(model=None, load_at_init=False)
+    with pytest.raises(ValueError, match="Could not resolve a local RF-DETR model"):
+        detection_model.load_model()


### PR DESCRIPTION
Fixes the confusion reported in #1388, where a locally trained RF-DETR model kept asking for a Roboflow API key.

`RoboflowDetectionModel` routed on `isinstance(model, str)` alone, so any string went to the Roboflow Universe API. Local models were only reachable by importing an `rfdetr` class.

The docs example for local use was broken: it passed `model_path="rfdetr-base"` with no `model=`, which raises `ValueError`. It is replaced with working Universe and local-weights examples, plus notes that `category_mapping` sets `num_classes` and that `image_size` only applies when `model_path` is set.