### PR TITLE
fix: enable MPS auto-detection for postprocessing on macOS

### DIFF
--- a/sahi/postprocess/backends.py
+++ b/sahi/postprocess/backends.py
@@ -50,8 +50,8 @@ def resolve_backend() -> str:
 
     When the backend is set to "auto", detection follows this priority:
 
-    1. **torchvision** -- selected if both torchvision and a CUDA GPU are
-       available (GPU-accelerated NMS).
+    1. **torchvision** -- selected if torchvision is installed and a GPU is
+       available, either CUDA or Apple MPS (GPU-accelerated NMS).
     2. **numba** -- selected if the numba package is installed (JIT-compiled
        loops, faster than pure numpy for large prediction counts).
     3. **numpy** -- always available as the fallback (pure numpy,
@@ -71,12 +71,14 @@ def resolve_backend() -> str:
         _resolved_cache = _backend
         return _backend
 
-    # Auto-detect: prefer torchvision on GPU, then numba, then numpy
+    # Auto-detect: prefer torchvision on CUDA/MPS, then numba, then numpy
     if is_available("torchvision"):
         try:
             import torch
 
-            if torch.cuda.is_available() or torch.mps.is_available():
+            # torch.mps.is_available() only exists from torch 2.5; torch.backends.mps
+            # has been the stable entry point since 1.12 and is False on non-Apple builds.
+            if torch.cuda.is_available() or torch.backends.mps.is_available():
                 _resolved_cache = "torchvision"
                 return _resolved_cache
         except ImportError:

--- a/sahi/postprocess/backends.py
+++ b/sahi/postprocess/backends.py
@@ -76,7 +76,7 @@ def resolve_backend() -> str:
         try:
             import torch
 
-            if torch.cuda.is_available():
+            if torch.cuda.is_available() or torch.mps.is_available():
                 _resolved_cache = "torchvision"
                 return _resolved_cache
         except ImportError:

--- a/sahi/utils/torch_utils.py
+++ b/sahi/utils/torch_utils.py
@@ -106,7 +106,7 @@ def select_device(device: str | None = None) -> str | torch.device:
         else:
             device = "cpu"
 
-    device = str(device).strip().lower().replace("cuda:", "").replace("none", "")
+    device = str(device).strip().lower().replace("cuda:", "").replace("none", "")  # to string, 'cuda:0' to '0'
     cpu = device == "cpu"
     mps = device == "mps"  # Apple Metal Performance Shaders (MPS)
     if cpu or mps:
@@ -119,7 +119,7 @@ def select_device(device: str | None = None) -> str | torch.device:
 
     if not cpu and not mps and torch.cuda.is_available() and valid_cuda_id:  # prefer GPU if available
         arg = f"cuda:{device}" if device else "cuda:0"
-    elif mps and getattr(torch, "has_mps", False) and torch.backends.mps.is_available():  # prefer MPS if available
+    elif mps and torch.backends.mps.is_available():  # prefer MPS if available
         arg = "mps"
     else:  # revert to CPU
         arg = "cpu"

--- a/sahi/utils/torch_utils.py
+++ b/sahi/utils/torch_utils.py
@@ -119,7 +119,7 @@ def select_device(device: str | None = None) -> str | torch.device:
 
     if not cpu and not mps and torch.cuda.is_available() and valid_cuda_id:  # prefer GPU if available
         arg = f"cuda:{device}" if device else "cuda:0"
-    elif mps and torch.backends.mps.is_available():  # prefer MPS if available
+    elif mps and getattr(torch, "has_mps", False) and torch.backends.mps.is_available():  # prefer MPS if available
         arg = "mps"
     else:  # revert to CPU
         arg = "cpu"

--- a/sahi/utils/torch_utils.py
+++ b/sahi/utils/torch_utils.py
@@ -96,9 +96,17 @@ def select_device(device: str | None = None) -> str | torch.device:
 
     import torch
 
-    if device == "cuda" or device is None:
+    if device == "cuda":
         device = "cuda:0"
-    device = str(device).strip().lower().replace("cuda:", "").replace("none", "")  # to string, 'cuda:0' to '0'
+    elif device is None:
+        if torch.cuda.is_available():
+            device = "cuda:0"
+        elif torch.backends.mps.is_available():
+            device = "mps"
+        else:
+            device = "cpu"
+
+    device = str(device).strip().lower().replace("cuda:", "").replace("none", "")
     cpu = device == "cpu"
     mps = device == "mps"  # Apple Metal Performance Shaders (MPS)
     if cpu or mps:
@@ -111,7 +119,7 @@ def select_device(device: str | None = None) -> str | torch.device:
 
     if not cpu and not mps and torch.cuda.is_available() and valid_cuda_id:  # prefer GPU if available
         arg = f"cuda:{device}" if device else "cuda:0"
-    elif mps and getattr(torch, "has_mps", False) and torch.backends.mps.is_available():  # prefer MPS if available
+    elif mps and torch.backends.mps.is_available():  # prefer MPS if available
         arg = "mps"
     else:  # revert to CPU
         arg = "cpu"


### PR DESCRIPTION
Hello @onuralpszr, 

I found that current version of sahi did not automatically use MPS on macOS, because the code only consider about CUDA device and can't route to MPS automatically. This behavior may be confusing to macOS users and prevents sahi from taking advantage tof the best available device.

This PR adds MPS detection to backend resolution and updates the automatic device selection priority to CUDA → MPS → CPU.

The docs and test part should also be updated if the PR is merged. If you are busy, I can take the part of updating them.😃

---

And by the way, I have one API question: should get_postprocess_backend() return the configured value ("auto") or the concrete backend actually being used? I would expect a getter with this name to report the effective backend, which would help users verify whether hardware acceleration was selected. If both states need to be exposed, we could add a separate getter for the configured value.