### PR TITLE
docs: note MPS in postprocess backend auto-detection

### DIFF
--- a/docs/postprocess/backends.md
+++ b/docs/postprocess/backends.md
@@ -14,17 +14,18 @@ right backend depends on your hardware and installed packages.
 
 ## Backend overview
 
-| Backend         | Best for                                                                   | Extra dependency                       |
-| --------------- | -------------------------------------------------------------------------- | -------------------------------------- |
-| **numpy**       | CPU-only environments, small/medium prediction counts                      | None (always available)                |
-| **numba**       | CPU with large prediction counts; ~1 s JIT warmup on first call, then fast | `pip install numba`                    |
-| **torchvision** | CUDA GPU available; fastest for large batches                              | `pip install torch torchvision` + CUDA |
+| Backend         | Best for                                                                   | Extra dependency                |
+| --------------- | -------------------------------------------------------------------------- | ------------------------------- |
+| **numpy**       | CPU-only environments, small/medium prediction counts                      | None (always available)         |
+| **numba**       | CPU with large prediction counts; ~1 s JIT warmup on first call, then fast | `pip install numba`             |
+| **torchvision** | CUDA or Apple MPS GPU available; fastest for large batches                 | `pip install torch torchvision` |
 
 ## Auto-detection (default)
 
 By default SAHI automatically picks the best available backend at runtime:
 
-1. **torchvision** — if `torchvision` is installed _and_ a CUDA GPU is present.
+1. **torchvision** — if `torchvision` is installed _and_ a GPU is present
+   (CUDA, or Apple MPS on Apple Silicon).
 2. **numba** — if the `numba` package is installed.
 3. **numpy** — always available as the final fallback.
 
@@ -65,7 +66,7 @@ from sahi import AutoDetectionModel
 from sahi.predict import get_sliced_prediction
 from sahi.postprocess.backends import set_postprocess_backend
 
-# Use GPU-accelerated postprocessing when running on a CUDA machine
+# Use GPU-accelerated postprocessing when running on a CUDA or Apple Silicon machine
 set_postprocess_backend("torchvision")
 
 detection_model = AutoDetectionModel.from_pretrained(

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -124,7 +124,7 @@ available backend is selected automatically:
 
 | Backend | When selected | Install |
 | --------- | -------------- | --------- |
-| **torchvision** | CUDA GPU + torchvision available | `pip install torch torchvision` |
+| **torchvision** | CUDA or Apple MPS GPU + torchvision available | `pip install torch torchvision` |
 | **numba** | numba installed, no GPU | `pip install numba` |
 | **numpy** | Always available (fallback) | -- |
 

--- a/docs/tr/postprocess/backends.md
+++ b/docs/tr/postprocess/backends.md
@@ -13,17 +13,18 @@ SAHI'nin postprocessing (NMS, NMM) işlemleri üç değiştirilebilir backend ü
 
 ## Backend genel bakış
 
-| Backend         | En iyi kullanım alanı                                                        | Ek bağımlılık                          |
-| --------------- | ---------------------------------------------------------------------------- | -------------------------------------- |
-| **numpy**       | Yalnızca CPU ortamları, küçük/orta prediction sayıları                       | Yok (her zaman mevcut)                 |
-| **numba**       | Yüksek prediction sayılı CPU; ilk çağrıda ~1 sn JIT ısınması, ardından hızlı | `pip install numba`                    |
-| **torchvision** | CUDA GPU mevcut olduğunda; büyük batch'ler için en hızlısı                   | `pip install torch torchvision` + CUDA |
+| Backend         | En iyi kullanım alanı                                                        | Ek bağımlılık                   |
+| --------------- | ---------------------------------------------------------------------------- | ------------------------------- |
+| **numpy**       | Yalnızca CPU ortamları, küçük/orta prediction sayıları                       | Yok (her zaman mevcut)          |
+| **numba**       | Yüksek prediction sayılı CPU; ilk çağrıda ~1 sn JIT ısınması, ardından hızlı | `pip install numba`             |
+| **torchvision** | CUDA veya Apple MPS GPU mevcut olduğunda; büyük batch'ler için en hızlısı    | `pip install torch torchvision` |
 
 ## Otomatik Algılama (varsayılan)
 
 SAHI varsayılan olarak çalışma anında (runtime) mevcut en iyi backend'i otomatik olarak seçer:
 
-1. **torchvision** — `torchvision` yüklüyse _ve_ bir CUDA GPU mevcutsa.
+1. **torchvision** — `torchvision` yüklüyse _ve_ bir GPU mevcutsa
+   (CUDA veya Apple Silicon üzerinde Apple MPS).
 2. **numba** — `numba` paketi yüklüyse.
 3. **numpy** — son çare (fallback) olarak her zaman mevcuttur.
 
@@ -63,7 +64,7 @@ from sahi import AutoDetectionModel
 from sahi.predict import get_sliced_prediction
 from sahi.postprocess.backends import set_postprocess_backend
 
-# Use GPU-accelerated postprocessing when running on a CUDA machine
+# CUDA veya Apple Silicon makinelerde GPU hızlandırmalı son işlemeyi kullan
 set_postprocess_backend("torchvision")
 
 detection_model = AutoDetectionModel.from_pretrained(

--- a/docs/tr/quick-start.md
+++ b/docs/tr/quick-start.md
@@ -117,7 +117,7 @@ Dilimleme sonrasında SAHI, örtüşen prediction'ları NMS veya NMM ile birleş
 
 | Backend | Ne zaman seçilir | Kurulum |
 | --------- | -------------- | --------- |
-| **torchvision** | CUDA GPU + torchvision mevcut olduğunda | `pip install torch torchvision` |
+| **torchvision** | CUDA veya Apple MPS GPU + torchvision mevcut olduğunda | `pip install torch torchvision` |
 | **numba** | numba yüklü, GPU yok | `pip install numba` |
 | **numpy** | Her zaman mevcut (fallback) | -- |
 

--- a/docs/zh/postprocess/backends.md
+++ b/docs/zh/postprocess/backends.md
@@ -14,17 +14,17 @@ SAHI 的后处理操作（NMS、NMM）可以在三种可互换的后端上运行
 
 ## 后端概览
 
-| 后端            | 适用场景                                                                | 额外依赖                               |
-| --------------- | ----------------------------------------------------------------------- | -------------------------------------- |
-| **numpy**       | 仅使用 CPU 的环境，预测结果数量较少或中等                               | 无（始终可用）                         |
-| **numba**       | 使用 CPU 且预测结果数量较多；首次调用需要约 1 秒进行 JIT 预热，之后较快 | `pip install numba`                    |
-| **torchvision** | CUDA GPU 可用；处理大型批次时速度最快                                   | `pip install torch torchvision` + CUDA |
+| 后端            | 适用场景                                                                | 额外依赖                        |
+| --------------- | ----------------------------------------------------------------------- | ------------------------------- |
+| **numpy**       | 仅使用 CPU 的环境，预测结果数量较少或中等                               | 无（始终可用）                  |
+| **numba**       | 使用 CPU 且预测结果数量较多；首次调用需要约 1 秒进行 JIT 预热，之后较快 | `pip install numba`             |
+| **torchvision** | CUDA 或 Apple MPS GPU 可用；处理大型批次时速度最快                      | `pip install torch torchvision` |
 
 ## 自动检测（默认）
 
 默认情况下，SAHI 会在运行时自动选择最佳可用后端：
 
-1. **torchvision** -- 已安装 `torchvision` 且存在 CUDA GPU 时使用。
+1. **torchvision** -- 已安装 `torchvision` 且存在 GPU（CUDA，或 Apple Silicon 上的 Apple MPS）时使用。
 2. **numba** -- 已安装 `numba` 软件包时使用。
 3. **numpy** -- 始终可用，作为最终兜底方案。
 
@@ -65,7 +65,7 @@ from sahi import AutoDetectionModel
 from sahi.predict import get_sliced_prediction
 from sahi.postprocess.backends import set_postprocess_backend
 
-# 在 CUDA 环境中使用 GPU 加速后处理
+# 在 CUDA 或 Apple Silicon 环境中使用 GPU 加速后处理
 set_postprocess_backend("torchvision")
 
 detection_model = AutoDetectionModel.from_pretrained(

--- a/docs/zh/quick-start.md
+++ b/docs/zh/quick-start.md
@@ -118,7 +118,7 @@ sahi predict \
 
 | 后端 | 选择条件 | 安装方式 |
 | ------ | --------- | --------- |
-| **torchvision** | CUDA GPU + torchvision 可用 | `pip install torch torchvision` |
+| **torchvision** | CUDA 或 Apple MPS GPU + torchvision 可用 | `pip install torch torchvision` |
 | **numba** | 已安装 numba，无 GPU | `pip install numba` |
 | **numpy** | 始终可用（兜底方案） | -- |
 


### PR DESCRIPTION
The docs still said torchvision is picked only when a CUDA GPU is present, which is no longer true once MPS is detected. Updates the backend table, the auto-detection list and the inline example in `docs/`, `docs/tr/` and `docs/zh/`. I tested NMS on Apple Silicon, IOU, best of 5 runs), which is why preferring torchvision on MPS is worth documenting:

| boxes | numpy | numba | torchvision (MPS) |
| ----: | ----: | ----: | ----------------: |
| 100 | 0.14 ms | 0.02 ms | 1.44 ms |
| 500 | 1.53 ms | 0.36 ms | 1.42 ms |
| 1000 | 5.46 ms | 1.40 ms | 1.45 ms |
| 5000 | 81.37 ms | 34.16 ms | 4.05 ms |
| 20000 | 1237.70 ms | 462.56 ms | 11.75 ms |