### PR TITLE
chore: bump version to 0.12.3

### DIFF
--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -5,8 +5,8 @@
 # Parse MkDocs / zensical syntax (admonitions, tabs, snippets, attr_list, grids)
 flavor = "mkdocs"
 
-# Lint the docs tree only
-include = ["docs/**/*.md"]
+# Lint the docs tree and the changelog
+include = ["docs/**/*.md", "CHANGELOG.md"]
 
 # Keep table columns padded and aligned (off by default)
 enable = ["MD060"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,44 +2,23 @@
 
 ## 🚀 SAHI v0.12.3 Release Notes
 
-A patch release that puts Apple Silicon GPUs to work, adds a Turkish
-translation of the documentation, and clears CI maintenance gathered since
-`0.12.2`.
+A patch release that puts Apple Silicon GPUs to work, adds a Turkish translation of the documentation, and clears CI maintenance gathered since `0.12.2`.
 
 ### 🐛 Fixes
 
-- **Apple MPS is now detected for device selection and postprocessing**
-  ([#1408](https://github.com/obss/sahi/pull/1408)). `select_device()` only
-  looked for CUDA, so macOS users fell back to CPU even with a working Metal
-  backend. Automatic selection is now CUDA → MPS → CPU, and the `torchvision`
-  postprocessing backend is picked when either GPU is present. Detection goes
-  through `torch.backends.mps.is_available()`, which exists on every supported
-  torch version and reports `False` on non-Apple builds.
-- **`threading.currentThread()` replaced with `current_thread()`**
-  ([#1392](https://github.com/obss/sahi/pull/1392)), removing a
-  `DeprecationWarning` on newer Python versions.
+- **Apple MPS is now detected for device selection and postprocessing** ([#1408](https://github.com/obss/sahi/pull/1408)). `select_device()` only looked for CUDA, so macOS users fell back to CPU even with a working Metal backend. Automatic selection is now CUDA → MPS → CPU, and the `torchvision` postprocessing backend is picked when either GPU is present. Detection goes through `torch.backends.mps.is_available()`, which exists on every supported torch version and reports `False` on non-Apple builds.
+- **`threading.currentThread()` replaced with `current_thread()`** ([#1392](https://github.com/obss/sahi/pull/1392)), removing a `DeprecationWarning` on newer Python versions.
 
 ### 📚 Documentation
 
-- **Turkish translation** of the documentation, with a build step and
-  `zensical` configuration to match
-  ([#1401](https://github.com/obss/sahi/pull/1401),
-  [#1402](https://github.com/obss/sahi/pull/1402),
-  [#1404](https://github.com/obss/sahi/pull/1404)).
-- Multilingual subpath links now resolve correctly
-  ([#1403](https://github.com/obss/sahi/pull/1403)).
-- Backend documentation lists MPS alongside CUDA
-  ([#1410](https://github.com/obss/sahi/pull/1410)).
+- **Turkish translation** of the documentation, with a build step and `zensical` configuration to match ([#1401](https://github.com/obss/sahi/pull/1401), [#1402](https://github.com/obss/sahi/pull/1402), [#1404](https://github.com/obss/sahi/pull/1404)).
+- Multilingual subpath links now resolve correctly ([#1403](https://github.com/obss/sahi/pull/1403)).
+- Backend documentation lists MPS alongside CUDA ([#1410](https://github.com/obss/sahi/pull/1410)).
 
 ### 🧹 Maintenance & CI
 
-- Device selection and postprocessing backend resolution are covered by tests
-  ([#1409](https://github.com/obss/sahi/pull/1409)).
-- Bumped `astral-sh/setup-uv` 8.3.2 → 9.0.0
-  ([#1399](https://github.com/obss/sahi/pull/1399)),
-  `actions/setup-python` 6.3.0 → 7.0.0
-  ([#1400](https://github.com/obss/sahi/pull/1400)) and `actions/checkout`
-  7.0.0 → 7.0.1 ([#1398](https://github.com/obss/sahi/pull/1398)).
+- Device selection and postprocessing backend resolution are covered by tests ([#1409](https://github.com/obss/sahi/pull/1409)).
+- Bumped `astral-sh/setup-uv` 8.3.2 → 9.0.0 ([#1399](https://github.com/obss/sahi/pull/1399)), `actions/setup-python` 6.3.0 → 7.0.0 ([#1400](https://github.com/obss/sahi/pull/1400)) and `actions/checkout` 7.0.0 → 7.0.1 ([#1398](https://github.com/obss/sahi/pull/1398)).
 
 ### ⚡ Performance
 
@@ -53,8 +32,7 @@ NMS with the `IOU` metric, best of 5 runs, on an Apple M2 Pro:
 | 5000 | 81.37 ms | 34.16 ms | 4.05 ms |
 | 20000 | 1237.70 ms | 462.56 ms | 11.75 ms |
 
-Below roughly 500 boxes `numba` stays ahead, but the difference there is about
-a millisecond.
+Below roughly 500 boxes `numba` stays ahead, but the difference there is about a millisecond.
 
 **Full Changelog**:
 <https://github.com/obss/sahi/compare/0.12.2...0.12.3>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ A patch release that puts Apple Silicon GPUs to work, adds a Turkish translation
 
 - Device selection and postprocessing backend resolution are covered by tests ([#1409](https://github.com/obss/sahi/pull/1409)).
 - Bumped `astral-sh/setup-uv` 8.3.2 → 9.0.0 ([#1399](https://github.com/obss/sahi/pull/1399)), `actions/setup-python` 6.3.0 → 7.0.0 ([#1400](https://github.com/obss/sahi/pull/1400)) and `actions/checkout` 7.0.0 → 7.0.1 ([#1398](https://github.com/obss/sahi/pull/1398)).
+- Relaxed the `twine` requirement to `>=5.1.1,<8.0.0` ([#1406](https://github.com/obss/sahi/pull/1406)).
 
 ### ⚡ Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,64 @@
 # 📝 CHANGELOG
 
+## 🚀 SAHI v0.12.3 Release Notes
+
+A patch release that puts Apple Silicon GPUs to work, adds a Turkish
+translation of the documentation, and clears CI maintenance gathered since
+`0.12.2`.
+
+### 🐛 Fixes
+
+- **Apple MPS is now detected for device selection and postprocessing**
+  ([#1408](https://github.com/obss/sahi/pull/1408)). `select_device()` only
+  looked for CUDA, so macOS users fell back to CPU even with a working Metal
+  backend. Automatic selection is now CUDA → MPS → CPU, and the `torchvision`
+  postprocessing backend is picked when either GPU is present. Detection goes
+  through `torch.backends.mps.is_available()`, which exists on every supported
+  torch version and reports `False` on non-Apple builds.
+- **`threading.currentThread()` replaced with `current_thread()`**
+  ([#1392](https://github.com/obss/sahi/pull/1392)), removing a
+  `DeprecationWarning` on newer Python versions.
+
+### 📚 Documentation
+
+- **Turkish translation** of the documentation, with a build step and
+  `zensical` configuration to match
+  ([#1401](https://github.com/obss/sahi/pull/1401),
+  [#1402](https://github.com/obss/sahi/pull/1402),
+  [#1404](https://github.com/obss/sahi/pull/1404)).
+- Multilingual subpath links now resolve correctly
+  ([#1403](https://github.com/obss/sahi/pull/1403)).
+- Backend documentation lists MPS alongside CUDA
+  ([#1410](https://github.com/obss/sahi/pull/1410)).
+
+### 🧹 Maintenance & CI
+
+- Device selection and postprocessing backend resolution are covered by tests
+  ([#1409](https://github.com/obss/sahi/pull/1409)).
+- Bumped `astral-sh/setup-uv` 8.3.2 → 9.0.0
+  ([#1399](https://github.com/obss/sahi/pull/1399)),
+  `actions/setup-python` 6.3.0 → 7.0.0
+  ([#1400](https://github.com/obss/sahi/pull/1400)) and `actions/checkout`
+  7.0.0 → 7.0.1 ([#1398](https://github.com/obss/sahi/pull/1398)).
+
+### ⚡ Performance
+
+NMS with the `IOU` metric, best of 5 runs, on an Apple M2 Pro:
+
+| boxes | numpy | numba | torchvision (MPS) |
+| ----: | ----: | ----: | ----------------: |
+| 100 | 0.14 ms | 0.02 ms | 1.44 ms |
+| 500 | 1.53 ms | 0.36 ms | 1.42 ms |
+| 1000 | 5.46 ms | 1.40 ms | 1.45 ms |
+| 5000 | 81.37 ms | 34.16 ms | 4.05 ms |
+| 20000 | 1237.70 ms | 462.56 ms | 11.75 ms |
+
+Below roughly 500 boxes `numba` stays ahead, but the difference there is about
+a millisecond.
+
+**Full Changelog**:
+<https://github.com/obss/sahi/compare/0.12.2...0.12.3>
+
 ## 🚀 SAHI v0.12.2 Release Notes
 
 A patch release fixing out-of-memory failures and severe slowdowns when

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sahi"
-version = "0.12.2"
+version = "0.12.3"
 readme = "README.md"
 description = "A vision library for performing sliced inference on large images/small objects"
 requires-python = ">=3.8"


### PR DESCRIPTION
Patch release. Apple MPS is now used for device selection and postprocessing, the documentation has a Turkish translation, and CI actions are up to date.

Full notes in `CHANGELOG.md`.
