### PR TITLE
Stream slices from disk instead of decoding the whole image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,66 @@ jobs:
           # coco analyse
           uv run sahi coco analyse --dataset_json_path tests/data/coco_evaluate/dataset.json --result_json_path tests/data/coco_evaluate/result.json --out_dir tests/data/coco_evaluate/
 
+  streaming:
+    name: "Streaming slice reads (${{ matrix.libvips }} libvips, OS: ${{ matrix.os }})"
+    if:
+      github.event_name != 'schedule' && github.event_name !=
+      'workflow_dispatch'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # System libvips with a pyvips<3.0 pin is what `sahi[ci]`/`inference` users end
+          # up with. See docs/predict.md for why the two cannot be combined.
+          - os: ubuntu-latest
+            libvips: system
+            pyvips: "pyvips<3.0"
+          # The string users are told to type. The leg above hand-installs pyvips, so it
+          # would not notice `[bigimage]` resolving to a pyvips with no libvips behind it,
+          # which falls back to a whole-image decode silently rather than failing.
+          - os: ubuntu-latest
+            libvips: extra
+            pyvips: ""
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup uv python package manager
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          python-version: "3.12"
+          enable-cache: true
+          activate-environment: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+
+      # -dev rather than libvips42, whose name moved to libvips42t64 in Ubuntu 24.04
+      - name: Install system libvips
+        if: matrix.libvips == 'system'
+        run: sudo apt-get update && sudo apt-get install -y libvips-dev
+
+      # Separate from the `ci` job, whose `inference` dependency caps pyvips<3.0.
+      # Installed without the `binary` extra so streaming is really exercised.
+      - name: Install sahi with libvips
+        if: matrix.libvips != 'extra'
+        run: uv pip install -e . pytest "${{ matrix.pyvips }}"
+      - name: Install sahi with the bigimage extra
+        if: matrix.libvips == 'extra'
+        run: uv pip install -e ".[bigimage]" pytest
+      # The extra must deliver a vendored libvips as well as the pyvips bindings. Without
+      # one, `import pyvips` raises OSError and slicing quietly decodes whole images.
+      # pyvips-binary ships the library as a top-level `_libvips` extension module, not
+      # as a `pyvips_binary` package, so that is what proves the wheel supplied it rather
+      # than a system libvips this leg deliberately does not install.
+      - name: Verify the extra vendored libvips
+        if: matrix.libvips == 'extra'
+        run: python -c "import _libvips; print('vendored libvips at', _libvips.__file__)"
+      - name: Verify libvips is really loadable
+        run: python -c "import pyvips; print('libvips', pyvips.version(0), pyvips.version(1), pyvips.version(2))"
+      # `not slow` drops the peak-RSS measurement: it is a real check but not a dependable
+      # one on a shared runner. See TestPeakMemory and scripts/benchmark_streaming_slices.py.
+      - name: Test streaming slice reads
+        run: pytest tests/test_slice_stream.py tests/test_predict_stream.py -q -m "not slow"
+
   schedule-test:
     name:
       "Schedule/PyPI check (OS: ${{ matrix.os }}, Python: ${{

--- a/README.md
+++ b/README.md
@@ -133,6 +133,16 @@ mim install mmdet==3.3.0
 pip install inference>=0.51.5 rfdetr>=1.6.2
 ```
 
+- Install the streaming backend for gigapixel images (optional, see
+  [slicing docs](docs/slicing.md)):
+
+```console
+pip install sahi[bigimage]
+```
+
+Installing it alongside `inference` needs libvips from your system package manager
+instead — see [installing libvips](docs/predict.md#installing-libvips).
+
 </details>
 
 ## <div align="center">Quick Start</div>

--- a/docs/predict.md
+++ b/docs/predict.md
@@ -39,6 +39,128 @@ result = get_sliced_prediction(
 
 ```
 
+### Predicting on very large images
+
+When you call `get_sliced_prediction` with a file path, slices are read from disk one
+row-band at a time instead of decoding the whole image up front, so peak memory stays a
+small fraction of the scan rather than tracking its full decoded size. Two things unlock
+the full saving:
+
+- Install the optional streaming backend: `pip install sahi[bigimage]` (bundles
+  libvips). Without it the image is decoded whole, matching the old behaviour.
+- Pass `perform_standard_pred=False`. The default also runs inference on the full
+  image, which decodes it in one piece and cancels out the saving. sahi logs a warning
+  when you leave it on while slices are being streamed.
+
+A Pillow image, a numpy array or a URL is already decoded (or has to be fetched whole),
+so those inputs keep the old behaviour. The same goes for the `sahi predict` CLI, which
+decodes the image up front for the visualisations it exports: use the Python API to
+stream.
+
+Images whose EXIF orientation tag rotates or mirrors them cannot be streamed and fall
+back to a whole-image decode (a warning says so). `SliceImageStream.is_streaming` reports
+whether a given input will actually be streamed.
+
+#### Measured effect
+
+A 39266x29140 (1144 MP) JPEG scan, sliced 640x640 at 0.2 overlap into 4389 slices,
+peak RSS of the whole process:
+
+| path | peak RSS | wall time |
+| --- | --- | --- |
+| streaming, libvips present | 671 MB | 10.9 s |
+| whole-image decode alone (no slicing) | 6613 MB | 9.0 s |
+| `slice_image`, all slices materialised | 3.2 GB image + 5.0 GB slices, does not complete in 6 GB | - |
+
+Slicing on its own, with nothing consuming the batches, streaming is about 10-15% slower
+than the eager path, plus a flat ~0.1 s for the one-time `import pyvips`:
+
+| image | eager | streaming |
+| --- | --- | --- |
+| 1 MP | 0.27 s / 156 MB | 0.44 s / 156 MB |
+| 16 MP | 0.62 s / 163 MB | 0.91 s / 189 MB |
+| 64 MP | 1.83 s / 438 MB | 2.07 s / 327 MB |
+| 144 MP | 3.71 s / 896 MB | 4.13 s / 508 MB |
+| 256 MP | 6.56 s / 1537 MB | 6.69 s / 733 MB |
+
+Below ~64 MP streaming costs memory rather than saving it, since the fixed overhead
+outweighs the band saving.
+
+That is the pessimistic case, though: it measures slicing with no inference. In a real
+`get_sliced_prediction` the model runs on each batch, and the next band is decoded on a
+worker thread while it does (libvips releases the GIL). At 30 ms of work per batch,
+roughly what a small detector costs on 8 slices:
+
+| image | eager | streaming, no prefetch | streaming + prefetch |
+| --- | --- | --- | --- |
+| 64 MP | 5.77 s / 438 MB | 5.83 s / 327 MB | **4.34 s / 321 MB** |
+| 256 MP | 20.73 s / 1537 MB | 19.45 s / 733 MB | **16.62 s / 722 MB** |
+
+So with anything real consuming the slices, streaming ends up both faster than the eager
+path and half its peak memory. Prefetch is on by default and can be turned off with
+`SliceImageStream.iter_batches(batch_size, prefetch=False)`.
+
+Reproduce any of this with:
+
+```console
+python scripts/benchmark_streaming_slices.py                  # slicing alone
+python scripts/benchmark_streaming_slices.py --consume-ms 30  # with simulated inference
+```
+
+Peak memory grows with image height, at roughly a tenth the rate of a whole-image
+decode. libvips retains about 0.45 bytes for every pixel it decodes — some 360 MB across
+the 1144 MP scan. This is the loader's own bookkeeping: the same climb reproduces with a
+bare `pyvips.Region` fetch loop and no sahi in the process. Much of the rest of the
+resident set is memory glibc has freed but not returned to the OS, which `malloc_trim(0)`
+reclaims. Budget for that slope on scans far taller than the ones measured here.
+
+#### Caveat: import order
+
+`sahi.utils.cv` raises `OPENCV_IO_MAX_IMAGE_PIXELS` at import time, because OpenCV reads
+that variable once when *it* is imported and refuses to decode anything above 2^30
+pixels otherwise. If something imports `cv2` before any `sahi` module, the limit stays
+at its default and images above 1073 MP quietly fall back to the slower, more allocating
+PIL path instead of failing. Import `sahi` first, or set the variable in the environment,
+if you work at that size.
+
+#### Installing libvips
+
+`pip install sahi[bigimage]` pulls `pyvips[binary]`, which ships libvips itself and
+needs nothing from the system.
+
+That extra only exists from pyvips 3.0 on, so it is unavailable when something else in
+the environment caps pyvips below 3.0. Roboflow's `inference` is the common case, since
+it requires `pyvips<3.0` transitively; `pip` then warns `does not have an extra named
+binary` and installs the bindings with no libvips behind them, and slicing falls back to
+decoding whole images — correct results, but not the low memory.
+
+Install libvips through the system instead and streaming works on any pyvips, 2.x
+included:
+
+| OS | command |
+| --- | --- |
+| Debian/Ubuntu | `apt install libvips42t64` (Ubuntu 24.04+; `libvips42` before that, `libvips` on older releases) |
+| Fedora/RHEL | `dnf install vips` |
+| macOS | `brew install vips` |
+| Windows | download the libvips zip and add its `bin` to `PATH`, or use `conda install -c conda-forge libvips` |
+
+then `pip install pyvips`. Verify with:
+
+```console
+python -c "import pyvips; print(pyvips.version(0), pyvips.version(1), pyvips.version(2))"
+```
+
+An importable pyvips with no libvips behind it raises `OSError` rather than
+`ImportError`. sahi treats that as a failed backend and decodes the image whole. This
+is logged at **debug** level, not as a warning — most installs have no libvips and its
+absence is not an error — so enable debug logging to see it:
+
+```python
+import logging
+
+logging.getLogger("sahi").setLevel(logging.DEBUG)
+```
+
 ## Standard inference
 
 ```python

--- a/docs/slicing.md
+++ b/docs/slicing.md
@@ -31,6 +31,24 @@ slice_image_result = slice_image(
 )
 ```
 
+- Stream slices of a huge image without decoding it whole (used internally by
+  `get_sliced_prediction`; install `sahi[bigimage]` for the libvips-backed band
+  reader, otherwise it falls back to a whole-image decode):
+
+```python
+from sahi.slicing import SliceImageStream
+
+stream = SliceImageStream(
+    image=image_path,
+    slice_height=256,
+    slice_width=256,
+    overlap_height_ratio=0.2,
+    overlap_width_ratio=0.2,
+)
+for batch_images, batch_starts in stream.iter_batches(batch_size=8):
+    ...  # at most one row-band of the image is resident at a time
+```
+
 - Slice a COCO formatted dataset:
 
 ```python

--- a/docs/zh/predict.md
+++ b/docs/zh/predict.md
@@ -39,6 +39,26 @@ result = get_sliced_prediction(
 
 ```
 
+### 超大图像推理
+
+当你向 `get_sliced_prediction` 传入文件路径时，切片会按行带（row-band）逐段从磁盘读取，
+而不是一次性解码整幅图像，因此峰值内存只占整幅扫描图的一小部分，而不再随其解码后的完整
+体积增长。要获得完整的内存收益，需要两件事：
+
+- 安装可选的流式后端：`pip install sahi[bigimage]`（内置 libvips）。没有它时图像会被整幅
+  解码，行为与以前一致。
+- 传入 `perform_standard_pred=False`。默认值还会在整幅图像上再跑一次推理，这会把图像整幅
+  解码，从而抵消上述收益。在流式读取切片时若保留该默认值，sahi 会记录一条警告。
+
+Pillow 图像、numpy 数组和 URL 本身就已经解码完毕（或必须整个下载），因此这些输入保持原有
+行为。`sahi predict` 命令行同样如此——它需要为导出的可视化结果预先解码图像，若要使用流式
+读取请改用 Python API。
+
+带有 EXIF 方向标签（旋转或镜像）的图像无法流式读取，会回退为整幅解码（并给出警告）。
+`SliceImageStream.is_streaming` 可以查询某个输入实际是否会被流式读取。
+
+具体的内存与耗时实测数据见[英文文档](../predict.md#predicting-on-very-large-images)。
+
 ## 全图推理
 
 ```python

--- a/docs/zh/slicing.md
+++ b/docs/zh/slicing.md
@@ -31,6 +31,23 @@ slice_image_result = slice_image(
 )
 ```
 
+- 流式读取超大图像的切片，无需整幅解码（`get_sliced_prediction` 内部即使用此方式；
+  安装 `sahi[bigimage]` 可启用基于 libvips 的行带读取器，否则会回退为整幅解码）：
+
+```python
+from sahi.slicing import SliceImageStream
+
+stream = SliceImageStream(
+    image=image_path,
+    slice_height=256,
+    slice_width=256,
+    overlap_height_ratio=0.2,
+    overlap_width_ratio=0.2,
+)
+for batch_images, batch_starts in stream.iter_batches(batch_size=8):
+    ...  # 任意时刻内存中最多只驻留一个行带
+```
+
 - 对一个 COCO 格式数据集进行切片操作：
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,9 @@ roboflow = [
   "rfdetr>=1.6.2;python_version>='3.12'",
 ]
 onnx = ["onnx;python_version>='3.10'", "onnxruntime;python_version>='3.10'"]
+# streams slices of huge images from disk band-by-band instead of decoding them whole.
+# Left unpinned so it stays resolvable alongside `inference`; see docs/predict.md.
+bigimage = ["pyvips[binary]"]
 numba = ["numba>=0.59.0;python_version>='3.10'"]
 torchvision = ["torch>=2.4.1", "torchvision>=0.19.0"]
 all = [
@@ -122,6 +125,9 @@ ci = [
   "ultralytics>=8.3.161",
   "scikit-image",
   "fiftyone",
+  # pyvips is deliberately absent: `inference` caps pyvips<3.0, so listing the extra
+  # here would install pyvips with no libvips behind it. The `streaming` job in ci.yml
+  # covers that path instead.
 ]
 
 [tool.uv]
@@ -360,6 +366,9 @@ line-ending = "auto"
 minversion = "6.0"
 addopts = ["--import-mode=importlib", "--no-header"]
 pythonpath = ["."]
+markers = [
+    "slow: measurements too heavy or too runner-dependent for CI; run with `pytest -m slow`",
+]
 
 [tool.typos.default]
 extend-ignore-identifiers-re = ["fo"]

--- a/sahi/predict.py
+++ b/sahi/predict.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
 import time
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Iterator
 from functools import cmp_to_key
 from typing import Any
 
@@ -24,7 +25,7 @@ from sahi.postprocess.combine import (
     PostprocessPredictions,
 )
 from sahi.prediction import ObjectPrediction, PredictionResult
-from sahi.slicing import slice_image
+from sahi.slicing import SliceExporter, SliceImageStream
 from sahi.utils.coco import Coco, CocoImage
 from sahi.utils.cv import (
     IMAGE_EXTENSIONS,
@@ -219,6 +220,9 @@ def get_sliced_prediction(
         perform_standard_pred: bool
             Perform a standard prediction on top of sliced predictions to increase large object
             detection accuracy. Default: True.
+            This also runs inference on the full image, which decodes it in one piece. The
+            low peak memory quoted for gigapixel inputs requires ``perform_standard_pred=False``;
+            leaving it on while slices are being streamed logs a warning.
         postprocess_type: str
             Type of the postprocess to be used after sliced inference while merging/eliminating predictions.
             Options are 'NMM', 'GREEDYNMM' or 'NMS'. Default is 'GREEDYNMM'.
@@ -301,12 +305,10 @@ def get_sliced_prediction(
     try:
         durations_in_seconds = dict()
 
-        # create slices from full image
+        # plan slices from the image header; pixels are read a row-band at a time below
         time_start = time.perf_counter()
-        slice_image_result = slice_image(
+        slice_stream = SliceImageStream(
             image=image,
-            output_file_name=slice_export_prefix,
-            output_dir=slice_dir,
             slice_height=slice_height,
             slice_width=slice_width,
             overlap_height_ratio=overlap_height_ratio,
@@ -315,8 +317,16 @@ def get_sliced_prediction(
         )
         from sahi.models.ultralytics import UltralyticsDetectionModel
 
-        num_slices = len(slice_image_result)
-        durations_in_seconds["slice"] = time.perf_counter() - time_start
+        num_slices = len(slice_stream)
+        # geometry only; the pixel reads are timed as they happen in the loop below
+        planning_seconds = time.perf_counter() - time_start
+
+        if num_slices > 1 and perform_standard_pred and slice_stream.is_streaming:
+            logger.warning(
+                "perform_standard_pred=True also runs inference on the full image, which decodes it in "
+                "one piece and undoes the memory saving of reading slices a band at a time. "
+                "Pass perform_standard_pred=False to keep peak memory bounded."
+            )
 
         # auto postprocess type switch for low confidence thresholds
         if (
@@ -349,51 +359,74 @@ def get_sliced_prediction(
 
         postprocess_time = 0.0
         time_start = time.perf_counter()
-        num_batches = (num_slices + batch_size - 1) // batch_size
         if verbose == 1 or verbose == 2:
             tqdm.write(f"Performing prediction on {num_slices} slices.")
 
-        if progress_bar:
-            slice_iterator = tqdm(range(num_batches), desc="Processing slices", total=num_batches)
-        else:
-            slice_iterator = range(num_batches)
-
         full_shape: list[int | float] = [
-            slice_image_result.original_image_height,
-            slice_image_result.original_image_width,
+            slice_stream.original_image_height,
+            slice_stream.original_image_width,
         ]
         object_prediction_list = []
         slices_processed = 0
-        for batch_ind in slice_iterator:
-            batch_start = batch_ind * batch_size
-            batch_end = min(batch_start + batch_size, num_slices)
-            batch_images = [slice_image_result.images[i] for i in range(batch_start, batch_end)]
-            batch_shifts: list[list[int | float]] = [
-                list(slice_image_result.starting_pixels[i]) for i in range(batch_start, batch_end)
-            ]
-            current_batch_size = len(batch_images)
+        read_seconds = [0.0]
 
-            detection_model.perform_batch_inference([np.ascontiguousarray(img) for img in batch_images])
-            detection_model.convert_original_predictions(
-                shift_amount=batch_shifts,
-                full_shape=[full_shape] * current_batch_size,
-            )
+        def timed(batches: Iterator[Any]) -> Generator[Any, None, None]:
+            """Yield from `batches`, accumulating the wall time spent waiting for pixels.
 
-            for image_preds in detection_model.object_prediction_list_per_image:
-                filtered_preds = filter_predictions(image_preds, exclude_classes_by_name, exclude_classes_by_id)
-                for object_prediction in filtered_preds:
-                    if object_prediction:
-                        object_prediction_list.append(object_prediction.get_shifted_object_prediction())
+            Measured around `next` rather than inside the stream: with prefetching most of
+            the band decode overlaps inference, and only the part the caller actually
+            waited on belongs in the slice duration.
+            """
+            while True:
+                started = time.perf_counter()
+                try:
+                    batch = next(batches)
+                except StopIteration:
+                    return
+                finally:
+                    read_seconds[0] += time.perf_counter() - started
+                yield batch
 
-            slices_processed += current_batch_size
+        with contextlib.ExitStack() as stack:
+            progress = stack.enter_context(tqdm(desc="Processing slices", total=num_slices)) if progress_bar else None
+            # export per batch, so slices are not held until the end
+            exporter = None
+            if slice_dir and slice_export_prefix:
+                exporter = stack.enter_context(
+                    SliceExporter(slice_dir, slice_export_prefix, image, max_workers=batch_size)
+                )
 
-            if merge_buffer_length is not None and len(object_prediction_list) > merge_buffer_length:
-                postprocess_time_start = time.time()
-                object_prediction_list = postprocess(object_prediction_list)
-                postprocess_time += time.time() - postprocess_time_start
+            for batch_images, batch_starts in timed(slice_stream.iter_batches(batch_size)):
+                current_batch_size = len(batch_images)
+                batch_shifts: list[list[int | float]] = [list(start) for start in batch_starts]
 
-            if progress_callback is not None:
-                progress_callback(slices_processed, num_slices)
+                if exporter is not None:
+                    exporter.export(batch_images, batch_starts)
+
+                # slices arrive as fresh C-contiguous copies, so no repacking is needed
+                detection_model.perform_batch_inference(batch_images)
+                detection_model.convert_original_predictions(
+                    shift_amount=batch_shifts,
+                    full_shape=[full_shape] * current_batch_size,
+                )
+
+                for image_preds in detection_model.object_prediction_list_per_image:
+                    filtered_preds = filter_predictions(image_preds, exclude_classes_by_name, exclude_classes_by_id)
+                    for object_prediction in filtered_preds:
+                        if object_prediction:
+                            object_prediction_list.append(object_prediction.get_shifted_object_prediction())
+
+                slices_processed += current_batch_size
+
+                if merge_buffer_length is not None and len(object_prediction_list) > merge_buffer_length:
+                    postprocess_time_start = time.time()
+                    object_prediction_list = postprocess(object_prediction_list)
+                    postprocess_time += time.time() - postprocess_time_start
+
+                if progress is not None:
+                    progress.update(current_batch_size)
+                if progress_callback is not None:
+                    progress_callback(slices_processed, num_slices)
 
         if num_slices > 1 and perform_standard_pred:
             prediction_result = get_prediction(
@@ -401,8 +434,8 @@ def get_sliced_prediction(
                 detection_model=detection_model,
                 shift_amount=[0, 0],
                 full_shape=[
-                    slice_image_result.original_image_height,
-                    slice_image_result.original_image_width,
+                    slice_stream.original_image_height,
+                    slice_stream.original_image_width,
                 ],
                 postprocess=None,
                 exclude_classes_by_name=exclude_classes_by_name,
@@ -416,7 +449,8 @@ def get_sliced_prediction(
             postprocess_time += time.time() - postprocess_time_start
 
         time_end = time.perf_counter() - time_start
-        durations_in_seconds["prediction"] = time_end - postprocess_time
+        durations_in_seconds["slice"] = planning_seconds + read_seconds[0]
+        durations_in_seconds["prediction"] = time_end - postprocess_time - read_seconds[0]
         durations_in_seconds["postprocess"] = postprocess_time
 
         if verbose == 2:

--- a/sahi/prediction.py
+++ b/sahi/prediction.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+from functools import cached_property
 from typing import Any
 
 import numpy as np
@@ -10,7 +11,7 @@ from PIL import Image
 
 from sahi.annotation import ObjectAnnotation
 from sahi.utils.coco import CocoPrediction
-from sahi.utils.cv import read_image_as_pil, visualize_object_predictions
+from sahi.utils.cv import read_image_as_pil, read_image_size, visualize_object_predictions
 from sahi.utils.file import Path
 
 
@@ -202,10 +203,27 @@ class PredictionResult:
             durations_in_seconds: dict[str, Any]
                 Elapsed times for profiling (e.g. inference, postprocess).
         """
-        self.image: Image.Image = read_image_as_pil(image)
-        self.image_width, self.image_height = self.image.size
+        self._image_source = image
+        if isinstance(image, str) and image.startswith("http"):
+            # sizing a remote image costs a full download, so keep what it fetched
+            fetched: Image.Image = read_image_as_pil(image)  # type: ignore[assignment]
+            self.__dict__["image"] = fetched
+            self.image_width, self.image_height = fetched.size
+        else:
+            # header read only: decoding a gigapixel scan to learn its size would undo
+            # the point of slicing it a band at a time
+            self.image_width, self.image_height = read_image_size(image)
         self.object_prediction_list: list[ObjectPrediction] = object_prediction_list
         self.durations_in_seconds = durations_in_seconds
+
+    @cached_property
+    def image(self) -> Image.Image:
+        """The source image, decoded on first access and cached thereafter.
+
+        Assignable: writing to it shadows the cache, as it did when this was a plain
+        attribute.
+        """
+        return read_image_as_pil(self._image_source)  # type: ignore[return-value]
 
     def export_visuals(
         self,

--- a/sahi/slicing.py
+++ b/sahi/slicing.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import concurrent.futures
+import contextlib
 import os
-from collections.abc import Sequence
+import queue
+import threading
+from collections.abc import Callable, Iterator, Sequence
 from pathlib import Path
 from typing import Any, Literal
 
@@ -16,11 +19,16 @@ from tqdm import tqdm
 from sahi.annotation import BoundingBox, Mask
 from sahi.logger import logger
 from sahi.utils.coco import Coco, CocoAnnotation, CocoImage, create_coco_dict
-from sahi.utils.cv import IMAGE_EXTENSIONS_LOSSLESS, IMAGE_EXTENSIONS_LOSSY, read_image_as_pil
+from sahi.utils.cv import IMAGE_EXTENSIONS_LOSSY, _to_hwc, read_image_as_pil, read_image_size
 from sahi.utils.file import load_json, save_json
 
 _CPU_COUNT = os.cpu_count() or 4
 MAX_WORKERS = max(1, min(32, _CPU_COUNT * 2))
+
+# Rows per forward read, trading calls into the decoder against the size of the buffer
+# the reader holds. Reads go through a single libvips region, so the decoder stays in
+# step regardless of where a chunk lands.
+_CHUNK_ROWS = 128
 
 
 def get_slice_bboxes(
@@ -65,10 +73,12 @@ def get_slice_bboxes(
     y_max = y_min = 0
 
     if slice_height and slice_width:
-        if overlap_height_ratio is not None and overlap_height_ratio >= 1.0:
-            raise ValueError("Overlap ratio must be less than 1.0")
-        if overlap_width_ratio is not None and overlap_width_ratio >= 1.0:
-            raise ValueError("Overlap ratio must be less than 1.0")
+        # a negative ratio spaces slices apart instead of overlapping them, which leaves
+        # rows no band covers and so cannot be streamed
+        if overlap_height_ratio is not None and not 0.0 <= overlap_height_ratio < 1.0:
+            raise ValueError("Overlap ratio must be in [0.0, 1.0)")
+        if overlap_width_ratio is not None and not 0.0 <= overlap_width_ratio < 1.0:
+            raise ValueError("Overlap ratio must be in [0.0, 1.0)")
         y_overlap = int((overlap_height_ratio if overlap_height_ratio is not None else 0.2) * slice_height)
         x_overlap = int((overlap_width_ratio if overlap_width_ratio is not None else 0.2) * slice_width)
     elif auto_slice_resolution:
@@ -275,6 +285,561 @@ class SliceImageResult:
         return len(self._sliced_image_list)
 
 
+def _slice_file_suffix(image: str | Image.Image | np.ndarray, out_ext: str | None = None) -> str:
+    """Resolve the file extension exported slices are written with.
+
+    Taken from the source path when there is one: a path handed in directly, or the
+    `filename` a PIL image opened from disk carries. Lossy sources are re-encoded as png
+    so repeated slicing does not compound the compression. Arrays, URLs and in-memory
+    images have no extension to inherit and also get png.
+    """
+    if out_ext:
+        return out_ext
+    if isinstance(image, str) and not image.startswith("http"):
+        source_name = image
+    elif isinstance(image, Image.Image):
+        source_name = str(getattr(image, "filename", ""))
+    else:
+        return ".png"
+    source_suffix = Path(source_name).suffix
+    if not source_suffix or source_suffix in IMAGE_EXTENSIONS_LOSSY:
+        return ".png"
+    return source_suffix
+
+
+def _export_slice(
+    image: np.ndarray,
+    starting_pixel: Sequence[int],
+    output_dir: str,
+    prefix: str,
+    suffix: str,
+) -> None:
+    """Write one slice to `output_dir` under the name pattern `slice_image` uses.
+
+    The slice bbox is recovered from the starting pixel plus the array shape, since
+    `get_slice_bboxes` clamps the far edge to the image bounds.
+    """
+    x_min, y_min = starting_pixel
+    height, width = image.shape[:2]
+    file_name = f"{prefix}_{x_min}_{y_min}_{x_min + width}_{y_min + height}{suffix}"
+    Image.fromarray(image).save(str(Path(output_dir) / file_name))
+
+
+class SliceExporter:
+    """Write slices to disk in the background, under the names `slice_image` uses.
+
+    A context manager so the writer threads are shut down with the caller's loop. Exists
+    so a streaming caller can flush each batch as it goes rather than holding every slice
+    until the end, which is the memory `SliceImageStream` exists to bound.
+    """
+
+    def __init__(
+        self,
+        output_dir: str,
+        prefix: str,
+        image: str | os.PathLike | Image.Image | np.ndarray,
+        out_ext: str | None = None,
+        max_workers: int | None = None,
+    ) -> None:
+        """Prepare `output_dir` and resolve the extension slices are written with.
+
+        Args:
+            output_dir: Directory to write slices into. Created if missing.
+            prefix: File name prefix, as `slice_image`'s `output_file_name`.
+            image: The image being sliced; its extension is inherited where it has one.
+            out_ext: Extension to force instead of inheriting one.
+            max_workers: Cap on writer threads. Defaults to `MAX_WORKERS`.
+        """
+        self._output_dir = output_dir
+        self._prefix = prefix
+        self._suffix = _slice_file_suffix(image, out_ext)
+        self._max_workers = min(MAX_WORKERS, max_workers) if max_workers else MAX_WORKERS
+        self._executor: concurrent.futures.ThreadPoolExecutor | None = None
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+    def __enter__(self) -> SliceExporter:
+        self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=self._max_workers)
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        if self._executor is not None:
+            self._executor.shutdown()
+            self._executor = None
+
+    def export(self, images: Sequence[np.ndarray], starting_pixels: Sequence[Sequence[int]]) -> None:
+        """Write one batch of slices, returning once they are all on disk.
+
+        Draining before returning is deliberate: queueing the writes would keep the batch
+        alive alongside the next one, doubling the peak this class is used to avoid.
+        """
+        if self._executor is None:
+            raise RuntimeError("SliceExporter must be used as a context manager")
+        list(
+            self._executor.map(
+                _export_slice,
+                images,
+                starting_pixels,
+                [self._output_dir] * len(images),
+                [self._prefix] * len(images),
+                [self._suffix] * len(images),
+            )
+        )
+
+
+class SliceImageStream:
+    """Compute slice geometry from the image header, reading pixels a band at a time.
+
+    `slice_image` holds the whole decoded image while every slice is materialised. This
+    exposes the geometry up front, which callers need for progress reporting and
+    coordinate shifts, but defers the pixel reads so the full image is never resident.
+    """
+
+    def __init__(
+        self,
+        image: str | os.PathLike | Image.Image | np.ndarray,
+        slice_height: int | None = None,
+        slice_width: int | None = None,
+        overlap_height_ratio: float | None = 0.2,
+        overlap_width_ratio: float | None = 0.2,
+        auto_slice_resolution: bool | None = True,
+        exif_fix: bool = True,
+    ) -> None:
+        """Initialize the stream and compute slice geometry.
+
+        Args:
+            image: File path of image, Pillow Image, or numpy array to be sliced.
+            slice_height: Height of each slice. Default None.
+            slice_width: Width of each slice. Default None.
+            overlap_height_ratio: Fractional overlap in height of each slice. Default 0.2.
+            overlap_width_ratio: Fractional overlap in width of each slice. Default 0.2.
+            auto_slice_resolution: Calculate slice params from resolution when not given.
+            exif_fix: Whether to apply an EXIF fix to the image.
+        """
+        if isinstance(image, os.PathLike):
+            # normalise early: every path check below (and _open_band_source's) tests for
+            # str, so a Path would silently skip streaming and decode whole instead.
+            image = os.fspath(image)
+        if isinstance(image, str) and image.startswith("http"):
+            # A remote image has no header to peek at, so read_image_size has to fetch the
+            # whole thing anyway. Keep the pixels: re-fetching them in iter_batches would
+            # double the transfer, and nothing is deferred by dropping them.
+            image = read_image_as_pil(image, exif_fix=exif_fix, return_arr=True)  # type: ignore[assignment]
+        self._image = image
+        self._exif_fix = exif_fix
+        width, height = read_image_size(image, exif_fix=exif_fix)
+        if height <= 0 or width <= 0:
+            # matches slice_image: an empty image yields no slices, and silently returning
+            # zero predictions reads as "nothing detected" rather than "nothing was read".
+            raise RuntimeError(f"invalid image size: {(width, height)}")
+        self.original_image_height, self.original_image_width = height, width
+        self.slice_bboxes = get_slice_bboxes(
+            image_height=self.original_image_height,
+            image_width=self.original_image_width,
+            slice_height=slice_height,
+            slice_width=slice_width,
+            auto_slice_resolution=auto_slice_resolution,
+            overlap_height_ratio=overlap_height_ratio,
+            overlap_width_ratio=overlap_width_ratio,
+        )
+
+    def __len__(self) -> int:
+        return len(self.slice_bboxes)
+
+    @property
+    def is_streaming(self) -> bool:
+        """Whether pixels will be read a band at a time rather than decoded in one piece.
+
+        False when the input is not a local path or the optional libvips extra is
+        unusable, in which case the whole image is decoded and peak memory is unchanged.
+        """
+        return _can_stream(self._image)
+
+    def iter_batches(
+        self, batch_size: int = 1, prefetch: bool = True
+    ) -> Iterator[tuple[list[np.ndarray], list[list[int]]]]:
+        """Yield batches of slices together with their starting pixels.
+
+        Slices are produced one row-band at a time, so at most one band is resident.
+        Batches are allowed to span bands: slices are handed out as copies, so carrying
+        the tail of one band into the next batch pins only those slices, and stopping at
+        each band would give short batches on images a few slices wide.
+
+        Args:
+            batch_size: Maximum number of slices per yielded batch.
+            prefetch: Decode the next band on a worker thread while the caller works on
+                the current batch. Only applies to the libvips source; see `_prefetch`.
+
+        Yields:
+            Tuples of (slice images, starting pixels as [x_min, y_min]).
+        """
+        if batch_size < 1:
+            raise ValueError(f"batch_size must be >= 1, got {batch_size}")
+
+        bands = _group_bboxes_into_bands(self.slice_bboxes)
+        band_height = max((y_max - y_min for (y_min, y_max), _ in bands), default=0)
+
+        def produce() -> Iterator[tuple[list[np.ndarray], list[list[int]]]]:
+            # Opened in here, not in iter_batches, so that when this runs on a prefetch
+            # worker the libvips region is created and used on the same thread. A
+            # VipsRegion is thread-affine: fetching from a region built on another
+            # thread aborts the process inside libvips.
+            source = _open_band_source(
+                self._image,
+                band_height=band_height,
+                exif_fix=self._exif_fix,
+                expected_shape=(self.original_image_height, self.original_image_width),
+            )
+            yield from self._batches_from(source, bands, batch_size)
+
+        batches = produce()
+        # Only libvips releases the GIL, so only it can overlap with the caller. An
+        # in-memory source is already decoded, and threading it would add handoffs to
+        # hide work that no longer exists.
+        if prefetch and self.is_streaming:
+            batches = _prefetch(batches)
+        # returned rather than delegated to, so this function is not itself a generator
+        # and the batch_size check above raises on the call instead of the first `next`
+        return batches
+
+    def _batches_from(
+        self,
+        source: _InMemoryBandSource | _VipsBandSource,
+        bands: list[tuple[tuple[int, int], list[list[int]]]],
+        batch_size: int,
+    ) -> Iterator[tuple[list[np.ndarray], list[list[int]]]]:
+        """Cut `bands` out of `source`, batched. See `iter_batches` for the contract."""
+        images: list[np.ndarray] = []
+        shifts: list[list[int]] = []
+        for (y_min, y_max), bboxes in bands:
+            try:
+                band = source.read_band(y_min, y_max)
+            except Exception as error:
+                if isinstance(source, _InMemoryBandSource):
+                    raise
+                # A streaming decoder can fail part way in, well after the open that
+                # _open_band_source guards: libvips only rejects a read it dislikes once
+                # it reaches it. Re-decode eagerly rather than failing the caller.
+                logger.warning(f"streaming read failed ({error}), decoding the whole image instead")
+                source = _decode_band_source(
+                    self._image,
+                    exif_fix=self._exif_fix,
+                    expected_shape=(self.original_image_height, self.original_image_width),
+                )
+                band = source.read_band(y_min, y_max)
+            for x_min, _, x_max, _ in bboxes:
+                # copy: a streaming source reuses its band buffer, so a view would be
+                # rewritten under the caller. np.ascontiguousarray is not enough here, as
+                # it returns the input untouched when the slice spans the full width.
+                images.append(band[:, x_min:x_max].copy())
+                shifts.append([x_min, y_min])
+                if len(images) == batch_size:
+                    yield images, shifts
+                    images, shifts = [], []
+        if images:
+            yield images, shifts
+
+
+def _can_stream(image: str | Image.Image | np.ndarray) -> bool:
+    """Whether `_open_band_source` will attempt libvips for this input.
+
+    Answers without opening anything, so `iter_batches` can decide about prefetching
+    before the source exists. A false positive (libvips is importable but rejects the
+    file) only costs a worker thread that overlaps nothing.
+    """
+    if not isinstance(image, str) or image.startswith("http"):
+        return False
+    try:
+        import pyvips  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+def _prefetch(
+    batches: Iterator[tuple[list[np.ndarray], list[list[int]]]], depth: int = 1
+) -> Iterator[tuple[list[np.ndarray], list[list[int]]]]:
+    """Run `batches` on a worker thread, keeping up to `depth` results ready.
+
+    libvips releases the GIL while it decodes, so the next band can be read while the
+    caller is busy with the current batch. Measured on a 256 MP JPEG: 1.5 s of
+    GIL-holding work in the consumer cost 0.2 s of wall time instead of 1.5 s.
+
+    `depth` is 1 because each queued item pins a whole batch of slices, which is the
+    memory this class exists to bound. Exceptions are re-raised in the caller's thread.
+    """
+    slots: queue.Queue = queue.Queue(maxsize=depth)
+    finished = object()
+    stop = threading.Event()
+
+    def pump() -> None:
+        try:
+            # closed here, on the thread that owns it: `batches` holds a thread-affine
+            # VipsRegion, and closing it from the consumer would raise
+            # "generator already executing" whenever the producer is mid-read.
+            with contextlib.closing(batches):  # type: ignore[type-var]
+                for batch in batches:
+                    slots.put(batch)
+                    if stop.is_set():
+                        return
+        except BaseException as error:
+            # broad on purpose: anything the producer raises is re-raised in the
+            # consumer's thread, where the caller can actually see it
+            slots.put(error)
+        else:
+            slots.put(finished)
+
+    worker = threading.Thread(target=pump, name="sahi-slice-prefetch", daemon=True)
+    worker.start()
+    try:
+        while True:
+            item = slots.get()
+            if item is finished:
+                return
+            if isinstance(item, BaseException):
+                raise item
+            yield item
+    finally:
+        # The caller may abandon us mid-iteration (`break`, or an error downstream).
+        # Draining lets the worker finish its blocked `put`, see the stop flag and exit
+        # instead of sitting on a full queue for the life of the process.
+        stop.set()
+        while worker.is_alive():
+            with contextlib.suppress(queue.Empty):
+                slots.get(timeout=0.1)
+        worker.join()
+
+
+def _group_bboxes_into_bands(
+    slice_bboxes: list[list[int]],
+) -> list[tuple[tuple[int, int], list[list[int]]]]:
+    """Group slice bboxes by their shared vertical extent, preserving order.
+
+    `get_slice_bboxes` emits slices in row-major order, so every slice sharing a
+    (y_min, y_max) pair can be cut from a single horizontal band of the image.
+    """
+    bands: dict[tuple[int, int], list[list[int]]] = {}
+    for bbox in slice_bboxes:
+        bands.setdefault((bbox[1], bbox[3]), []).append(bbox)
+    return list(bands.items())
+
+
+class _ChunkedBandReader:
+    """Assemble overlapping bands from a source that can only be read forwards.
+
+    Consecutive bands overlap, but a sequential decoder cannot rewind to serve the
+    overlap a second time. Rows therefore arrive in fixed forward-only chunks, and the
+    overlap is carried forward inside a preallocated buffer.
+    """
+
+    def __init__(
+        self,
+        read_chunk: Callable[[int, int], np.ndarray],
+        image_height: int,
+        band_height: int,
+    ) -> None:
+        """Initialize the reader.
+
+        Args:
+            read_chunk: Callable taking (first row, number of rows) and returning them.
+                It is only ever called with monotonically advancing rows.
+            image_height: Total height of the source image.
+            band_height: Tallest band that will be requested.
+        """
+        self._read_chunk = read_chunk
+        self._image_height = image_height
+        self._capacity = band_height + _CHUNK_ROWS
+        self._buffer: np.ndarray | None = None
+        self._buffer_start = 0  # image row held at buffer[0]
+        self._valid = 0  # rows currently held in the buffer
+        self._read_pos = 0  # rows already consumed from the source
+
+    def read_band(self, y_min: int, y_max: int) -> np.ndarray:
+        """Return rows [y_min, y_max) of the image.
+
+        Bands must be requested with non-decreasing `y_min`. The returned array is a
+        view into a reused buffer and is only valid until the next call; copy anything
+        that must outlive it.
+        """
+        self._discard_rows_before(y_min)
+        while self._buffer_start + self._valid < y_max:
+            self._pull_chunk()
+        start = y_min - self._buffer_start
+        return self._buffer[start : start + (y_max - y_min)]  # type: ignore[index]
+
+    def _discard_rows_before(self, y_min: int) -> None:
+        """Drop rows that no later band can need, compacting in place."""
+        drop = y_min - self._buffer_start
+        if drop <= 0:
+            return
+        if drop > self._valid:
+            # A gap means rows were never read, which would leave _read_pos behind
+            # _buffer_start and make every later band return the wrong rows.
+            raise ValueError(f"band starts at row {y_min}, past buffered row {self._buffer_start + self._valid}")
+        keep = self._valid - drop
+        if keep and self._buffer is not None:
+            self._buffer[:keep] = self._buffer[drop : drop + keep]
+        self._valid = keep
+        self._buffer_start = y_min
+
+    def _pull_chunk(self) -> None:
+        """Read the next chunk of rows from the source."""
+        rows = min(_CHUNK_ROWS, self._image_height - self._read_pos, self._capacity - self._valid)
+        if rows <= 0:
+            # read_band loops until the buffer reaches y_max, so a zero-row read would hang
+            # instead of failing. Unreachable as constructed: the only source cross-checks
+            # its dimensions at open.
+            raise ValueError(f"no rows left to read at row {self._read_pos} of {self._image_height}")
+        chunk = self._read_chunk(self._read_pos, rows)
+        if self._buffer is None:
+            self._buffer = np.empty((self._capacity, *chunk.shape[1:]), dtype=chunk.dtype)
+        self._buffer[self._valid : self._valid + rows] = chunk
+        self._valid += rows
+        self._read_pos += rows
+
+
+class _InMemoryBandSource:
+    """Band source for images already decoded in memory; bands are views into the array."""
+
+    def __init__(self, array: np.ndarray, expected_shape: tuple[int, int] | None = None) -> None:
+        """Serve bands from `array`, refusing it if it is not the size slices were planned for.
+
+        numpy clamps an out-of-range slice instead of raising, so a geometry/pixels
+        disagreement would hand back short bands and mis-sized slices rather than an
+        error. `_VipsBandSource` cross-checks its dimensions at open; this is that check
+        here, and on both axes: the `band[:, x_min:x_max]` cut in `_batches_from` has the
+        same hazard on x, where no quarter turn is needed to reach it.
+        """
+        actual = array.shape[:2]
+        if expected_shape is not None and actual != expected_shape:
+            raise ValueError(f"decoded image is {actual} where the header read saw {expected_shape}")
+        self._array = array
+
+    def read_band(self, y_min: int, y_max: int) -> np.ndarray:
+        """Return rows [y_min, y_max) of the image."""
+        return self._array[y_min:y_max]
+
+
+class _VipsBandSource:
+    """Stream bands from a file with libvips, decoding only as far as the current band.
+
+    Requires the optional `pyvips` extra. This is the only source that does not hold the
+    whole decoded image at once.
+
+    Memory is not constant in image height: libvips itself retains roughly 0.45 bytes per
+    pixel decoded. See docs/predict.md for the measurements.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        band_height: int,
+        expected_shape: tuple[int, int] | None = None,
+    ) -> None:
+        """Open `path` for sequential access and prepare the band reader.
+
+        Args:
+            path: Local file to stream.
+            band_height: Tallest band that will be requested.
+            expected_shape: (height, width) the caller computed for the image; a
+                mismatch means this source would mis-slice, so it refuses to open.
+        """
+        import pyvips
+
+        image = pyvips.Image.new_from_file(path, access="sequential")
+        # libvips omits the field entirely when the file carries no orientation tag
+        orientation = image.get("orientation") if image.get_typeof("orientation") else 1
+        if orientation != 1:
+            # read_image_as_pil applies every EXIF transform (mirrors and 180s, not only
+            # quarter turns) while sequential decoding applies none, so a streamed slice
+            # would carry the right geometry and the wrong pixels.
+            #
+            # This refuses on the tag alone, ignoring exif_fix. Pillow's TIFF plugin
+            # applies orientations 2-4 in load() whatever the caller asked for, so
+            # honouring the flag here made a mirrored TIFF differ on every slice.
+            raise ValueError(f"EXIF orientation {orientation} transforms the image")
+        if expected_shape is not None and (image.height, image.width) != expected_shape:
+            raise ValueError(f"libvips sees {(image.height, image.width)} where the header read saw {expected_shape}")
+        if image.interpretation not in ("srgb", "b-w"):
+            # libvips converts CMYK to sRGB without the Adobe inversion PIL and OpenCV
+            # apply, which is up to 127 levels of error per channel. An allowlist, since
+            # anything unlisted is safer decoded eagerly than converted differently.
+            raise ValueError(f"{image.interpretation} converts differently in libvips than in PIL")
+        if image.format != "uchar":
+            # colourspace() rescales deep samples onto 0-255 where PIL's I;16 -> RGB
+            # clips, so the two paths disagree by up to a full level.
+            # _read_local_image_as_arr bails to PIL for the same reason.
+            raise ValueError(f"{image.format} samples convert differently in libvips than in PIL")
+        # Match read_image_as_pil's .convert("RGB"): promote grayscale/CMYK to 3-channel
+        # sRGB and drop any alpha, so slices carry the same channels either way.
+        image = image.colourspace("srgb")
+        if image.bands > 3:
+            image = image[0:3]
+        self._image = image
+        # One region for the whole read. crop(...).numpy() evaluates the pipeline afresh
+        # per chunk, which desynchronises the sequential loader's line counter: the TIFF
+        # loader rejects that outright ("out of order read"), while the JPEG and PNG
+        # loaders happen to hold enough line cache to absorb it.
+        self._region = pyvips.Region.new(image)
+        self._reader = _ChunkedBandReader(
+            self._read_chunk,
+            image_height=self._image.height,
+            band_height=band_height,
+        )
+
+    def _read_chunk(self, y_min: int, rows: int) -> np.ndarray:
+        # colourspace("srgb") always yields an 8-bit image, so the buffer is plain uint8
+        buffer = self._region.fetch(0, y_min, self._image.width, rows)
+        return np.frombuffer(buffer, dtype=np.uint8).reshape(rows, self._image.width, self._image.bands)
+
+    def read_band(self, y_min: int, y_max: int) -> np.ndarray:
+        """Return rows [y_min, y_max) of the image."""
+        return self._reader.read_band(y_min, y_max)
+
+
+def _open_band_source(
+    image: str | Image.Image | np.ndarray,
+    band_height: int,
+    exif_fix: bool = True,
+    expected_shape: tuple[int, int] | None = None,
+) -> _InMemoryBandSource | _VipsBandSource:
+    """Select the cheapest band source available for this input.
+
+    Falls back to decoding the whole image when nothing cheaper applies, so behaviour
+    never regresses relative to `slice_image`.
+    """
+    # libvips reads files, so URLs skip it: handing it one costs an exception and a
+    # warning blaming libvips for a file it was never given.
+    if isinstance(image, str) and not image.startswith("http"):
+        try:
+            import pyvips  # noqa: F401
+        except Exception as error:
+            # pyvips binds libvips through cffi at import and raises OSError, not
+            # ImportError, when the shared library is absent. Both mean the optional extra
+            # is unusable here, which is the documented default.
+            logger.debug(f"pyvips is unusable ({error}), decoding the whole image instead")
+        else:
+            try:
+                return _VipsBandSource(image, band_height=band_height, expected_shape=expected_shape)
+            except Exception as error:
+                # warn: the caller may be relying on streaming to fit in RAM
+                logger.warning(f"libvips cannot stream {image} ({error}), decoding the whole image instead")
+    return _decode_band_source(image, exif_fix=exif_fix, expected_shape=expected_shape)
+
+
+def _decode_band_source(
+    image: str | Image.Image | np.ndarray,
+    exif_fix: bool = True,
+    expected_shape: tuple[int, int] | None = None,
+) -> _InMemoryBandSource:
+    """Decode the whole image up front and serve bands from memory."""
+    if isinstance(image, np.ndarray):
+        # match read_image_as_pil, which transposes CHW arrays; the transpose is a view
+        return _InMemoryBandSource(_to_hwc(image), expected_shape=expected_shape)
+    # a Pillow image is already decoded, so there is nothing left to defer
+    image_arr: np.ndarray = read_image_as_pil(image, exif_fix=exif_fix, return_arr=True)  # type: ignore[assignment]
+    return _InMemoryBandSource(image_arr, expected_shape=expected_shape)
+
+
 def slice_image(
     image: str | Image.Image | np.ndarray,
     coco_annotation_list: list[CocoAnnotation] | None = None,
@@ -327,25 +892,17 @@ def slice_image(
     # define verboseprint
     verboselog = logger.info if verbose else lambda *a, **k: None
 
-    def _export_single_slice(image: np.ndarray, output_dir: str, slice_file_name: str) -> None:
-        image_pil = read_image_as_pil(image, exif_fix=exif_fix)
-        slice_file_path = str(Path(output_dir) / slice_file_name)
-        # export sliced image
-        image_pil.save(slice_file_path)
-        image_pil.close()  # to fix https://github.com/obss/sahi/issues/565
-        verboselog("sliced image path: " + slice_file_path)
-
     # create outdir if not present
     if output_dir is not None:
         Path(output_dir).mkdir(parents=True, exist_ok=True)
 
-    # read image
-    image_pil = read_image_as_pil(image, exif_fix=exif_fix)
-    verboselog("image.shape: " + str(image_pil.size))
+    # read image directly as an array, so no full-size PIL copy is held alongside it
+    image_arr: np.ndarray = read_image_as_pil(image, exif_fix=exif_fix, return_arr=True)  # type: ignore[assignment]
+    image_height, image_width = image_arr.shape[:2]
+    verboselog("image.shape: " + str((image_width, image_height)))
 
-    image_width, image_height = image_pil.size
     if not (image_width != 0 and image_height != 0):
-        raise RuntimeError(f"invalid image size: {image_pil.size} for 'slice_image'.")
+        raise RuntimeError(f"invalid image size: {(image_width, image_height)} for 'slice_image'.")
     slice_bboxes = get_slice_bboxes(
         image_height=image_height,
         image_width=image_width,
@@ -361,7 +918,8 @@ def slice_image(
     # init images and annotations lists
     sliced_image_result = SliceImageResult(original_image_size=[image_height, image_width], image_dir=output_dir)
 
-    image_pil_arr = np.asarray(image_pil)
+    suffix = _slice_file_suffix(image, out_ext)
+
     # iterate over slices
     for slice_bbox in slice_bboxes:
         n_ims += 1
@@ -371,22 +929,10 @@ def slice_image(
         tly = slice_bbox[1]
         brx = slice_bbox[2]
         bry = slice_bbox[3]
-        image_pil_slice = image_pil_arr[tly:bry, tlx:brx]
-
-        # set image file suffixes
-        slice_suffixes = "_".join(map(str, slice_bbox))
-        if out_ext:
-            suffix = out_ext
-        elif hasattr(image_pil, "filename"):
-            suffix = Path(getattr(image_pil, "filename")).suffix
-            if suffix in IMAGE_EXTENSIONS_LOSSY:
-                suffix = ".png"
-            elif suffix in IMAGE_EXTENSIONS_LOSSLESS:
-                suffix = Path(image_pil.filename).suffix
-        else:
-            suffix = ".png"
+        image_pil_slice = image_arr[tly:bry, tlx:brx]
 
         # set image file name and path
+        slice_suffixes = "_".join(map(str, slice_bbox))
         slice_file_name = f"{output_file_name}_{slice_suffixes}{suffix}"
 
         # create coco image
@@ -416,12 +962,15 @@ def slice_image(
         max_workers = max(1, max_workers)
         with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
             # map will schedule tasks and wait for completion when the context exits
+            num = len(sliced_image_result)
             list(
                 executor.map(
-                    _export_single_slice,
+                    _export_slice,
                     sliced_image_result.images,
-                    [output_dir] * len(sliced_image_result),
-                    sliced_image_result.filenames,
+                    sliced_image_result.starting_pixels,
+                    [output_dir] * num,
+                    [output_file_name] * num,
+                    [suffix] * num,
                 )
             )
 

--- a/sahi/utils/cv.py
+++ b/sahi/utils/cv.py
@@ -16,6 +16,12 @@ from sahi.logger import logger
 from sahi.utils.file import Path
 from sahi.utils.import_utils import get_opencv_conflict_message
 
+# OpenCV refuses to decode images above 2**30 pixels and reads the limit once at import
+# time, so it has to be raised before cv2 is imported. Gigapixel scans exceed it (a
+# 39266x29140 slide is 1144 MP) and would otherwise take the costlier PIL path, whose
+# equivalent guard sahi already lifts below. setdefault so a user setting still wins.
+os.environ.setdefault("OPENCV_IO_MAX_IMAGE_PIXELS", str(2**40))
+
 try:
     import cv2
 except Exception:
@@ -200,16 +206,118 @@ def _to_hwc(arr: np.ndarray) -> np.ndarray:
     return a
 
 
+def _read_local_image_as_arr(path: str, exif_fix: bool = True) -> np.ndarray | None:
+    """Decode a local image file straight to an HWC RGB ndarray, skipping the PIL intermediate.
+
+    `np.asarray(PIL.Image)` goes through `Image.tobytes()`, so the PIL path costs two
+    full-size buffers on top of the transient `.convert("RGB")` allocation. Decoding with
+    OpenCV and swapping channels in place leaves one, which is what lets gigapixel inputs
+    fit in RAM.
+
+    Args:
+        path (str): Local filesystem path of the image.
+        exif_fix (bool): Whether to honor the EXIF orientation tag. Defaults to True.
+
+    Returns:
+        np.ndarray | None: HWC RGB uint8 array, or None when OpenCV cannot decode the
+            file (unsupported codec, or a pixel count above `CV_IO_MAX_IMAGE_PIXELS`)
+            so the caller can fall back to the PIL/skimage path.
+
+    Note:
+        Returning None is a normal outcome, but OpenCV is not quiet about it: for a TIFF
+        carrying an EXIF orientation tag it prints its own C++ error to stderr first.
+        That text is not raised and cannot be caught; the decode falls back to PIL and
+        the result is correct.
+    """
+    # ANYDEPTH keeps 16-bit samples 16-bit so they can be detected below; plain
+    # IMREAD_COLOR would silently rescale them where the PIL path clips, and the two
+    # entry points must agree on the same file.
+    flags = cv2.IMREAD_COLOR | cv2.IMREAD_ANYDEPTH
+    if not exif_fix:
+        flags |= cv2.IMREAD_IGNORE_ORIENTATION
+    try:
+        bgr = cv2.imread(path, flags)
+    except cv2.error:
+        # OpenCV hard-fails above CV_IO_MAX_IMAGE_PIXELS instead of returning None.
+        # Gigapixel scans land here; PIL reads them since read_image_as_pil clears
+        # Image.MAX_IMAGE_PIXELS.
+        return None
+    if bgr is None:
+        return None
+    if bgr.dtype != np.uint8:
+        # deep images take the PIL path so both entry points convert identically
+        return None
+    # in-place channel swap, so no second full-size buffer is allocated
+    return cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB, dst=bgr)
+
+
+# EXIF orientation tag; values 5-8 rotate by a quarter turn and so swap width and height.
+_EXIF_ORIENTATION_TAG = 0x0112
+_EXIF_QUARTER_TURNS = frozenset({5, 6, 7, 8})
+
+
+def read_image_size(image: Image.Image | str | os.PathLike | np.ndarray, exif_fix: bool = True) -> tuple[int, int]:
+    """Return the (width, height) `read_image_as_pil` would produce, without decoding it.
+
+    For a local path only the header is read. Decoding a gigapixel scan just to ask for
+    its dimensions costs gigabytes.
+
+    Args:
+        image: The image to size. An image path or URL (str), a numpy image (np.ndarray),
+            or a PIL.Image object.
+        exif_fix: Whether the caller will apply the EXIF orientation, as
+            `read_image_as_pil` does by default.
+
+    Returns:
+        The image size as (width, height).
+    """
+    if isinstance(image, np.ndarray):
+        # read_image_as_pil transposes CHW input, so the reported size must match that
+        hwc = _to_hwc(image)
+        return hwc.shape[1], hwc.shape[0]
+    if isinstance(image, Image.Image):
+        return image.size
+    if str(image).startswith("http"):
+        # remote images have no local header to peek at, so there is nothing to save
+        return read_image_as_pil(image, exif_fix=exif_fix).size  # type: ignore[union-attr]
+    # https://stackoverflow.com/questions/56174099/how-to-load-images-larger-than-max-image-pixels-with-pil
+    Image.MAX_IMAGE_PIXELS = None
+    try:
+        with Image.open(image) as image_pil:
+            width, height = image_pil.size
+            # Pillow's TIFF plugin swaps _size for a quarter turn in _setup, at open, and
+            # only drops the tag later in load(), which a header read never reaches. So a
+            # TIFF reports the transposed size while still advertising the tag, and
+            # swapping again would undo it. Every other plugin leaves the work to
+            # exif_transpose and so does report the untransposed size here.
+            if (
+                exif_fix
+                and image_pil.format != "TIFF"
+                and image_pil.getexif().get(_EXIF_ORIENTATION_TAG) in _EXIF_QUARTER_TURNS
+            ):
+                return height, width
+    except FileNotFoundError:
+        raise
+    except Exception as error:
+        # read_image_as_pil has a skimage fallback for files PIL cannot open, so a failed
+        # header read must not make sizing stricter than decoding. Logged because the
+        # fallback decodes the whole file: a header read failing on every image would
+        # otherwise look like a memory bug.
+        logger.debug(f"header read of {image} failed ({error}), sizing from a full decode instead")
+        return read_image_as_pil(image, exif_fix=exif_fix).size  # type: ignore[union-attr]
+    return width, height
+
+
 def read_image_as_pil(
-    image: Image.Image | str | np.ndarray,
+    image: Image.Image | str | os.PathLike | np.ndarray,
     exif_fix: bool = True,
     return_arr: bool = False,
 ) -> Image.Image | np.ndarray:
     """Loads an image as PIL.Image.Image (or np.ndarray when return_arr=True).
 
     Args:
-        image (Union[Image.Image, str, np.ndarray]): The image to be loaded. It can be an image path or URL (str),
-            a numpy image (np.ndarray), or a PIL.Image object.
+        image (Union[Image.Image, str, os.PathLike, np.ndarray]): The image to be loaded. It can be an image path
+            (str or path-like) or URL (str), a numpy image (np.ndarray), or a PIL.Image object.
         exif_fix (bool): Whether to apply an EXIF fix to the image. Defaults to False.
         return_arr (bool): When True and the input is already a numpy array, skip the
             costly PIL conversion and return an HWC RGB ndarray directly. For PIL/str inputs the
@@ -221,11 +329,21 @@ def read_image_as_pil(
     # https://stackoverflow.com/questions/56174099/how-to-load-images-larger-than-max-image-pixels-with-pil
     Image.MAX_IMAGE_PIXELS = None
 
+    if isinstance(image, os.PathLike):
+        # read_image_size already accepts a Path (Image.open does), so rejecting one here
+        # meant a path could be sized and then fail to decode.
+        image = os.fspath(image)
+
     if isinstance(image, Image.Image):
         if return_arr:
             return np.asarray(image)
         return image
     elif isinstance(image, str):
+        # local files decode straight to an array; URLs still need the download path below
+        if return_arr and not str(image).startswith("http"):
+            image_arr = _read_local_image_as_arr(image, exif_fix=exif_fix)
+            if image_arr is not None:
+                return image_arr
         # read image if str image path is provided
         try:
             import requests

--- a/scripts/benchmark_streaming_slices.py
+++ b/scripts/benchmark_streaming_slices.py
@@ -1,0 +1,182 @@
+"""Benchmark streaming slice reads against the eager whole-image decode.
+
+Measures peak RSS and wall time for `SliceImageStream` (reads one row-band at a time)
+against `slice_image` (decodes the image, then materialises every slice). Each
+measurement runs in a fresh child process, because `ru_maxrss` is a high-water mark that
+never comes back down: measuring both paths in one process would report the larger.
+
+The eager path allocates the full decoded image plus every slice, so it is expected to
+fail with `MemoryError` on large sizes. That is a result, not a crash, and is reported
+as `OOM`.
+
+Usage:
+    python scripts/benchmark_streaming_slices.py                 # 1..256 MP sweep
+    python scripts/benchmark_streaming_slices.py --mp 1 16 64    # pick sizes
+    python scripts/benchmark_streaming_slices.py --image scan.jpg
+    python scripts/benchmark_streaming_slices.py --keep-images   # reuse across runs
+
+Requires `pip install sahi[bigimage]` for the streaming column to mean anything; without
+libvips it silently measures the fallback, and the script says so up front.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SLICE = 640
+OVERLAP = 0.2
+BATCH_SIZE = 8
+DEFAULT_MP = [1, 16, 64, 144, 256]
+
+# Run one path over one image and print "<seconds> <peak_kib>". Kept as source rather
+# than imported so the child starts clean, with no sahi module already resident.
+_PROBE = """
+import resource, sys, time
+path, mode = sys.argv[1], sys.argv[2]
+
+def consume():
+    # GIL-holding stand-in for per-batch inference. Deliberately pure Python: a real
+    # model releases the GIL, so anything prefetch wins here it wins by more in practice.
+    total = 0
+    for _ in range({consume_iters}):
+        total = (total + 1) & 255
+    return total
+
+start = time.perf_counter()
+if mode.startswith("streaming"):
+    from sahi.slicing import SliceImageStream
+    stream = SliceImageStream(
+        path, slice_height={slice}, slice_width={slice},
+        overlap_height_ratio={overlap}, overlap_width_ratio={overlap},
+        auto_slice_resolution=False,
+    )
+    for images, starts in stream.iter_batches({batch}, prefetch=mode.endswith("prefetch")):
+        consume()
+else:
+    from sahi.slicing import slice_image
+    result = slice_image(
+        image=path, slice_height={slice}, slice_width={slice},
+        overlap_height_ratio={overlap}, overlap_width_ratio={overlap},
+        auto_slice_resolution=False,
+    )
+    # per batch, not per slice, so both paths pay the same simulated inference
+    for _ in range(0, len(result.images), {batch}):
+        consume()
+print(time.perf_counter() - start, resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+"""
+
+# Pure-Python iterations standing in for one batch of inference. 3M lands near 30 ms,
+# which is the order a small detector takes on a batch of 8 slices.
+CONSUME_ITERS = {0.0: 0, 30.0: 3_000_000}
+
+
+def probe(path: str, mode: str, consume_ms: float) -> tuple[float, float] | None:
+    """Run `mode` over `path` in a fresh process. Returns (seconds, peak MB), or None on OOM."""
+    iters = CONSUME_ITERS.get(consume_ms, int(consume_ms * 100_000))
+    source = _PROBE.format(slice=SLICE, overlap=OVERLAP, batch=BATCH_SIZE, consume_iters=iters)
+    done = subprocess.run([sys.executable, "-c", source, path, mode], capture_output=True, text=True)
+    if done.returncode != 0:
+        if "MemoryError" in done.stderr or done.returncode == -9:  # -9 is the OOM killer
+            return None
+        raise RuntimeError(f"{mode} probe failed on {path}:\n{done.stderr}")
+    seconds, max_rss = done.stdout.split()
+    # ru_maxrss is KiB on Linux and bytes on macOS
+    divisor = 1024 if sys.platform == "linux" else 1024**2
+    return float(seconds), int(max_rss) / divisor
+
+
+def write_test_image(path: Path, megapixels: int) -> None:
+    """Write a square JPEG of the requested size without holding it in memory."""
+    side = int(math.sqrt(megapixels * 1_000_000))
+    try:
+        import pyvips
+
+        # gaussian noise, so the JPEG does not compress to nothing and the decoder does
+        # real work; .copy(interpretation=...) tags it sRGB without a conversion pass
+        pyvips.Image.gaussnoise(side, side, mean=128, sigma=40).bandjoin(
+            [pyvips.Image.gaussnoise(side, side, mean=128, sigma=40) for _ in range(2)]
+        ).cast("uchar").copy(interpretation="srgb").write_to_file(str(path), Q=90)
+    except Exception:
+        # not just ImportError: pyvips binds libvips through cffi at import and raises
+        # OSError when the shared library is absent, which is the common case here
+        import numpy as np
+        from PIL import Image
+
+        Image.MAX_IMAGE_PIXELS = None
+        rng = np.random.default_rng(0)
+        Image.fromarray(rng.integers(0, 255, (side, side, 3), dtype=np.uint8)).save(path, quality=90)
+
+
+def fmt(result: tuple[float, float] | None) -> str:
+    """Render one cell of the results table."""
+    if result is None:
+        return "OOM"
+    seconds, peak_mb = result
+    return f"{seconds:.2f} s / {peak_mb:.0f} MB"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--image", help="benchmark this file instead of the generated sweep")
+    parser.add_argument("--mp", type=int, nargs="+", default=DEFAULT_MP, help="megapixel sizes to generate")
+    parser.add_argument("--keep-images", action="store_true", help="keep generated images for reuse")
+    parser.add_argument(
+        "--consume-ms",
+        type=float,
+        default=0.0,
+        help="simulated per-batch inference cost. Prefetch only pays off above roughly 30",
+    )
+    args = parser.parse_args()
+
+    try:
+        import pyvips
+
+        print(f"libvips {pyvips.version(0)}.{pyvips.version(1)}.{pyvips.version(2)} — streaming active\n")
+    except Exception as error:
+        print(f"!! pyvips unusable ({error}); the streaming column measures the fallback, not libvips.")
+        print("!! Install with: pip install sahi[bigimage]\n")
+
+    if args.image:
+        cases = [(Path(args.image).name, Path(args.image))]
+        holder = None
+    else:
+        holder = Path("scripts/outputs/bench") if args.keep_images else Path(tempfile.mkdtemp())
+        holder.mkdir(parents=True, exist_ok=True)
+        cases = []
+        for megapixels in args.mp:
+            path = holder / f"noise_{megapixels}mp.jpg"
+            if not path.exists():
+                print(f"generating {megapixels} MP test image...", flush=True)
+                write_test_image(path, megapixels)
+            cases.append((f"{megapixels} MP", path))
+        print()
+
+    print(f"{SLICE}x{SLICE} slices at {OVERLAP} overlap, batch {BATCH_SIZE}, peak RSS of a fresh process")
+    print(f"simulated inference: {args.consume_ms:.0f} ms/batch\n")
+    print("| image | eager (slice_image) | streaming, no prefetch | streaming + prefetch |")
+    print("| --- | --- | --- | --- |")
+    for label, path in cases:
+        eager = probe(str(path), "eager", args.consume_ms)
+        serial = probe(str(path), "streaming", args.consume_ms)
+        prefetched = probe(str(path), "streaming+prefetch", args.consume_ms)
+        print(f"| {label} | {fmt(eager)} | {fmt(serial)} | {fmt(prefetched)} |", flush=True)
+
+    print("\nStreaming costs a flat ~0.1 s for `import pyvips`, paid once per process. On")
+    print("small images that fixed cost outweighs the saving; it is the large end that matters.")
+    if args.consume_ms == 0:
+        print("Prefetch has nothing to overlap with at 0 ms/batch. Try --consume-ms 30.")
+
+    if holder is not None and not args.keep_images:
+        for _, path in cases:
+            path.unlink(missing_ok=True)
+        holder.rmdir()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cv_utils.py
+++ b/tests/test_cv_utils.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import cv2
 import numpy as np
+import pytest
+from PIL import Image, ImageOps
 
 from sahi.utils.cv import (
     Colors,
@@ -12,7 +16,177 @@ from sahi.utils.cv import (
     get_bbox_from_bool_mask,
     get_coco_segmentation_from_bool_mask,
     read_image,
+    read_image_as_pil,
+    read_image_size,
 )
+
+
+class TestReadImageSize:
+    """Test read_image_size, which reads sizes from the header rather than decoding."""
+
+    def _save(self, path: str, height: int, width: int, orientation: int | None = None) -> None:
+        image = Image.fromarray(np.full((height, width, 3), 90, dtype=np.uint8))
+        if orientation is None:
+            image.save(path)
+            return
+        exif = Image.Exif()
+        exif[0x0112] = orientation
+        image.save(path, exif=exif)
+
+    def test_matches_a_full_decode_for_a_plain_image(self, tmp_path: Path) -> None:
+        """Test the header read agrees with a full decode."""
+        path = str(tmp_path / "plain.png")
+        self._save(path, height=30, width=40)
+
+        assert read_image_size(path) == read_image_as_pil(path).size == (40, 30)
+
+    @pytest.mark.parametrize("suffix", [".jpg", ".png", ".tif"])
+    @pytest.mark.parametrize("orientation", [5, 6, 7, 8])
+    def test_quarter_turn_exif_swaps_the_axes(self, tmp_path: Path, orientation: int, suffix: str) -> None:
+        """Test EXIF orientations 5-8 swap the reported axes.
+
+        These are quarter turns, which `read_image_as_pil` applies, so a header read
+        alone reports them backwards. Containers differ in who applies the tag: PIL's
+        TIFF plugin does it on load, so its header size already accounts for it.
+        """
+        path = str(tmp_path / f"rotated{suffix}")
+        self._save(path, height=30, width=40, orientation=orientation)
+
+        assert read_image_size(path) == read_image_as_pil(path).size == (30, 40)
+
+    @pytest.mark.parametrize("suffix", [".jpg", ".png", ".tif"])
+    @pytest.mark.parametrize("orientation", [1, 2, 3, 4])
+    def test_non_rotating_exif_keeps_the_axes(self, tmp_path: Path, orientation: int, suffix: str) -> None:
+        """Test EXIF orientations 2-4 keep the reported axes, being flips and 180s."""
+        path = str(tmp_path / f"flipped{suffix}")
+        self._save(path, height=30, width=40, orientation=orientation)
+
+        assert read_image_size(path) == read_image_as_pil(path).size == (40, 30)
+
+    def test_exif_is_ignored_when_the_caller_disables_the_fix(self, tmp_path: Path) -> None:
+        """Test exif_fix=False reports the header size, no rotation applied."""
+        path = str(tmp_path / "rotated.jpg")
+        self._save(path, height=30, width=40, orientation=6)
+
+        assert read_image_size(path, exif_fix=False) == (40, 30)
+
+    @pytest.mark.parametrize("as_array", [True, False])
+    def test_in_memory_images_report_their_own_size(self, as_array: bool) -> None:
+        """Test already-decoded inputs, which have nothing to defer and no EXIF left."""
+        pixels = np.full((30, 40, 3), 5, dtype=np.uint8)
+
+        assert read_image_size(pixels if as_array else Image.fromarray(pixels)) == (40, 30)
+
+    def test_chw_array_reports_the_transposed_size(self) -> None:
+        """Test CHW arrays report the size read_image_as_pil's transpose produces."""
+        chw = np.zeros((3, 30, 40), dtype=np.uint8)
+
+        assert read_image_size(chw) == (40, 30)
+
+    def test_falls_back_to_full_decode_when_the_header_read_fails(self, tmp_path: Path) -> None:
+        """Test a file PIL cannot open falls back to read_image_as_pil's skimage path.
+
+        The fallback has to be stubbed: `sahi.utils.cv.Image` is the PIL module itself, so
+        patching `Image.open` breaks skimage's own reader too. The stub reports a size the
+        file does not have, so a header read that quietly succeeded would fail the assert.
+        """
+        path = str(tmp_path / "odd.png")
+        Image.fromarray(np.full((30, 40, 3), 9, dtype=np.uint8)).save(path)
+
+        with patch("sahi.utils.cv.Image.open", side_effect=OSError("unsupported")):
+            with patch("sahi.utils.cv.read_image_as_pil", return_value=Image.new("RGB", (7, 5))) as fallback:
+                assert read_image_size(path) == (7, 5)
+
+        fallback.assert_called_once()
+
+
+class TestSixteenBitDecodeParity:
+    """Test the cv2 fast path returns what the PIL path returns for the same file."""
+
+    def test_return_arr_matches_pil_path_for_16bit_png(self, tmp_path: Path) -> None:
+        """Test 16-bit files take the PIL path.
+
+        cv2's IMREAD_COLOR rescales 16-bit samples where PIL clips I;16 at 255, and the
+        two entry points must not disagree on the same file.
+        """
+        path = str(tmp_path / "deep.png")
+        pixels = np.array([[55745, 41743, 33497, 120]], dtype=np.uint16)
+        cv2.imwrite(path, pixels)
+
+        via_arr = read_image_as_pil(path, return_arr=True)
+        via_pil = np.asarray(read_image_as_pil(path))
+
+        np.testing.assert_array_equal(via_arr, via_pil)
+
+
+def pil_reference_decode(path: str, exif_fix: bool = True) -> np.ndarray:
+    """Decode exactly as sahi did before the OpenCV fast path existed.
+
+    Every other pixel test compares one current code path against another, and both now
+    share the cv2 decode, so a regression in it would be invisible to all of them. This
+    is the fixed reference they cannot drift away from together.
+    """
+    image = Image.open(path).convert("RGB")
+    if exif_fix:
+        ImageOps.exif_transpose(image, in_place=True)
+    return np.asarray(image)
+
+
+class TestDecoderParity:
+    """Test the current decode against the pre-change PIL decode."""
+
+    @pytest.mark.parametrize(
+        ("mode", "suffix"),
+        [
+            (mode, suffix)
+            for mode in ("RGB", "L", "1", "P", "LA", "RGBA")
+            for suffix in (".png", ".tif", ".jpg")
+            if not (suffix == ".jpg" and mode in ("P", "LA", "RGBA"))
+        ],
+    )
+    def test_decode_matches_the_pil_reference(self, tmp_path: Path, mode: str, suffix: str) -> None:
+        """Test each colour mode decodes to what the PIL path produced."""
+        path = str(tmp_path / f"{mode}{suffix}")
+        source = np.random.default_rng(21).integers(0, 255, (24, 32, 3), dtype=np.uint8)
+        Image.fromarray(source).convert(mode).save(path)
+
+        result = read_image_as_pil(path, return_arr=True)
+
+        assert isinstance(result, np.ndarray)
+        np.testing.assert_array_equal(result, pil_reference_decode(path))
+
+    @pytest.mark.parametrize("suffix", [".jpg", ".tif"])
+    def test_cmyk_decode_matches_the_pil_reference_within_rounding(self, tmp_path: Path, suffix: str) -> None:
+        """Test CMYK matches the PIL reference to within a level.
+
+        cv2 and PIL round the CMYK inversion differently, so this one is not exact. The
+        bound still matters: libvips converts CMYK without the Adobe inversion at all,
+        which is 127 levels out, not one.
+        """
+        path = str(tmp_path / f"cmyk{suffix}")
+        source = np.random.default_rng(22).integers(0, 255, (24, 32, 3), dtype=np.uint8)
+        Image.fromarray(source).convert("CMYK").save(path)
+
+        result = read_image_as_pil(path, return_arr=True)
+
+        np.testing.assert_allclose(np.asarray(result, dtype=int), pil_reference_decode(path).astype(int), atol=1)
+
+    @pytest.mark.parametrize("suffix", [".jpg", ".png", ".tif"])
+    @pytest.mark.parametrize("orientation", [1, 2, 3, 4, 5, 6, 7, 8])
+    @pytest.mark.parametrize("exif_fix", [True, False])
+    def test_oriented_decode_matches_the_pil_reference(
+        self, tmp_path: Path, orientation: int, suffix: str, exif_fix: bool
+    ) -> None:
+        """Test the EXIF orientation is applied exactly as the PIL path applied it."""
+        path = str(tmp_path / f"rotated{suffix}")
+        exif = Image.Exif()
+        exif[0x0112] = orientation
+        source = np.random.default_rng(23).integers(0, 255, (24, 32, 3), dtype=np.uint8)
+        Image.fromarray(source).save(path, exif=exif)
+
+        result = read_image_as_pil(path, return_arr=True, exif_fix=exif_fix)
+
+        np.testing.assert_array_equal(result, pil_reference_decode(path, exif_fix=exif_fix))
 
 
 class TestCvUtils:
@@ -43,6 +217,51 @@ class TestCvUtils:
         # mock_cv2.assert_called_once_with(fake_image)
         mock_imread.assert_called_once_with(fake_image)
         np.testing.assert_array_equal(result, fake_image_rbg_val)
+
+    def test_read_image_as_pil_return_arr_matches_pil_path(self, tmp_path: Path) -> None:
+        """Test the array fast path is pixel-identical to the PIL path, RGB order included.
+
+        The fast path decodes via OpenCV, which yields BGR, and a missed channel swap
+        degrades predictions silently rather than raising.
+        """
+        # asymmetric channels: a BGR/RGB mix-up cannot pass by coincidence
+        expected = np.zeros((4, 6, 3), dtype=np.uint8)
+        expected[..., 0], expected[..., 1], expected[..., 2] = 200, 120, 40
+        path = str(tmp_path / "swatch.png")
+        Image.fromarray(expected).save(path)
+
+        result = read_image_as_pil(path, return_arr=True)
+
+        assert isinstance(result, np.ndarray)
+        np.testing.assert_array_equal(result, expected)
+        np.testing.assert_array_equal(result, np.asarray(Image.open(path).convert("RGB")))
+
+    def test_read_image_as_pil_return_arr_falls_back_when_opencv_fails(self, tmp_path: Path) -> None:
+        """Test a file OpenCV cannot decode falls back to the PIL path."""
+        expected = np.full((3, 5, 3), 77, dtype=np.uint8)
+        path = str(tmp_path / "fallback.png")
+        Image.fromarray(expected).save(path)
+
+        with patch("sahi.utils.cv.cv2.imread", return_value=None):
+            result = read_image_as_pil(path, return_arr=True)
+
+        np.testing.assert_array_equal(np.asarray(result), expected)
+
+    def test_read_image_as_pil_return_arr_survives_opencv_pixel_limit(self, tmp_path: Path) -> None:
+        """Test a cv2.imread that raises falls back rather than propagating.
+
+        Images above CV_IO_MAX_IMAGE_PIXELS raise instead of returning None, and real
+        gigapixel scans hit it (39266x29140 is 1.14e9 px against OpenCV's 2**30 cap).
+        """
+        expected = np.full((3, 5, 3), 42, dtype=np.uint8)
+        path = str(tmp_path / "huge.png")
+        Image.fromarray(expected).save(path)
+        boom = cv2.error("OpenCV(5.0.0) ... (-215:Assertion failed) pixels <= CV_IO_MAX_IMAGE_PIXELS")
+
+        with patch("sahi.utils.cv.cv2.imread", side_effect=boom):
+            result = read_image_as_pil(path, return_arr=True)
+
+        np.testing.assert_array_equal(np.asarray(result), expected)
 
     def test_apply_color_mask(self) -> None:
         """Test applying color mask to image."""

--- a/tests/test_predict_stream.py
+++ b/tests/test_predict_stream.py
@@ -1,0 +1,304 @@
+"""Tests for streaming slice reads inside get_sliced_prediction."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from sahi.predict import get_sliced_prediction
+from sahi.slicing import _group_bboxes_into_bands, get_slice_bboxes, slice_image
+
+SLICE = 128
+OVERLAP = 0.2
+
+
+class RecordingModel:
+    """A detection model that predicts nothing and records what it was handed.
+
+    Implements only the surface `get_sliced_prediction` touches. The real base class
+    pulls in torch, which these tests run without.
+    """
+
+    def __init__(self, events: list[str] | None = None) -> None:
+        self.confidence_threshold = 0.5
+        self.batches: list[list[np.ndarray]] = []
+        self.shifts: list[list[list[int | float]]] = []
+        self.object_prediction_list_per_image: list[list] = []
+        self.object_prediction_list: list = []
+        # shared with the band-source spy, so reads and inferences can be interleaved
+        self.events = events if events is not None else []
+
+    def perform_inference(self, image: np.ndarray) -> None:
+        """Whole-image inference, which `perform_standard_pred=True` adds on top."""
+        self.events.append("standard_infer")
+
+    def perform_batch_inference(self, images: list[np.ndarray]) -> None:
+        self.events.append("infer")
+        # the eager path fed models np.ascontiguousarray output and backends index into
+        # the buffer directly, so a non-contiguous slice is a silent wrong-pixels bug
+        assert all(image.flags["C_CONTIGUOUS"] for image in images), "slices must reach the model contiguous"
+        self.batches.append([image.copy() for image in images])
+        self.object_prediction_list_per_image = [[] for _ in images]
+
+    def convert_original_predictions(self, shift_amount: list, full_shape: list) -> None:
+        self.shifts.append(shift_amount)
+
+
+def make_image(height: int, width: int, seed: int = 0) -> np.ndarray:
+    """Noise image; any band-boundary mistake shows up as a pixel mismatch."""
+    return np.random.default_rng(seed).integers(0, 255, (height, width, 3), dtype=np.uint8)
+
+
+def run(path: str, batch_size: int, model: RecordingModel | None = None, **kwargs: Any) -> RecordingModel:
+    """Run a sliced prediction that produces no detections, and return the model."""
+    model = model or RecordingModel()
+    get_sliced_prediction(
+        image=path,
+        detection_model=model,  # type: ignore[arg-type]
+        slice_height=SLICE,
+        slice_width=SLICE,
+        overlap_height_ratio=OVERLAP,
+        overlap_width_ratio=OVERLAP,
+        auto_slice_resolution=False,
+        batch_size=batch_size,
+        verbose=0,
+        **{"perform_standard_pred": False, **kwargs},
+    )
+    return model
+
+
+class TestSlicedPredictionEquivalence:
+    """Test the model receives what the eager path would have produced."""
+
+    @pytest.mark.parametrize("batch_size", [1, 4])
+    def test_model_receives_same_slices_as_slice_image(self, tmp_path: Path, batch_size: int) -> None:
+        """Test the same slices arrive, in the same order, as slice_image produces."""
+        path = str(tmp_path / "scan.png")
+        Image.fromarray(make_image(300, 400, seed=1)).save(path)
+        eager = slice_image(
+            image=path,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+        )
+
+        model = run(path, batch_size)
+
+        received = [image for batch in model.batches for image in batch]
+        assert len(received) == len(eager)
+        for index, (got, want) in enumerate(zip(received, eager.images)):
+            np.testing.assert_array_equal(got, want, err_msg=f"slice {index} differs")
+
+    def test_shift_amounts_match_slice_image_starting_pixels(self, tmp_path: Path) -> None:
+        path = str(tmp_path / "scan.png")
+        Image.fromarray(make_image(300, 400, seed=2)).save(path)
+        eager = slice_image(
+            image=path,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+        )
+
+        model = run(path, batch_size=4)
+
+        received = [shift for batch in model.shifts for shift in batch]
+        assert received == [list(pixel) for pixel in eager.starting_pixels]
+
+
+class TestStreamingIsActuallyUsed:
+    """Test slices really are streamed. Eager slicing passes the equivalence tests too."""
+
+    def test_read_ahead_stays_bounded(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test bands are read as inference consumes them, rather than all up front.
+
+        Not strict read/infer alternation: the prefetch worker reads one band ahead by
+        design, so a read may overtake an inference. What must stay true is that the
+        read-ahead is *bounded* — if slicing went back to materialising everything, every
+        band would be read before the first inference.
+        """
+        import sahi.slicing as slicing
+
+        events: list[str] = []
+        open_band_source = slicing._open_band_source
+
+        def spy(*args: Any, **kwargs: Any) -> Any:
+            source = open_band_source(*args, **kwargs)
+            read_band = source.read_band
+
+            def recording_read_band(y_min: int, y_max: int) -> np.ndarray:
+                events.append("read")
+                return read_band(y_min, y_max)
+
+            source.read_band = recording_read_band  # type: ignore[method-assign]
+            return source
+
+        monkeypatch.setattr(slicing, "_open_band_source", spy)
+        path = str(tmp_path / "scan.png")
+        Image.fromarray(make_image(300, 400, seed=3)).save(path)
+        bands = _group_bboxes_into_bands(get_slice_bboxes(300, 400, SLICE, SLICE, False, OVERLAP, OVERLAP))
+        assert len(bands) > 1, "fixture no longer exercises more than one band"
+
+        run(path, batch_size=3, model=RecordingModel(events))
+
+        assert events.count("read") == len(bands)
+        assert events[0] == "read", "inference ran before any band was read"
+        # one band in the queue plus one being cut is the most _prefetch(depth=1) allows
+        reads_before_first_infer = events.index("infer")
+        assert reads_before_first_infer <= 2, (
+            f"{reads_before_first_infer} of {len(bands)} bands were read before the first "
+            f"inference; read-ahead should be bounded by the prefetch depth"
+        )
+        # and the rest really are read later, not front-loaded
+        assert events.count("read") > reads_before_first_infer, "every band was read up front"
+
+
+def pyvips_installed() -> bool:
+    """Whether the optional libvips extra is usable here.
+
+    pyvips raises OSError, not ImportError, when the shared library is missing.
+    """
+    try:
+        import pyvips  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+class TestStandardPredWarning:
+    """Test the streaming caller is told when perform_standard_pred undoes the saving.
+
+    It defaults to True and runs inference on the *whole* image, which decodes it in one
+    piece: the peak memory the streaming path exists to bound is silently restored.
+    """
+
+    @pytest.mark.skipif(not pyvips_installed(), reason="pyvips is an optional extra")
+    def test_warns_when_streaming_and_standard_pred_is_on(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test the warning fires, and names the flag that turns it off."""
+        path = str(tmp_path / "scan.png")
+        Image.fromarray(make_image(300, 400)).save(path)
+
+        with caplog.at_level("WARNING"):
+            model = run(path, batch_size=2, perform_standard_pred=True)
+
+        assert "standard_infer" in model.events, "fixture no longer runs the standard prediction"
+        assert "perform_standard_pred=False" in caplog.text
+
+    def test_no_warning_when_standard_pred_is_off(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """Test the caller who already did the right thing is not nagged."""
+        path = str(tmp_path / "scan.png")
+        Image.fromarray(make_image(300, 400)).save(path)
+
+        with caplog.at_level("WARNING"):
+            run(path, batch_size=2)
+
+        assert "perform_standard_pred" not in caplog.text
+
+    def test_no_warning_when_the_image_is_not_streamed(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """Test an in-memory image does not warn: it is already decoded, so nothing is lost."""
+        with caplog.at_level("WARNING"):
+            get_sliced_prediction(
+                image=make_image(300, 400),
+                detection_model=RecordingModel(),  # type: ignore[arg-type]
+                slice_height=SLICE,
+                slice_width=SLICE,
+                overlap_height_ratio=OVERLAP,
+                overlap_width_ratio=OVERLAP,
+                auto_slice_resolution=False,
+                perform_standard_pred=True,
+                verbose=0,
+            )
+
+        assert "perform_standard_pred" not in caplog.text
+
+
+class TestSliceDurations:
+    """Test the reported slice duration still describes the pixel reads.
+
+    Reads moved inside the prediction loop, so timing only the geometry step would report
+    ~0 seconds for slicing a gigapixel scan, which reads as a broken counter.
+    """
+
+    def test_slice_duration_covers_the_band_reads(self, tmp_path: Path) -> None:
+        """Test time spent waiting for bands lands in `slice`, not in `prediction`."""
+        import sahi.slicing as slicing
+
+        path = str(tmp_path / "scan.png")
+        Image.fromarray(make_image(300, 400)).save(path)
+        open_band_source = slicing._open_band_source
+
+        def slow(*args: Any, **kwargs: Any) -> Any:
+            source = open_band_source(*args, **kwargs)
+            read_band = source.read_band
+
+            def slow_read_band(y_min: int, y_max: int) -> np.ndarray:
+                time.sleep(0.05)
+                return read_band(y_min, y_max)
+
+            source.read_band = slow_read_band  # type: ignore[method-assign]
+            return source
+
+        with pytest.MonkeyPatch.context() as patch:
+            patch.setattr(slicing, "_open_band_source", slow)
+            result = get_sliced_prediction(
+                image=path,
+                detection_model=RecordingModel(),  # type: ignore[arg-type]
+                slice_height=SLICE,
+                slice_width=SLICE,
+                overlap_height_ratio=OVERLAP,
+                overlap_width_ratio=OVERLAP,
+                auto_slice_resolution=False,
+                perform_standard_pred=False,
+                batch_size=2,
+                # prefetch would hide the sleep behind inference, which is the point of it
+                # but leaves nothing to measure here
+                verbose=0,
+            )
+
+        assert result.durations_in_seconds["slice"] >= 0.05, (
+            f"band reads took at least 0.05s but slice duration was {result.durations_in_seconds['slice']:.4f}s"
+        )
+        assert result.durations_in_seconds["prediction"] >= 0, "read time was double-counted out of prediction"
+
+
+class TestSliceExport:
+    """Test slice_dir export, now done one band at a time rather than all at once."""
+
+    def test_exports_one_file_per_slice(self, tmp_path: Path) -> None:
+        path = str(tmp_path / "scan.png")
+        Image.fromarray(make_image(300, 400, seed=4)).save(path)
+        out_dir = tmp_path / "slices"
+        expected = {
+            f"pre_{'_'.join(map(str, bbox))}.png"
+            for bbox in get_slice_bboxes(300, 400, SLICE, SLICE, False, OVERLAP, OVERLAP)
+        }
+
+        run(path, batch_size=4, slice_dir=str(out_dir), slice_export_prefix="pre")
+
+        assert {file.name for file in out_dir.iterdir()} == expected
+
+    def test_exported_slices_match_the_slices_predicted_on(self, tmp_path: Path) -> None:
+        """Exports are written from the band buffer the reader reuses, so a missing copy
+        corrupts them silently.
+        """
+        path = str(tmp_path / "scan.png")
+        Image.fromarray(make_image(300, 400, seed=5)).save(path)
+        out_dir = tmp_path / "slices"
+
+        model = run(path, batch_size=4, slice_dir=str(out_dir), slice_export_prefix="pre")
+
+        received = [image for batch in model.batches for image in batch]
+        bboxes = get_slice_bboxes(300, 400, SLICE, SLICE, False, OVERLAP, OVERLAP)
+        for image, bbox in zip(received, bboxes):
+            written = np.asarray(Image.open(out_dir / f"pre_{'_'.join(map(str, bbox))}.png"))
+            np.testing.assert_array_equal(written, image, err_msg=f"export for {bbox} differs")

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
-import numpy as np
+from pathlib import Path
 
-from sahi.prediction import PredictionScore
+import numpy as np
+import pytest
+from PIL import Image
+
+import sahi.prediction
+import sahi.utils.cv
+from sahi.prediction import PredictionResult, PredictionScore
 
 
 class TestPrediction:
@@ -16,3 +22,91 @@ class TestPrediction:
         assert isinstance(prediction_score.value, float)
         assert prediction_score.is_greater_than_threshold(0.5)
         assert not prediction_score.is_greater_than_threshold(0.7)
+
+
+class TestPredictionResultImage:
+    """Test the source image is decoded only when its pixels are asked for.
+
+    Sliced prediction streams a gigapixel scan a band at a time so the whole image is
+    never resident, and decoding it here to read `.size` would undo that.
+    """
+
+    @pytest.fixture
+    def image_path(self, tmp_path: Path) -> str:
+        path = str(tmp_path / "scan.png")
+        Image.fromarray(np.full((30, 40, 3), 77, dtype=np.uint8)).save(path)
+        return path
+
+    def test_dimensions_do_not_decode_the_image(self, image_path: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test width and height come from the header, with no decode."""
+        calls: list[object] = []
+        real = sahi.prediction.read_image_as_pil
+        monkeypatch.setattr(
+            sahi.prediction,
+            "read_image_as_pil",
+            lambda image, *args, **kwargs: (calls.append(image), real(image, *args, **kwargs))[1],
+        )
+
+        result = PredictionResult(object_prediction_list=[], image=image_path)
+
+        assert (result.image_width, result.image_height) == (40, 30)
+        assert calls == [], "constructing a PredictionResult must not decode the image"
+
+    def test_image_still_returns_the_source_pixels(self, image_path: str) -> None:
+        """Test `.image` returns what an eager decode would have returned."""
+        result = PredictionResult(object_prediction_list=[], image=image_path)
+
+        np.testing.assert_array_equal(np.asarray(result.image), np.full((30, 40, 3), 77, dtype=np.uint8))
+
+    def test_image_is_decoded_only_once(self, image_path: str) -> None:
+        """Test the decoded image is cached across repeated access."""
+        result = PredictionResult(object_prediction_list=[], image=image_path)
+
+        assert result.image is result.image
+
+    def test_missing_file_still_fails_at_construction(self, tmp_path: Path) -> None:
+        """Test a bad path still raises at construction rather than on first access."""
+        with pytest.raises(FileNotFoundError):
+            PredictionResult(object_prediction_list=[], image=str(tmp_path / "nope.png"))
+
+    def test_url_source_is_fetched_exactly_once(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test a remote image is downloaded once.
+
+        There is no header to peek at, so sizing it costs a full download and that
+        download is kept rather than repeated on the first `.image` access.
+        """
+        calls: list[object] = []
+        fetched = Image.new("RGB", (40, 30))
+
+        def fake_fetch(image: object, *args: object, **kwargs: object) -> Image.Image:
+            calls.append(image)
+            return fetched
+
+        monkeypatch.setattr(sahi.prediction, "read_image_as_pil", fake_fetch)
+        monkeypatch.setattr(sahi.utils.cv, "read_image_as_pil", fake_fetch)
+
+        result = PredictionResult(object_prediction_list=[], image="https://example.com/scan.jpg")
+
+        assert (result.image_width, result.image_height) == (40, 30)
+        assert result.image is fetched
+        assert len(calls) == 1, f"expected one fetch, saw {len(calls)}"
+
+    @pytest.mark.parametrize("as_array", [True, False])
+    def test_accepts_in_memory_images(self, as_array: bool) -> None:
+        """Test arrays and Pillow images, which are already decoded, keep working."""
+        pixels = np.full((30, 40, 3), 12, dtype=np.uint8)
+        image = pixels if as_array else Image.fromarray(pixels)
+
+        result = PredictionResult(object_prediction_list=[], image=image)
+
+        assert (result.image_width, result.image_height) == (40, 30)
+        np.testing.assert_array_equal(np.asarray(result.image), pixels)
+
+    def test_image_can_be_replaced(self, image_path: str) -> None:
+        """Test `.image` is still assignable, as it was before it became lazy."""
+        result = PredictionResult(object_prediction_list=[], image=image_path)
+        replacement = Image.fromarray(np.full((10, 20, 3), 5, dtype=np.uint8))
+
+        result.image = replacement
+
+        assert result.image is replacement

--- a/tests/test_slice_stream.py
+++ b/tests/test_slice_stream.py
@@ -1,0 +1,1027 @@
+"""Tests for streaming slice reads (SliceImageStream)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from sahi.slicing import (
+    SliceImageStream,
+    _ChunkedBandReader,
+    _group_bboxes_into_bands,
+    _InMemoryBandSource,
+    _open_band_source,
+    _prefetch,
+    _VipsBandSource,
+    get_slice_bboxes,
+    slice_image,
+)
+
+
+class RecordingForwardSource:
+    """Sequential decoder stand-in: serves rows forward-only and raises on a rewind."""
+
+    def __init__(self, array: np.ndarray) -> None:
+        self.array = array
+        self.reads: list[tuple[int, int]] = []
+        self.position = 0
+
+    def read_chunk(self, y_min: int, rows: int) -> np.ndarray:
+        if y_min < self.position:
+            raise AssertionError(f"backward read: asked for row {y_min}, decoder is at {self.position}")
+        self.reads.append((y_min, y_min + rows))
+        self.position = y_min + rows
+        return self.array[y_min : y_min + rows]
+
+
+SLICE = 128
+OVERLAP = 0.2
+
+
+def make_image(height: int, width: int, seed: int = 0) -> np.ndarray:
+    """Noise image; any band-boundary mistake shows up as a pixel mismatch."""
+    return np.random.default_rng(seed).integers(0, 255, (height, width, 3), dtype=np.uint8)
+
+
+def stream_all(stream: SliceImageStream, batch_size: int = 4) -> list[np.ndarray]:
+    """Flatten every batch into a single ordered list of slices."""
+    return [image for batch_images, _ in stream.iter_batches(batch_size) for image in batch_images]
+
+
+class TestSliceImageStreamGeometry:
+    """Test slice geometry, which is computed without decoding pixels."""
+
+    def test_reports_same_geometry_as_get_slice_bboxes(self) -> None:
+        """Test the stream reports the same bboxes as get_slice_bboxes."""
+        image = np.zeros((300, 400, 3), dtype=np.uint8)
+
+        stream = SliceImageStream(
+            image,
+            slice_height=128,
+            slice_width=128,
+            overlap_height_ratio=0.2,
+            overlap_width_ratio=0.2,
+            auto_slice_resolution=False,
+        )
+
+        expected = get_slice_bboxes(300, 400, 128, 128, False, 0.2, 0.2)
+        assert stream.original_image_height == 300
+        assert stream.original_image_width == 400
+        assert stream.slice_bboxes == expected
+        assert len(stream) == len(expected)
+
+    @pytest.mark.parametrize("axis", ["overlap_height_ratio", "overlap_width_ratio"])
+    def test_negative_overlap_is_rejected(self, axis: str) -> None:
+        """Test a negative ratio is rejected, since it spaces slices apart.
+
+        Gapped slices leave rows no band covers, which a forward-only reader cannot
+        serve; catching it at the geometry step keeps the error at the caller's input.
+        """
+        ratios = {"overlap_height_ratio": 0.2, "overlap_width_ratio": 0.2, axis: -0.5}
+
+        with pytest.raises(ValueError, match=r"Overlap ratio must be in \[0.0, 1.0\)"):
+            get_slice_bboxes(300, 400, 128, 128, False, **ratios)
+
+    @pytest.mark.parametrize("size", [300, 640, 1024, 2048, 6380])
+    def test_auto_slice_resolution_survives_the_ratio_bound(self, size: int) -> None:
+        """The auto path still produces covering slices at every resolution tier.
+
+        `calc_slice_and_overlap_params` uses an overlap *ratio* of 1.0 for low-resolution
+        images, which the bound above would reject. It never reaches that bound: the auto
+        branch converts to pixel overlaps itself, and the 1.0 tier is also the one that
+        splits into a single whole-image slice. Both facts are pinned here, since routing
+        auto through the ratio check would raise, and an overlap equal to the slice size
+        with more than one slice would hang.
+        """
+        bboxes = get_slice_bboxes(size, size, auto_slice_resolution=True)
+
+        assert bboxes, "auto slicing produced no slices"
+        assert bboxes[0][:2] == [0, 0]
+        assert max(x_max for _, _, x_max, _ in bboxes) == size
+        assert max(y_max for _, _, _, y_max in bboxes) == size
+
+
+class TestSliceImageStreamInputValidation:
+    """Test bad inputs are refused at construction, where slice_image refuses them."""
+
+    @pytest.mark.parametrize("shape", [(0, 400, 3), (300, 0, 3), (0, 0, 3)])
+    def test_zero_size_image_is_rejected(self, shape: tuple[int, int, int]) -> None:
+        """Test an empty image raises rather than yielding no slices.
+
+        `slice_image` raises on the same input. Yielding nothing would surface through
+        `get_sliced_prediction` as an empty result, which reads as "nothing detected"
+        rather than "nothing was read".
+        """
+        with pytest.raises(RuntimeError, match="invalid image size"):
+            SliceImageStream(np.zeros(shape, dtype=np.uint8), auto_slice_resolution=True)
+
+    def test_batch_size_is_validated_on_the_call(self) -> None:
+        """Test an invalid batch_size raises from iter_batches, not from the first next().
+
+        `iter_batches` returns its generator rather than delegating to it precisely so
+        this check is not deferred to a `for` statement somewhere else in the caller.
+        """
+        stream = SliceImageStream(make_image(300, 400), slice_height=SLICE, slice_width=SLICE)
+
+        with pytest.raises(ValueError, match="batch_size must be >= 1"):
+            stream.iter_batches(0)
+
+
+class TestPathInput:
+    """Test os.PathLike inputs, which used to size fine and then fail to decode."""
+
+    def test_path_and_str_produce_the_same_slices(self, tmp_path: Path) -> None:
+        """Test a Path is accepted end to end and matches the str spelling."""
+        array = make_image(300, 400, seed=7)
+        path = tmp_path / "scan.png"
+        Image.fromarray(array).save(str(path))
+        kwargs = {
+            "slice_height": SLICE,
+            "slice_width": SLICE,
+            "overlap_height_ratio": OVERLAP,
+            "overlap_width_ratio": OVERLAP,
+            "auto_slice_resolution": False,
+        }
+
+        from_path = stream_all(SliceImageStream(path, **kwargs))  # type: ignore[arg-type]
+        from_str = stream_all(SliceImageStream(str(path), **kwargs))
+
+        assert len(from_path) == len(from_str)
+        for index, (got, want) in enumerate(zip(from_path, from_str)):
+            np.testing.assert_array_equal(got, want, err_msg=f"slice {index} differs")
+
+    def test_path_still_takes_the_streaming_route(self, tmp_path: Path) -> None:
+        """Test a Path is normalised early enough to stream.
+
+        Every path check downstream tests for `str`, so a Path that reached them unchanged
+        would silently fall back to a whole-image decode.
+        """
+        path = tmp_path / "scan.png"
+        Image.fromarray(make_image(300, 400)).save(str(path))
+
+        streams_as_str = SliceImageStream(str(path), auto_slice_resolution=True).is_streaming
+
+        assert SliceImageStream(path, auto_slice_resolution=True).is_streaming == streams_as_str  # type: ignore[arg-type]
+
+
+class TestInMemoryBandSourceShapeGuard:
+    """Test the decoded array is checked against the geometry it will be cut with.
+
+    `_VipsBandSource` cross-checks its dimensions at open; without the same check here a
+    header/decode disagreement produces silently wrong slices instead of an error, since
+    numpy clamps an out-of-range slice rather than raising.
+    """
+
+    @pytest.mark.parametrize("expected", [(301, 400), (300, 401), (299, 399)])
+    def test_shape_disagreement_is_rejected(self, expected: tuple[int, int]) -> None:
+        """Test a mismatch on either axis raises at construction."""
+        with pytest.raises(ValueError, match="where the header read saw"):
+            _InMemoryBandSource(make_image(300, 400), expected_shape=expected)
+
+    def test_matching_shape_is_accepted(self) -> None:
+        """Test the guard does not reject the images it is supposed to pass."""
+        array = make_image(300, 400)
+
+        source = _InMemoryBandSource(array, expected_shape=(300, 400))
+
+        np.testing.assert_array_equal(source.read_band(0, 128), array[0:128])
+
+
+class TestSliceImageStreamEquivalence:
+    """Test streamed slices against slice_image."""
+
+    def test_streamed_slices_match_slice_image_pixels(self) -> None:
+        """Test streamed slices are pixel-identical to slice_image output."""
+        image = make_image(300, 400)
+        stream = SliceImageStream(
+            image,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+        )
+        eager = slice_image(
+            image=image,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+        )
+
+        streamed = stream_all(stream)
+
+        assert len(streamed) == len(eager)
+        for index, (got, want) in enumerate(zip(streamed, eager.images)):
+            np.testing.assert_array_equal(got, want, err_msg=f"slice {index} differs")
+
+    def test_batches_stay_full_across_band_boundaries(self) -> None:
+        """Test a band boundary does not cut a batch short.
+
+        Only two slices fit across this image, so a batch that stopped at the end of a
+        row-band would never reach the requested size.
+        """
+        image = make_image(600, 200)
+        stream = SliceImageStream(
+            image,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+        )
+
+        sizes = [len(images) for images, _ in stream.iter_batches(4)]
+
+        assert sum(sizes) == len(stream)
+        assert sizes[:-1] == [4] * (len(sizes) - 1), f"short batch before the last: {sizes}"
+
+    def test_streamed_shifts_match_slice_image(self) -> None:
+        """Test starting pixels match slice_image."""
+        image = make_image(300, 400)
+        stream = SliceImageStream(
+            image,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+        )
+        eager = slice_image(
+            image=image,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+        )
+
+        shifts = [shift for _, batch_shifts in stream.iter_batches(4) for shift in batch_shifts]
+
+        assert shifts == eager.starting_pixels
+
+
+class TestExifOrientation:
+    """Test EXIF orientation handling.
+
+    The contract is that an oriented file never streams. `read_image_as_pil` applies every
+    EXIF transform and a sequential decoder applies none, so a streamed oriented image
+    would carry the right geometry and the wrong pixels. The `_VipsBandSource` assertions
+    below hold that line, since once a case falls back its pixel comparison is eager
+    against eager and cannot fail. Sizes are covered by TestReadImageSize.
+    """
+
+    @pytest.mark.parametrize("suffix", [".jpg", ".png", ".tif"])
+    @pytest.mark.parametrize("orientation", [2, 6])
+    @pytest.mark.parametrize("exif_fix", [True, False])
+    def test_oriented_image_falls_back_and_matches_slice_image(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture, orientation: int, suffix: str, exif_fix: bool
+    ) -> None:
+        """An oriented file falls back to an eager decode, whatever exif_fix says.
+
+        6 is a quarter turn, which transposes the geometry; 2 is a mirror, which keeps the
+        shape and so returns plausible-looking slices when it is skipped. `exif_fix=False`
+        is covered because PIL's TIFF plugin applies orientations 2-4 on load regardless
+        of the flag, so honouring the flag in the streaming source made the two paths
+        disagree on every slice of a mirrored TIFF.
+        """
+        path = str(tmp_path / f"rotated{suffix}")
+        exif = Image.Exif()
+        exif[0x0112] = orientation
+        Image.fromarray(make_image(200, 300, seed=11)).save(path, exif=exif, quality=95)
+
+        stream = SliceImageStream(
+            path,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+            exif_fix=exif_fix,
+        )
+        with caplog.at_level("WARNING"):
+            source = _open_band_source(
+                path,
+                band_height=SLICE,
+                exif_fix=exif_fix,
+                expected_shape=(stream.original_image_height, stream.original_image_width),
+            )
+        assert not isinstance(source, _VipsBandSource), "an oriented image must not be streamed"
+        assert "decoding the whole image instead" in caplog.text
+
+        eager = slice_image(
+            image=path,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+            exif_fix=exif_fix,
+        )
+        streamed = stream_all(stream)
+
+        assert len(streamed) == len(eager)
+        for index, (got, want) in enumerate(zip(streamed, eager.images)):
+            assert got.shape == want.shape, f"slice {index} shape {got.shape} != {want.shape}"
+            np.testing.assert_array_equal(got, want, err_msg=f"slice {index} differs")
+
+    def test_untagged_image_still_streams(self, tmp_path: Path) -> None:
+        """Test the orientation guard only refuses files that carry a tag."""
+        path = str(tmp_path / "plain.tif")
+        Image.fromarray(make_image(200, 300, seed=13)).save(path)
+
+        if pyvips_installed():
+            assert isinstance(_open_band_source(path, band_height=SLICE), _VipsBandSource)
+
+
+class TestPillowInput:
+    """Test slicing an in-memory Pillow image."""
+
+    def test_streamed_slices_from_pil_image_match_slice_image(self) -> None:
+        """Test a Pillow image falls back to an eager decode and still matches slice_image."""
+        pil_image = Image.fromarray(make_image(300, 400, seed=9))
+
+        stream = SliceImageStream(
+            pil_image,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+        )
+        eager = slice_image(
+            image=pil_image,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+        )
+
+        streamed = stream_all(stream)
+
+        assert len(streamed) == len(eager)
+        for index, (got, want) in enumerate(zip(streamed, eager.images)):
+            np.testing.assert_array_equal(got, want, err_msg=f"slice {index} differs")
+
+
+class TestPrefetch:
+    """Test the worker thread that reads the next band while the caller works.
+
+    Correctness here is not about pixels, it is about what a thread can get wrong:
+    losing an exception, reordering results, or outliving the iteration.
+    """
+
+    def test_yields_everything_in_order(self) -> None:
+        """Test the results and their order are exactly the source's."""
+        source = ((["item"], [[index, 0]]) for index in range(50))
+
+        assert [shift[0][0] for _, shift in _prefetch(source)] == list(range(50))
+
+    def test_exception_reaches_the_caller(self) -> None:
+        """Test a failure inside the worker is re-raised in the consuming thread.
+
+        Swallowed here it would look like a short iteration: some slices silently never
+        inferred on, and no error anywhere.
+        """
+
+        def explode() -> Iterator[tuple[list, list]]:
+            yield ([], [[0, 0]])
+            raise RuntimeError("band read failed")
+
+        received = []
+        with pytest.raises(RuntimeError, match="band read failed"):
+            for batch in _prefetch(explode()):
+                received.append(batch)
+
+        assert len(received) == 1, "batches before the failure should still arrive"
+
+    def test_abandoning_the_iteration_stops_the_worker(self) -> None:
+        """Test breaking out of the loop does not leave the thread parked on a full queue.
+
+        The worker blocks on `put` once the queue is full, so without the drain in
+        `_prefetch`'s finally it would sit there for the life of the process.
+        """
+        import threading
+
+        before = threading.active_count()
+        for _ in _prefetch(([f"item{i}"], [[i, 0]]) for i in range(1000)):
+            break  # abandon immediately, while the worker is still producing
+
+        deadline = time.time() + 5
+        while threading.active_count() > before and time.time() < deadline:
+            time.sleep(0.01)
+        assert threading.active_count() == before, "prefetch worker outlived the iteration"
+
+    def test_source_is_closed_when_abandoned(self) -> None:
+        """Test the underlying generator is closed, so its `finally` blocks run."""
+        closed = []
+
+        def source() -> Iterator[tuple[list, list]]:
+            try:
+                for index in range(1000):
+                    yield ([], [[index, 0]])
+            finally:
+                closed.append(True)
+
+        for _ in _prefetch(source()):
+            break
+
+        deadline = time.time() + 5
+        while not closed and time.time() < deadline:
+            time.sleep(0.01)
+        assert closed, "source generator was never closed"
+
+    def test_abandoning_a_slow_producer_stops_the_worker(self) -> None:
+        """Test abandonment works while the worker is mid-read, not parked on `put`.
+
+        The tests above abandon an instantaneous source, so the worker is always already
+        blocked in `put`. A real band decode spends its time inside `next()`, and closing
+        the generator from the consumer there raises "generator already executing",
+        which skips the drain and strands the worker with a whole batch pinned.
+        """
+        import threading
+
+        closed = []
+
+        def slow_source() -> Iterator[tuple[list, list]]:
+            try:
+                for index in range(1000):
+                    time.sleep(0.02)  # stand in for a band decode
+                    yield ([], [[index, 0]])
+            finally:
+                closed.append(True)
+
+        before = threading.active_count()
+        for _ in _prefetch(slow_source()):
+            break  # abandon while the worker is inside the source's sleep
+
+        assert closed, "source generator was never closed"
+        assert threading.active_count() == before, "prefetch worker outlived the iteration"
+
+
+class TestChunkedBandReader:
+    """Test band assembly from a forward-only source."""
+
+    @pytest.mark.parametrize(
+        "height,width",
+        [(128, 128), (129, 127), (200, 300), (256, 256), (300, 151), (300, 400), (65, 400), (400, 65)],
+    )
+    def test_assembles_overlapping_bands_with_forward_only_reads(self, height: int, width: int) -> None:
+        """Test overlapping bands are assembled without re-reading a row."""
+        array = make_image(height, width, seed=2)
+        bands = _group_bboxes_into_bands(get_slice_bboxes(height, width, SLICE, SLICE, False, OVERLAP, OVERLAP))
+        band_height = max(y_max - y_min for (y_min, y_max), _ in bands)
+        source = RecordingForwardSource(array)
+        reader = _ChunkedBandReader(source.read_chunk, image_height=height, band_height=band_height)
+
+        for (y_min, y_max), _ in bands:
+            np.testing.assert_array_equal(
+                reader.read_band(y_min, y_max),
+                array[y_min:y_max],
+                err_msg=f"band {y_min}:{y_max} differs",
+            )
+
+        assert source.reads, "expected the reader to pull chunks from the source"
+        starts = [start for start, _ in source.reads]
+        assert starts == sorted(starts), "chunk reads must advance monotonically"
+
+    def test_skipping_rows_raises_instead_of_returning_the_wrong_ones(self) -> None:
+        """Test a gap between bands is rejected rather than silently misread.
+
+        A forward-only reader cannot serve a band starting past what it has read; the
+        old code let the buffer label drift and returned plausible but wrong pixels.
+        """
+        array = make_image(600, 128, seed=3)
+        source = RecordingForwardSource(array)
+        reader = _ChunkedBandReader(source.read_chunk, image_height=600, band_height=128)
+        reader.read_band(0, 128)
+
+        with pytest.raises(ValueError, match="past buffered row"):
+            reader.read_band(400, 528)
+
+
+class TestCHWInput:
+    """Test CHW arrays are transposed the way read_image_as_pil transposes them."""
+
+    def test_chw_array_matches_slice_image(self) -> None:
+        """Test a (3, H, W) array is sliced along the same axes as slice_image."""
+        hwc = make_image(200, 300, seed=13)
+        chw = np.ascontiguousarray(np.transpose(hwc, (2, 0, 1)))
+
+        stream = SliceImageStream(
+            chw,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+        )
+        eager = slice_image(
+            image=chw,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+        )
+
+        assert (stream.original_image_height, stream.original_image_width) == (200, 300)
+        streamed = stream_all(stream)
+
+        assert len(streamed) == len(eager)
+        for index, (got, want) in enumerate(zip(streamed, eager.images)):
+            assert got.shape == want.shape, f"slice {index} shape {got.shape} != {want.shape}"
+            np.testing.assert_array_equal(got, want, err_msg=f"slice {index} differs")
+
+
+def pyvips_installed() -> bool:
+    """Whether the optional streaming backend is usable.
+
+    Importable is not enough: pyvips binds libvips through cffi at import time and
+    raises OSError, not ImportError, when the shared library is missing.
+    `_open_band_source` treats both the same way, so this must too.
+    """
+    try:
+        import pyvips  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+class TestPyvipsAbsentFallback:
+    """Test the fallback taken when pyvips is unavailable."""
+
+    def test_falls_back_to_eager_decode_and_matches_slice_image(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test an unimportable pyvips falls back to an eager decode."""
+        import sys
+
+        monkeypatch.setitem(sys.modules, "pyvips", None)  # makes `import pyvips` raise
+        path = str(tmp_path / "scan.png")
+        image = make_image(200, 300, seed=14)
+        Image.fromarray(image).save(path)
+
+        source = _open_band_source(path, band_height=SLICE)
+        stream = SliceImageStream(
+            path,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+        )
+        streamed = stream_all(stream)
+        eager = slice_image(
+            image=path,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+        )
+
+        assert not isinstance(source, _VipsBandSource)
+        assert len(streamed) == len(eager)
+        for index, (got, want) in enumerate(zip(streamed, eager.images)):
+            np.testing.assert_array_equal(got, want, err_msg=f"slice {index} differs")
+
+    def test_pyvips_without_libvips_is_not_a_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test a pyvips that cannot bind libvips falls back quietly.
+
+        pyvips binds libvips through cffi at import and raises OSError, not ImportError,
+        when the shared library is missing. That is the same "extra not usable" case as
+        pyvips being absent, which is the documented default, so it must not warn.
+        """
+        import builtins
+
+        real_import = builtins.__import__
+
+        def raise_oserror(name: str, *args: object, **kwargs: object) -> object:
+            if name == "pyvips":
+                raise OSError("cannot load library 'libvips.so.42'")
+            return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(builtins, "__import__", raise_oserror)
+        path = str(tmp_path / "scan.png")
+        Image.fromarray(make_image(200, 300, seed=15)).save(path)
+
+        # the sahi logger sits at INFO, so the debug record is dropped unless it is named
+        with caplog.at_level("DEBUG", logger="sahi"):
+            source = _open_band_source(path, band_height=SLICE)
+
+        assert not isinstance(source, _VipsBandSource)
+        assert not [record for record in caplog.records if record.levelname == "WARNING"]
+        assert "pyvips is unusable" in caplog.text
+
+
+URL = "http://example.invalid/scan.png"
+
+
+@pytest.fixture
+def served_image(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, list[str]]:
+    """Serve a local PNG at `URL`, recording every fetch of it.
+
+    Returns the local path and the list requests are appended to.
+    """
+    import requests
+
+    local = tmp_path / "scan.png"
+    Image.fromarray(make_image(300, 400, seed=5)).save(local)
+    payload = local.read_bytes()
+    urls: list[str] = []
+
+    class FakeResponse:
+        content = payload
+
+    def fake_get(url: str, **kwargs: object) -> FakeResponse:
+        urls.append(url)
+        return FakeResponse()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    return local, urls
+
+
+class TestUrlInput:
+    """Test remote inputs, which have no local header to peek at."""
+
+    def test_url_is_downloaded_once(self, served_image: tuple[Path, list[str]]) -> None:
+        """Test sizing and slicing a URL share a single download.
+
+        `read_image_size` cannot avoid fetching a remote image in full, so the stream
+        keeps what it decoded: re-fetching in `iter_batches` doubles the transfer for
+        every remote input.
+        """
+        local, urls = served_image
+
+        stream = SliceImageStream(
+            URL,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+        )
+        assert len(urls) == 1, "sizing should account for the only download"
+
+        streamed = stream_all(stream)
+        assert len(urls) == 1, f"image was fetched {len(urls)} times"
+
+        eager = slice_image(
+            image=str(local),
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+        )
+        assert len(streamed) == len(eager)
+        for index, (got, want) in enumerate(zip(streamed, eager.images)):
+            np.testing.assert_array_equal(got, want, err_msg=f"slice {index} differs")
+
+    @pytest.mark.skipif(not pyvips_installed(), reason="pyvips is an optional extra")
+    def test_url_does_not_reach_libvips(
+        self, served_image: tuple[Path, list[str]], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test a URL skips the vips branch instead of failing into it.
+
+        `pyvips.Image.new_from_file` cannot open a URL, so letting one through costs an
+        exception and logs a warning blaming libvips for a file it was never given.
+        """
+        with caplog.at_level("WARNING"):
+            source = _open_band_source(URL, band_height=SLICE)
+
+        assert not isinstance(source, _VipsBandSource)
+        assert "libvips cannot stream" not in caplog.text
+
+
+@pytest.mark.skipif(not pyvips_installed(), reason="pyvips is an optional extra")
+class TestVipsBandSource:
+    """Test the libvips band source."""
+
+    def test_path_uses_streaming_source_when_pyvips_available(self, tmp_path: Path) -> None:
+        """Test a file path selects the streaming source rather than falling back."""
+        path = str(tmp_path / "scan.jpg")
+        Image.fromarray(make_image(300, 400, seed=3)).save(path, quality=95)
+
+        source = _open_band_source(path, band_height=SLICE)
+
+        assert isinstance(source, _VipsBandSource)
+
+    @pytest.mark.parametrize("suffix", [".jpg", ".png", ".tif"])
+    def test_streamed_slices_match_slice_image(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture, suffix: str
+    ) -> None:
+        """Test streamed slices match slice_image, in every container libvips handles.
+
+        The image is tall enough to span several chunk reads, which is where a loader
+        whose line counter has drifted starts serving the wrong rows or refuses outright.
+        The caplog assertion keeps this honest: a silent fallback to an eager decode
+        would otherwise make the comparison pass without streaming anything.
+        """
+        path = str(tmp_path / f"scan{suffix}")
+        Image.fromarray(make_image(600, 400, seed=3)).save(path, quality=95)
+
+        assert isinstance(_open_band_source(path, band_height=SLICE), _VipsBandSource)
+
+        stream = SliceImageStream(
+            path,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+        )
+        eager = slice_image(
+            image=path,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+        )
+
+        with caplog.at_level("WARNING"):
+            streamed = stream_all(stream)
+
+        assert "decoding the whole image instead" not in caplog.text
+        assert len(streamed) == len(eager)
+        for index, (got, want) in enumerate(zip(streamed, eager.images)):
+            np.testing.assert_array_equal(got, want, err_msg=f"slice {index} differs")
+
+    @pytest.mark.parametrize("suffix", [".png", ".tif"])
+    def test_deep_samples_fall_back_and_match_slice_image(self, tmp_path: Path, suffix: str) -> None:
+        """Test 16-bit files take the eager path, which is the only one that matches PIL.
+
+        libvips' colourspace("srgb") rescales 16-bit samples onto 0-255 while PIL's
+        `I;16 -> RGB` clips at 255. `_read_local_image_as_arr` already bails to PIL for
+        non-uint8 samples so both entry points convert identically; without a matching
+        guard here the same file yields different pixels depending on whether the
+        optional extra happens to be installed.
+        """
+        path = str(tmp_path / f"deep{suffix}")
+        samples = np.random.default_rng(7).integers(0, 65536, (300, 400), dtype=np.uint16)
+        Image.fromarray(samples).save(path)
+
+        assert not isinstance(_open_band_source(path, band_height=SLICE), _VipsBandSource)
+
+        streamed = stream_all(
+            SliceImageStream(
+                path,
+                slice_height=SLICE,
+                slice_width=SLICE,
+                overlap_height_ratio=OVERLAP,
+                overlap_width_ratio=OVERLAP,
+                auto_slice_resolution=False,
+            )
+        )
+        eager = slice_image(
+            image=path,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+        )
+
+        assert len(streamed) == len(eager)
+        for index, (got, want) in enumerate(zip(streamed, eager.images)):
+            np.testing.assert_array_equal(got, want, err_msg=f"slice {index} differs")
+
+    @pytest.mark.parametrize("suffix", [".jpg", ".tif"])
+    def test_cmyk_falls_back_and_matches_slice_image(self, tmp_path: Path, suffix: str) -> None:
+        """Test CMYK files take the eager path, which is the only one that matches PIL.
+
+        libvips converts CMYK to sRGB without the Adobe inversion PIL and OpenCV apply, so
+        streaming a CMYK JPEG was off by up to 127 levels per channel, which is visibly
+        wrong colour rather than a rounding difference. Only `srgb` and `b-w` convert
+        identically in both, so anything else falls back.
+        """
+        path = str(tmp_path / f"cmyk{suffix}")
+        Image.fromarray(make_image(300, 400, seed=6)).convert("CMYK").save(path, quality=95)
+
+        assert not isinstance(_open_band_source(path, band_height=SLICE), _VipsBandSource)
+
+        streamed = stream_all(
+            SliceImageStream(
+                path,
+                slice_height=SLICE,
+                slice_width=SLICE,
+                overlap_height_ratio=OVERLAP,
+                overlap_width_ratio=OVERLAP,
+                auto_slice_resolution=False,
+            )
+        )
+        eager = slice_image(
+            image=path,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+        )
+
+        assert len(streamed) == len(eager)
+        for index, (got, want) in enumerate(zip(streamed, eager.images)):
+            np.testing.assert_array_equal(got, want, err_msg=f"slice {index} differs")
+
+    def test_a_failing_stream_falls_back_mid_iteration(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test a read that fails part way in falls back to an eager decode.
+
+        _open_band_source guards only the open, but a sequential loader rejects a read it
+        dislikes when it reaches it, which can be several bands into the iteration.
+        """
+        path = str(tmp_path / "scan.png")
+        Image.fromarray(make_image(600, 400, seed=4)).save(path)
+        eager = slice_image(
+            image=path,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+        )
+
+        stream = SliceImageStream(
+            path,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+        )
+        calls = {"n": 0}
+        original = _VipsBandSource.read_band
+
+        def fail_on_second_band(self: _VipsBandSource, y_min: int, y_max: int) -> np.ndarray:
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise RuntimeError("out of order read")
+            return original(self, y_min, y_max)
+
+        monkeypatch.setattr(_VipsBandSource, "read_band", fail_on_second_band)
+        with caplog.at_level("WARNING"):
+            streamed = stream_all(stream)
+
+        assert "streaming read failed" in caplog.text
+        assert len(streamed) == len(eager)
+        for index, (got, want) in enumerate(zip(streamed, eager.images)):
+            np.testing.assert_array_equal(got, want, err_msg=f"slice {index} differs")
+
+
+_PEAK_RSS_PROBE = """
+import resource, sys
+from sahi.slicing import SliceImageStream
+
+for images, _ in SliceImageStream(
+    sys.argv[1], slice_height=640, slice_width=640,
+    overlap_height_ratio=0.2, overlap_width_ratio=0.2, auto_slice_resolution=False,
+).iter_batches(8):
+    pass
+print(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+"""
+
+
+def peak_rss_mb(path: str) -> float:
+    """Peak RSS of a fresh process that streams every slice of `path`.
+
+    A child process because ru_maxrss is a high-water mark that never comes back down:
+    measuring in the test process would report whatever the rest of the suite allocated.
+    """
+    probe = subprocess.run([sys.executable, "-c", _PEAK_RSS_PROBE, path], capture_output=True, text=True, check=True)
+    return int(probe.stdout.split()[-1]) / 1024  # ru_maxrss is KiB on Linux
+
+
+def write_uniform_jpeg(path: str, width: int, height: int) -> None:
+    """Write a large flat JPEG without ever holding it in memory."""
+    import pyvips
+
+    pyvips.Image.black(width, height, bands=3).copy(interpretation="srgb").write_to_file(path)
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(sys.platform != "linux", reason="ru_maxrss is KiB on Linux and bytes elsewhere")
+@pytest.mark.skipif(not pyvips_installed(), reason="pyvips is an optional extra")
+class TestPeakMemory:
+    """Guard the property this path exists for: peak memory must not follow image height.
+
+    Marked `slow` and deselected in CI: it writes a 144 MP JPEG and measures peak RSS in
+    child processes, and RSS assertions are not dependable on shared runners. Run it
+    locally with `pytest -m slow`; `scripts/benchmark_streaming_slices.py` is the fuller
+    measurement.
+    """
+
+    def test_peak_memory_grows_far_slower_than_a_whole_image_decode(self, tmp_path: Path) -> None:
+        """A 4x taller image at the same width costs far less than decoding it whole.
+
+        A comparison rather than an absolute cap, because baseline RSS varies with
+        platform and installed extras while the invariant does not. A reintroduced
+        whole-image decode grows the peak by the extra decoded bytes and fails here.
+
+        The bound is a fraction of `decode_growth_mb` rather than a flat cap because
+        libvips retains roughly 0.45 bytes per pixel decoded, so the peak does grow with
+        height, at about a tenth the rate of a full decode.
+        """
+        width, short_height, tall_height = 12_000, 3_000, 12_000
+        short_path = str(tmp_path / "short.jpg")
+        tall_path = str(tmp_path / "tall.jpg")
+        write_uniform_jpeg(short_path, width, short_height)
+        write_uniform_jpeg(tall_path, width, tall_height)
+        # what a whole-image decode would add for the extra rows
+        decode_growth_mb = width * (tall_height - short_height) * 3 / 1024**2
+
+        growth_mb = peak_rss_mb(tall_path) - peak_rss_mb(short_path)
+
+        assert growth_mb < decode_growth_mb / 3, (
+            f"peak memory grew {growth_mb:.0f} MB for {tall_height - short_height} extra rows; "
+            f"a whole-image decode would grow it {decode_growth_mb:.0f} MB"
+        )
+
+
+class TestAwkwardShapes:
+    """Test images whose size is not a multiple of the slice stride."""
+
+    @pytest.mark.parametrize(
+        "height,width",
+        [(128, 128), (129, 127), (200, 300), (256, 256), (300, 151), (65, 400), (400, 65)],
+    )
+    def test_streamed_slices_match_slice_image(self, tmp_path: Path, height: int, width: int) -> None:
+        """Test slices match slice_image when the final band is clamped."""
+        path = str(tmp_path / "scan.png")
+        Image.fromarray(make_image(height, width, seed=height)).save(path)
+
+        stream = SliceImageStream(
+            path,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+        )
+        eager = slice_image(
+            image=path,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+        )
+
+        streamed = stream_all(stream)
+
+        assert len(streamed) == len(eager)
+        for index, (got, want) in enumerate(zip(streamed, eager.images)):
+            np.testing.assert_array_equal(got, want, err_msg=f"slice {index} differs")
+
+
+class TestChannelNormalisation:
+    """Test grayscale and RGBA inputs are normalised to RGB."""
+
+    @pytest.mark.parametrize("mode", ["L", "RGBA"])
+    def test_non_rgb_input_matches_slice_image(self, tmp_path: Path, mode: str) -> None:
+        """Test non-RGB inputs match slice_image."""
+        path = str(tmp_path / f"scan_{mode}.png")
+        channels = {"L": 1, "RGBA": 4}[mode]
+        pixels = make_image(200, 300, seed=7)[:, :, :1] if channels == 1 else None
+        if mode == "L":
+            Image.fromarray(pixels[:, :, 0], mode="L").save(path)
+        else:
+            rgba = np.dstack([make_image(200, 300, seed=8), np.full((200, 300), 200, np.uint8)])
+            Image.fromarray(rgba, mode="RGBA").save(path)
+
+        stream = SliceImageStream(
+            path,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+        )
+        eager = slice_image(
+            image=path,
+            slice_height=SLICE,
+            slice_width=SLICE,
+            overlap_height_ratio=OVERLAP,
+            overlap_width_ratio=OVERLAP,
+            auto_slice_resolution=False,
+        )
+
+        streamed = stream_all(stream)
+
+        assert len(streamed) == len(eager)
+        for index, (got, want) in enumerate(zip(streamed, eager.images)):
+            assert got.shape == want.shape, f"slice {index} shape {got.shape} != {want.shape}"
+            np.testing.assert_array_equal(got, want, err_msg=f"slice {index} differs")

--- a/tests/test_slicing.py
+++ b/tests/test_slicing.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import numpy as np
+import pytest
 from PIL import Image
 
-from sahi.slicing import shift_bboxes, shift_masks, slice_coco, slice_image
+from sahi.slicing import _slice_file_suffix, shift_bboxes, shift_masks, slice_coco, slice_image
 from sahi.utils.coco import Coco
 from sahi.utils.cv import read_image
 
@@ -188,3 +191,36 @@ class TestSlicing:
         shifted_masks = shift_masks(masks=masks, offset=[shift_x, shift_y], full_shape=full_shape)
         assert shifted_masks.shape == (3, 720, 1280)
         assert isinstance(shifted_masks, np.ndarray)
+
+
+class TestSliceFileSuffix:
+    """Test the extension exported slices are written with."""
+
+    @pytest.mark.parametrize(
+        ("image", "expected"),
+        [
+            ("scan.tif", ".tif"),
+            ("scan.png", ".png"),
+            ("scan.jpg", ".png"),  # lossy sources are re-encoded losslessly
+            ("https://example.com/scan.jpg", ".png"),
+            ("https://example.com/scan", ".png"),  # nothing to inherit
+        ],
+    )
+    def test_path_keeps_its_extension_unless_lossy(self, image: str, expected: str) -> None:
+        """Test a path input exports slices under its own extension."""
+        assert _slice_file_suffix(image) == expected
+
+    def test_pil_image_uses_the_file_it_was_opened_from(self, tmp_path: Path) -> None:
+        """Test a PIL image carries the extension of the file behind it."""
+        path = tmp_path / "scan.tif"
+        Image.fromarray(np.zeros((4, 4, 3), np.uint8)).save(path)
+        with Image.open(path) as image_pil:
+            assert _slice_file_suffix(image_pil) == ".tif"
+
+    def test_in_memory_image_falls_back_to_png(self) -> None:
+        """Test an array has no source extension to inherit."""
+        assert _slice_file_suffix(np.zeros((4, 4, 3), np.uint8)) == ".png"
+
+    def test_out_ext_wins(self) -> None:
+        """Test an explicit out_ext overrides the source extension."""
+        assert _slice_file_suffix("scan.tif", out_ext=".jpg") == ".jpg"


### PR DESCRIPTION
# Stream slices from disk instead of decoding the whole image

## Problem

`get_sliced_prediction()` called `slice_image()`, which decoded the entire image and
materialised every slice before the first inference ran. For a 39266x29140 (1144 MP)
scan that is a 3.2 GB decoded array plus ~5.0 GB of slices, so it raises `MemoryError`
on a 6 GB machine no matter how small `batch_size` is.

## What changed

When `image` is a file path, slices are now read one horizontal row-band at a time, so
peak memory is set by the band, not by the image.

- `SliceImageStream` (`sahi/slicing.py`) computes slice geometry from the file header
  and yields batches of slices lazily via `iter_batches()`. Three band sources:
  libvips (sequential access, the only one whose peak is not the full image),
  in-memory (arrays and Pillow images, which are already decoded), and a whole-image
  decode fallback so nothing regresses when libvips is absent. `is_streaming` reports
  which case an input falls into.
- `read_image_size()` (`sahi/utils/cv.py`) reads dimensions from the header without
  decoding, EXIF quarter-turns included.
- `_read_local_image_as_arr()` decodes local files with OpenCV straight to HWC RGB.
  The old PIL path cost two extra full-size buffers via `Image.tobytes()`.
- `get_sliced_prediction()` consumes `iter_batches()`. Slice export moved inside the
  loop via a new `SliceExporter`, which writes each batch in the background and drains
  before the next one.
- `PredictionResult.image` is a lazily decoded `functools.cached_property`, so a result
  object no longer re-decodes a gigapixel image nobody asked for.
- New optional extra: `pip install sahi[bigimage]`.
- Docs: new sections in `docs/predict.md` and `docs/slicing.md`, mirrored into
  `docs/zh`. The `docs/tr` mirror is left for a Turkish speaker in a follow-up.

Existing public API is unchanged; `slice_image()` still behaves exactly as before.

## Measured

Reproduce everything below with:

```console
pip install -e ".[bigimage]"
python scripts/benchmark_streaming_slices.py                  # slicing alone
python scripts/benchmark_streaming_slices.py --consume-ms 30   # with simulated inference
python scripts/benchmark_streaming_slices.py --image your_scan.jpg
```

Square gaussian-noise JPEGs, 640x640 slices at 0.2 overlap, batch 8, peak RSS of a
fresh process (so the interpreter and imports are in both columns). Ubuntu, libvips
8.15.1, Python 3.13. Medians of 3 runs; memory was near-deterministic, wall time
varied by under 5%:

| image | eager (`slice_image`) | streaming (`SliceImageStream`) |
| --- | --- | --- |
| 1 MP | 0.27 s / 156 MB | 0.44 s / 156 MB |
| 16 MP | 0.62 s / 163 MB | 0.91 s / 189 MB |
| 64 MP | 1.83 s / 438 MB | 2.07 s / 327 MB |
| 144 MP | 3.71 s / 896 MB | 4.13 s / 508 MB |
| 256 MP | 6.56 s / 1537 MB | 6.69 s / 733 MB |

And the case the change exists for — a real 1144 MP JPEG scan, 4389 slices (measured
separately; the sweep above does not go this large):

| path | peak RSS | wall |
| --- | --- | --- |
| streaming (libvips) | 671 MB | 10.9 s |
| `get_sliced_prediction` end to end | 668 MB | 10.9 s |
| whole-image decode alone, no slicing | 6613 MB | 9.0 s |
| `slice_image` (old path) | 3.2 GB + 5.0 GB of slices, `MemoryError` | - |

**Speed depends entirely on whether anything is consuming the slices.**

Slicing alone, streaming is ~10-15% *slower* than eager (the table above), and below
~64 MP it costs memory rather than saving it. But that measures slicing with no model
attached. `iter_batches` now decodes the next band on a worker thread while the caller
works on the current batch - libvips releases the GIL during decode, verified by
cpu-time-over-wall-time (1.97 for two concurrent libvips decodes, 1.00 for the
pure-Python control). At 30 ms of work per batch, about what a small detector costs on
8 slices:

| image | eager | streaming, no prefetch | streaming + prefetch |
| --- | --- | --- | --- |
| 64 MP | 5.77 s / 438 MB | 5.83 s / 327 MB | **4.34 s / 321 MB** |
| 256 MP | 20.73 s / 1537 MB | 19.45 s / 733 MB | **16.62 s / 722 MB** |

So in the path users actually run, streaming is faster than the old eager code *and*
uses half the memory. Prefetch is on by default; `iter_batches(n, prefetch=False)`
turns it off. It is skipped for non-libvips sources, which are already decoded and have
nothing to overlap.

Reviewer note: the prefetch worker owns its libvips source end to end. A `VipsRegion`
is thread-affine — building it on one thread and fetching from another aborts the
process inside libvips — which is why `_open_band_source` is called inside the produced
generator rather than in `iter_batches`, and why `_prefetch` closes that generator on
the producer thread rather than the consumer's. Closing it from the consumer raises
`ValueError: generator already executing` whenever the producer is mid-decode, which
skips the cleanup and strands the worker with a batch and a region pinned.

Memory is not constant in image height either. libvips retains roughly 0.45 bytes per
pixel decoded (~360 MB across the 1144 MP scan), which is the loader's own bookkeeping —
the same climb reproduces with a bare `pyvips.Region` fetch loop and no sahi in the
process. Call it a tenth of a whole-image decode, not a flat line.

## Behaviour changes

- `PredictionResult.image` decodes on first access rather than at construction, so a
  decode error surfaces there instead. A missing file still raises at construction
  (there is a test for it). It stays assignable: `cached_property` writes into
  `__dict__`, so `result.image = img` shadows the cache as the plain attribute did.
  For a numpy input it is no longer a snapshot — mutating the array you passed in now
  shows up in `.image`.
- The `get_sliced_prediction` progress bar counts slices, not batches.
- `durations_in_seconds["slice"]` now covers the time the caller waited for pixels,
  timed around each band read in the loop, plus the geometry step. With prefetching most
  band decoding overlaps inference and is counted in neither, so `["slice"]` is smaller
  than before on the same workload.
- `get_slice_bboxes` now rejects overlap ratios outside `[0.0, 1.0)`. Ratios `>= 1.0`
  already raised; what is new is the rejection of negative ratios, which used to be
  accepted and spaced slices apart, leaving rows no slice covered.
- `SliceImageStream` raises on a zero-size image, matching `slice_image`.
- `read_image_as_pil()` accepts `os.PathLike` as well as `str`, which
  `read_image_size()` already did.
- Images with an EXIF orientation tag, CMYK images, and images with more than 8 bits
  per sample fall back to a whole-image decode, with a warning. libvips converts each
  differently from PIL, and silently wrong pixels are worse than a slower path.
- With `perform_standard_pred=True` (the default) the full image is still decoded once
  for the whole-image pass, which cancels the saving. Leaving it on while slices are
  being streamed now logs a warning naming the flag. Auto-disabling it above some pixel
  threshold would be a silent behaviour change, so it is not done here.
- The `sahi predict` CLI decodes the image up front for the visualisations it exports,
  so it does not benefit from streaming. Documented; use the Python API.

## Tests and CI

`tests/test_slice_stream.py` and `tests/test_predict_stream.py`, 83 tests. Every
streamed slice is compared pixel-for-pixel against `slice_image()` across EXIF
orientations 2-8, grayscale/RGBA/CHW inputs, and image shapes that do not divide evenly
by the slice stride. `tests/test_cv_utils.py` gained a decoder-parity class pinning the
new cv2 fast path against the pre-change PIL semantics across mode/container/EXIF
combinations.

Four of them guard the properties that make this change worth having rather than just
correct:

- `test_read_ahead_stays_bounded` asserts bands are pulled as inference consumes them,
  and that the prefetch worker reads at most one band ahead. The equivalence tests all
  pass against an eager decode, so without this one nothing fails if slicing quietly
  goes back to materialising everything.
- `test_peak_memory_grows_far_slower_than_a_whole_image_decode` streams a 12000x3000
  and a 12000x12000 image in child processes and asserts the peak RSS difference stays
  under a third of the extra decoded bytes. Marked `slow` and deselected in CI, where
  peak-RSS assertions on a shared runner are not dependable; run it with `pytest -m slow`.
- `TestPrefetch` covers what a worker thread gets wrong rather than what pixels it
  produces: a lost exception, reordered batches, and a thread outliving an abandoned
  iteration. One case uses a producer that sleeps *inside* `next()`, since an
  instantaneous producer is always parked in `put` and never reproduces the
  close-from-the-wrong-thread failure described above.
- `TestStandardPredWarning` pins the warning to the streaming case only, so callers who
  passed an already-decoded array are not nagged.

The `streaming` CI job runs two configurations: Ubuntu with system libvips and
`pyvips<3.0` (what `sahi[ci]` and Roboflow `inference` users get, since `inference` caps
pyvips below 3.0 and the libvips-vendoring `binary` extra only exists from 3.0 on), and
the `sahi[bigimage]` extra as documented. The second leg asserts the library really came
from the wheel by importing `_libvips`, the top-level extension module `pyvips-binary`
ships — without that check, an extra that resolved to bindings with no libvips behind
them would silently decode whole images and still pass. **This drops the macOS and
Windows legs an earlier revision had** — the argument is that those tested pyvips' own
wheels rather than sahi, but it is a real coverage reduction and a reasonable thing to
challenge.

`pyvips[binary]` was checked to resolve on both Python 3.8 and 3.12, so the `bigimage`
extra needs no version marker against `requires-python = ">=3.8"`.

## Deliberate choices worth flagging

- **`sahi/utils/cv.py` raises `OPENCV_IO_MAX_IMAGE_PIXELS` at import time.** OpenCV
  reads that variable once when it is imported, so there is no later hook; if something
  imports `cv2` before any `sahi` module, images above 2^30 pixels silently take the
  slower PIL path. Documented in `docs/predict.md` rather than worked around.
- **Batches span row-bands.** Slices are handed out as copies, so carrying the tail of
  one band into the next batch pins nothing but the slices and keeps batches full on
  images only a few slices wide.
- **`_ChunkedBandReader` reads fixed 128-row chunks** rather than fetching each band's
  delta directly. The simpler version quadruples the transient fetch at gigapixel width
  (a 512-row delta is ~60 MB against 15 MB), which is the allocation being bounded.
- **Both band sources check their dimensions against the header read.** libvips refuses
  at open; the in-memory source refuses at construction, on both axes. numpy clamps an
  out-of-range slice instead of raising, so an unchecked disagreement produces silently
  short bands rather than an error.
- **A missing libvips is logged at debug, not warning.** Most installs will not have it
  and its absence is not an error. A libvips that is present but *refuses a file* does
  warn, since the caller may be relying on streaming to fit in RAM.
- **cv2 decode peaks at roughly 2x the final array** (6.6 GB for a 3.2 GB result), so
  the fallback path is not free. That is the ceiling the libvips source removes.
