### PR TITLE
Added labelme json file slicing, Enhanced annotation filtering with min_width_height parameter.

### DIFF
--- a/sahi/slicing.py
+++ b/sahi/slicing.py
@@ -123,7 +123,10 @@ def annotation_inside_slice(annotation: dict, slice_bbox: list[int]) -> bool:
 
 
 def process_coco_annotations(
-    coco_annotation_list: list[CocoAnnotation], slice_bbox: list[int], min_area_ratio: float
+    coco_annotation_list: list[CocoAnnotation],
+    slice_bbox: list[int],
+    min_area_ratio: float,
+    min_width_height: float | None = None,
 ) -> list[CocoAnnotation]:
     """Slices and filters given list of CocoAnnotation objects with given 'slice_bbox' and 'min_area_ratio'.
 
@@ -135,6 +138,9 @@ def process_coco_annotations(
         min_area_ratio (float): If the cropped annotation area to original
             annotation ratio is smaller than this value, the annotation is
             filtered out. Default 0.1.
+        min_width_height (float | None): If provided, an annotation is filtered
+            out only when BOTH sliced width and height are smaller than this
+            threshold and its area ratio is smaller than ``min_area_ratio``.
 
     Returns:
         (List[CocoAnnotation]): Sliced annotations.
@@ -143,8 +149,30 @@ def process_coco_annotations(
     for coco_annotation in coco_annotation_list:
         if annotation_inside_slice(coco_annotation.json, slice_bbox):
             sliced_coco_annotation = coco_annotation.get_sliced_coco_annotation(slice_bbox)
-            if sliced_coco_annotation.area / coco_annotation.area >= min_area_ratio:
-                sliced_coco_annotation_list.append(sliced_coco_annotation)
+            original_area = coco_annotation.area
+            if original_area <= 0:
+                continue
+            area_ratio = sliced_coco_annotation.area / original_area
+            if min_width_height is None:
+                if area_ratio >= min_area_ratio:
+                    sliced_coco_annotation_list.append(sliced_coco_annotation)
+            else:
+                sliced_bbox = sliced_coco_annotation.bbox
+                if len(sliced_bbox) >= 4:
+                    sliced_width = sliced_bbox[2]
+                    sliced_height = sliced_bbox[3]
+                else:
+                    # Degenerate intersections can produce non-area geometries
+                    # without a valid xywh bbox; treat their size as zero.
+                    sliced_width = 0.0
+                    sliced_height = 0.0
+                should_filter = (
+                    area_ratio < min_area_ratio
+                    and sliced_width < min_width_height
+                    and sliced_height < min_width_height
+                )
+                if not should_filter:
+                    sliced_coco_annotation_list.append(sliced_coco_annotation)
     return sliced_coco_annotation_list
 
 

--- a/sahi/slicing.py
+++ b/sahi/slicing.py
@@ -775,3 +775,212 @@ def shift_masks(masks: np.ndarray, offset: Sequence[int], full_shape: Sequence[i
         shifted_masks.append(mask.bool_mask)
 
     return np.stack(shifted_masks, axis=0)
+
+
+def _normalize_labelme_points(shape: dict) -> list[list[float]]:
+    """Extract and normalize Labelme points to ``[[x, y], ...]``."""
+    points = shape.get("points")
+    if not isinstance(points, list) or not points:
+        raise ValueError("Each Labelme shape must have a non-empty 'points' list.")
+
+    normalized_points: list[list[float]] = []
+    for point in points:
+        if not isinstance(point, list) or len(point) < 2:
+            raise ValueError("Each point in Labelme shape must be a list with at least 2 values.")
+        normalized_points.append([float(point[0]), float(point[1])])
+    return normalized_points
+
+
+def _labelme_shape_to_coco_annotation(shape: dict, category_id: int) -> CocoAnnotation:
+    """Convert one Labelme shape to a CocoAnnotation."""
+    if "label" not in shape:
+        raise ValueError("Each Labelme shape must include a 'label' field.")
+
+    category_name = str(shape["label"])
+    shape_type = shape.get("shape_type", "polygon")
+    points = _normalize_labelme_points(shape)
+
+    if shape_type == "polygon":
+        if len(points) < 3:
+            raise ValueError("Labelme polygon shape must include at least 3 points.")
+        segmentation = [[coord for point in points for coord in point]]
+        return CocoAnnotation.from_coco_segmentation(
+            segmentation=segmentation,
+            category_id=category_id,
+            category_name=category_name,
+        )
+
+    if shape_type == "rectangle":
+        xs = [point[0] for point in points]
+        ys = [point[1] for point in points]
+        x_min, x_max = min(xs), max(xs)
+        y_min, y_max = min(ys), max(ys)
+        return CocoAnnotation.from_coco_bbox(
+            bbox=[x_min, y_min, x_max - x_min, y_max - y_min],
+            category_id=category_id,
+            category_name=category_name,
+        )
+
+    # Fallback for unsupported shape types: approximate with tight bbox.
+    logger.warning(
+        "Unsupported Labelme shape_type '%s' detected; converting to bbox before slicing.",
+        shape_type,
+    )
+    xs = [point[0] for point in points]
+    ys = [point[1] for point in points]
+    x_min, x_max = min(xs), max(xs)
+    y_min, y_max = min(ys), max(ys)
+    return CocoAnnotation.from_coco_bbox(
+        bbox=[x_min, y_min, x_max - x_min, y_max - y_min],
+        category_id=category_id,
+        category_name=category_name,
+    )
+
+
+def _coco_segmentation_to_labelme_points(segmentation: list[float] | list[int]) -> list[list[float]]:
+    """Convert one COCO polygon list to Labelme points."""
+    if len(segmentation) % 2 != 0:
+        raise ValueError("COCO polygon segmentation must contain an even number of coordinates.")
+
+    points = [[float(segmentation[i]), float(segmentation[i + 1])] for i in range(0, len(segmentation), 2)]
+    if len(points) > 1 and points[0] == points[-1]:
+        points = points[:-1]
+    return points
+
+
+def _coco_annotation_to_labelme_shapes(coco_annotation: CocoAnnotation, shape_template: dict) -> list[dict]:
+    """Convert a sliced CocoAnnotation to one or more Labelme shapes."""
+    output_shapes: list[dict] = []
+    segmentation = coco_annotation.segmentation
+
+    if segmentation:
+        for polygon in segmentation:
+            polygon_points = _coco_segmentation_to_labelme_points(polygon)
+            if len(polygon_points) < 3:
+                continue
+            output_shapes.append(
+                {
+                    "label": shape_template["label"],
+                    "points": polygon_points,
+                    "group_id": shape_template["group_id"],
+                    "description": shape_template["description"],
+                    "shape_type": "polygon",
+                    "flags": shape_template["flags"],
+                }
+            )
+        return output_shapes
+
+    x_min, y_min, width, height = coco_annotation.bbox
+    output_shapes.append(
+        {
+            "label": shape_template["label"],
+            "points": [[x_min, y_min], [x_min + width, y_min + height]],
+            "group_id": shape_template["group_id"],
+            "description": shape_template["description"],
+            "shape_type": "rectangle",
+            "flags": shape_template["flags"],
+        }
+    )
+    return output_shapes
+
+
+def slice_labelme_json(
+    image: str | Image.Image | np.ndarray,
+    input_json_path: str,
+    output_dir: str | None = None,
+    output_file_name: str | None = None,
+    slice_height: int | None = None,
+    slice_width: int | None = None,
+    overlap_height_ratio: float | None = 0.2,
+    overlap_width_ratio: float | None = 0.2,
+    auto_slice_resolution: bool | None = True,
+    min_area_ratio: float | None = 0.1,
+    min_width_height: float | None = None,
+    out_ext: str | None = None,
+    verbose: bool | None = False,
+    exif_fix: bool = True,
+) -> tuple[SliceImageResult, list[dict], list[str]]:
+    """Slice one image and its Labelme JSON annotation into sliding-window patches."""
+    labelme_dict: dict = load_json(input_json_path)  # type: ignore[assignment]
+    labelme_shapes = labelme_dict.get("shapes")
+    if not isinstance(labelme_shapes, list):
+        raise ValueError("Labelme JSON must include a 'shapes' list.")
+
+    coco_annotation_list: list[CocoAnnotation] = []
+    shape_id_to_template: dict[int, dict] = {}
+    for shape_index, shape in enumerate(labelme_shapes, start=1):
+        if not isinstance(shape, dict):
+            raise ValueError("Each entry in Labelme 'shapes' must be a dictionary.")
+        coco_annotation = _labelme_shape_to_coco_annotation(shape, category_id=shape_index)
+        coco_annotation_list.append(coco_annotation)
+        shape_id_to_template[shape_index] = {
+            "label": shape["label"],
+            "group_id": shape.get("group_id"),
+            "description": shape.get("description", ""),
+            "flags": shape.get("flags", {}),
+        }
+
+    resolved_output_file_name = output_file_name
+    if resolved_output_file_name is None:
+        if isinstance(image, str):
+            resolved_output_file_name = Path(image).stem
+        else:
+            resolved_output_file_name = Path(input_json_path).stem
+
+    slice_image_result = slice_image(
+        image=image,
+        coco_annotation_list=coco_annotation_list,
+        output_file_name=resolved_output_file_name,
+        output_dir=output_dir,
+        slice_height=slice_height,
+        slice_width=slice_width,
+        overlap_height_ratio=overlap_height_ratio,
+        overlap_width_ratio=overlap_width_ratio,
+        auto_slice_resolution=auto_slice_resolution,
+        min_area_ratio=min_area_ratio,
+        min_width_height=min_width_height,
+        out_ext=out_ext,
+        verbose=verbose,
+        exif_fix=exif_fix,
+    )
+
+    base_labelme_dict = {
+        key: value
+        for key, value in labelme_dict.items()
+        if key not in {"shapes", "imagePath", "imageData", "imageHeight", "imageWidth"}
+    }
+    if "version" not in base_labelme_dict:
+        base_labelme_dict["version"] = "5.0.0"
+    if "flags" not in base_labelme_dict:
+        base_labelme_dict["flags"] = {}
+
+    sliced_labelme_dict_list: list[dict] = []
+    saved_json_paths: list[str] = []
+    for sliced_coco_image in slice_image_result.coco_images:
+        sliced_shapes: list[dict] = []
+        for sliced_annotation in sliced_coco_image.annotations:
+            shape_template = shape_id_to_template.get(sliced_annotation.category_id)
+            if shape_template is None:
+                raise ValueError(
+                    f"Unable to map sliced annotation category_id={sliced_annotation.category_id} to Labelme shape."
+                )
+            sliced_shapes.extend(_coco_annotation_to_labelme_shapes(sliced_annotation, shape_template))
+
+        sliced_labelme_dict = dict(base_labelme_dict)
+        sliced_labelme_dict.update(
+            {
+                "shapes": sliced_shapes,
+                "imagePath": sliced_coco_image.file_name,
+                "imageData": None,
+                "imageHeight": sliced_coco_image.height,
+                "imageWidth": sliced_coco_image.width,
+            }
+        )
+        sliced_labelme_dict_list.append(sliced_labelme_dict)
+
+        if output_dir:
+            output_json_path = str(Path(output_dir) / f"{Path(sliced_coco_image.file_name).stem}.json")
+            save_json(sliced_labelme_dict, output_json_path)
+            saved_json_paths.append(output_json_path)
+
+    return slice_image_result, sliced_labelme_dict_list, saved_json_paths

--- a/sahi/slicing.py
+++ b/sahi/slicing.py
@@ -314,6 +314,7 @@ def slice_image(
     overlap_width_ratio: float | None = 0.2,
     auto_slice_resolution: bool | None = True,
     min_area_ratio: float | None = 0.1,
+    min_width_height: float | None = None,
     out_ext: str | None = None,
     verbose: bool | None = False,
     exif_fix: bool = True,
@@ -338,6 +339,9 @@ def slice_image(
             it enables automatically calculate these params from image resolution and orientation.
         min_area_ratio (float, optional): If the cropped annotation area to original annotation
             ratio is smaller than this value, the annotation is filtered out. Default 0.1.
+        min_width_height (float | None, optional): If provided, annotations are filtered
+            only when BOTH sliced width and height are smaller than this threshold and
+            cropped/original area ratio is smaller than ``min_area_ratio``.
         out_ext (str, optional): Extension of saved images. Default is the
             original suffix for lossless image formats and png for lossy formats ('.jpg','.jpeg').
         verbose (bool, optional): Switch to print relevant values to screen.
@@ -426,7 +430,10 @@ def slice_image(
         if coco_annotation_list is not None:
             min_area_ratio_val: float = min_area_ratio if min_area_ratio is not None else 0.1
             for sliced_coco_annotation in process_coco_annotations(
-                coco_annotation_list, slice_bbox, min_area_ratio_val
+                coco_annotation_list,
+                slice_bbox,
+                min_area_ratio_val,
+                min_width_height=min_width_height,
             ):
                 coco_image.add_annotation(sliced_coco_annotation)
 
@@ -471,6 +478,7 @@ def slice_coco(
     overlap_height_ratio: float | None = 0.2,
     overlap_width_ratio: float | None = 0.2,
     min_area_ratio: float | None = 0.1,
+    min_width_height: float | None = None,
     out_ext: str | None = None,
     verbose: bool | None = False,
     exif_fix: bool = True,
@@ -497,6 +505,9 @@ def slice_coco(
             overlap of 20 pixels). Default 0.2.
         min_area_ratio (float): If the cropped annotation area to original annotation
             ratio is smaller than this value, the annotation is filtered out. Default 0.1.
+        min_width_height (float | None, optional): If provided, annotations are filtered
+            only when BOTH sliced width and height are smaller than this threshold and
+            cropped/original area ratio is smaller than ``min_area_ratio``.
         out_ext (str, optional): Extension of saved images. Default is the
             original suffix.
         verbose (bool, optional): Switch to print relevant values to screen.
@@ -532,6 +543,7 @@ def slice_coco(
                 overlap_height_ratio=overlap_height_ratio,
                 overlap_width_ratio=overlap_width_ratio,
                 min_area_ratio=min_area_ratio,
+                min_width_height=min_width_height,
                 out_ext=out_ext,
                 verbose=verbose,
                 exif_fix=exif_fix,

--- a/tests/test_slice_labelme_json.py
+++ b/tests/test_slice_labelme_json.py
@@ -1,0 +1,170 @@
+"""Tests for slicing Labelme JSON annotations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+from sahi.slicing import slice_labelme_json
+from sahi.utils.file import save_json
+
+
+def test_slice_labelme_json(tmp_path: Path) -> None:
+    """Slices one image + Labelme json and exports image/json patches."""
+    image_array = np.full((100, 100, 3), 255, dtype=np.uint8)
+    image_path = tmp_path / "sample.png"
+    Image.fromarray(image_array).save(image_path)
+
+    labelme_dict = {
+        "version": "5.4.1",
+        "flags": {},
+        "shapes": [
+            {
+                "label": "scratch",
+                "points": [[10, 10], [60, 10], [60, 60], [10, 60]],
+                "group_id": None,
+                "description": "",
+                "shape_type": "polygon",
+                "flags": {},
+            },
+            {
+                "label": "dent",
+                "points": [[70, 70], [90, 70], [90, 90], [70, 90]],
+                "group_id": None,
+                "description": "",
+                "shape_type": "polygon",
+                "flags": {},
+            },
+        ],
+        "imagePath": image_path.name,
+        "imageData": None,
+        "imageHeight": 100,
+        "imageWidth": 100,
+    }
+    annotation_path = tmp_path / "sample.json"
+    save_json(labelme_dict, str(annotation_path))
+
+    output_dir = tmp_path / "sliced"
+    slice_image_result, sliced_labelme_dicts, saved_json_paths = slice_labelme_json(
+        image=str(image_path),
+        input_json_path=str(annotation_path),
+        output_dir=str(output_dir),
+        slice_height=50,
+        slice_width=50,
+        overlap_height_ratio=0.0,
+        overlap_width_ratio=0.0,
+        auto_slice_resolution=False,
+        min_area_ratio=0.0,
+    )
+
+    assert len(slice_image_result) == 4
+    assert len(sliced_labelme_dicts) == 4
+    assert len(saved_json_paths) == 4
+
+    saved_files = list(output_dir.glob("*"))
+    assert len(saved_files) == 8
+    assert len(list(output_dir.glob("*.png"))) == 4
+    assert len(list(output_dir.glob("*.json"))) == 4
+
+    first_slice = next(item for item in sliced_labelme_dicts if item["imagePath"].startswith("sample_0_0_50_50"))
+    assert first_slice["imageHeight"] == 50
+    assert first_slice["imageWidth"] == 50
+    assert len(first_slice["shapes"]) == 1
+    assert first_slice["shapes"][0]["label"] == "scratch"
+    assert all(0 <= point[0] <= 50 and 0 <= point[1] <= 50 for point in first_slice["shapes"][0]["points"])
+
+    bottom_right_slice = next(
+        item for item in sliced_labelme_dicts if item["imagePath"].startswith("sample_50_50_100_100")
+    )
+    labels = sorted(shape["label"] for shape in bottom_right_slice["shapes"])
+    assert labels == ["dent", "scratch"]
+
+
+def test_slice_labelme_json_min_width_height_filter(tmp_path: Path) -> None:
+    """Keeps thin fragments and drops tiny fragments when min_width_height is set."""
+    image_array = np.full((100, 100, 3), 255, dtype=np.uint8)
+    image_path = tmp_path / "filter_sample.png"
+    Image.fromarray(image_array).save(image_path)
+
+    labelme_dict = {
+        "version": "5.4.1",
+        "flags": {},
+        "shapes": [
+            {
+                "label": "tall",
+                "points": [[40, 5], [95, 5], [95, 45], [40, 45]],
+                "group_id": None,
+                "description": "",
+                "shape_type": "polygon",
+                "flags": {},
+            },
+            {
+                "label": "tiny",
+                "points": [[49, 49], [99, 49], [99, 99], [49, 99]],
+                "group_id": None,
+                "description": "",
+                "shape_type": "polygon",
+                "flags": {},
+            },
+        ],
+        "imagePath": image_path.name,
+        "imageData": None,
+        "imageHeight": 100,
+        "imageWidth": 100,
+    }
+    annotation_path = tmp_path / "filter_sample.json"
+    save_json(labelme_dict, str(annotation_path))
+
+    _, default_filtered_dicts, _ = slice_labelme_json(
+        image=str(image_path),
+        input_json_path=str(annotation_path),
+        output_dir=None,
+        slice_height=50,
+        slice_width=50,
+        overlap_height_ratio=0.0,
+        overlap_width_ratio=0.0,
+        auto_slice_resolution=False,
+        min_area_ratio=0.2,
+    )
+    top_left_default = next(
+        item for item in default_filtered_dicts if item["imagePath"].startswith("filter_sample_0_0_50_50")
+    )
+    assert top_left_default["shapes"] == []
+
+    _, custom_filtered_dicts, _ = slice_labelme_json(
+        image=str(image_path),
+        input_json_path=str(annotation_path),
+        output_dir=None,
+        slice_height=50,
+        slice_width=50,
+        overlap_height_ratio=0.0,
+        overlap_width_ratio=0.0,
+        auto_slice_resolution=False,
+        min_area_ratio=0.2,
+        min_width_height=15,
+    )
+    top_left_custom = next(
+        item for item in custom_filtered_dicts if item["imagePath"].startswith("filter_sample_0_0_50_50")
+    )
+    kept_labels = [shape["label"] for shape in top_left_custom["shapes"]]
+    assert kept_labels == ["tall"]
+
+def test_my():
+    ret = slice_labelme_json(
+        image=r"E:\Pictures\scratches\1.jpg",
+        input_json_path=r"E:\Pictures\scratches\1.json",
+        output_dir="E:\Pictures\scratches\sliced1",
+        slice_height=512,
+        slice_width=512,
+        overlap_height_ratio=0.2,
+        overlap_width_ratio=0.2,
+        auto_slice_resolution=False,
+        min_area_ratio=0.01,
+        min_width_height=15,
+    )
+    assert len(ret)>0
+
+if __name__ == "__main__":
+    test_my()


### PR DESCRIPTION
I added labelme json file slicing functions to slicing.py, support polygons and rectangles.

<img width="1081" height="897" alt="image" src="https://github.com/user-attachments/assets/9ad2de65-3e2e-41db-82ba-ffc687e97665" />

sliced sub images:
<img width="907" height="902" alt="image" src="https://github.com/user-attachments/assets/e75d39f1-58af-4da4-9770-e721bec0eaf5" />
<img width="915" height="904" alt="image" src="https://github.com/user-attachments/assets/ef1e55d6-036f-4262-8806-9a74fae68347" />
<img width="918" height="905" alt="image" src="https://github.com/user-attachments/assets/22abb0ad-0987-4956-a5b1-d680834d6efe" />
....

And I Enhanced annotation filtering with min_width_height parameter. A shape will be ignored when its width and height smaller than min_width_height **and** area_ratio smaller than min_area_ratio.