### PR TITLE
Stop NMM from merging a keeper into itself

### DIFF
--- a/sahi/postprocess/_numpy_backend.py
+++ b/sahi/postprocess/_numpy_backend.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import numpy as np
 
 from sahi.postprocess._sparse_backend import (
+    _safe_ratio,
     build_sparse_matches,
     greedy_nmm_sparse,
     nmm_sparse,
@@ -55,10 +56,10 @@ def compute_metric_matrix(boxes: np.ndarray, areas: np.ndarray, match_metric: st
 
         if match_metric == "IOU":
             union = areas[i:ie, None] + areas[None, :] - inter
-            matrix[i:ie] = np.where(union > 0, inter / union, 0)
+            matrix[i:ie] = _safe_ratio(inter, union)
         else:  # IOS
             smaller = np.minimum(areas[i:ie, None], areas[None, :])
-            matrix[i:ie] = np.where(smaller > 0, inter / smaller, 0)
+            matrix[i:ie] = _safe_ratio(inter, smaller)
     return matrix
 
 
@@ -82,10 +83,10 @@ def _compute_metric_matrix_full(boxes: np.ndarray, areas: np.ndarray, match_metr
 
     if match_metric == "IOU":
         union = areas[:, None] + areas[None, :] - inter
-        return np.where(union > 0, inter / union, 0).astype(np.float32)
+        return _safe_ratio(inter, union).astype(np.float32)
     else:  # IOS
         smaller = np.minimum(areas[:, None], areas[None, :])
-        return np.where(smaller > 0, inter / smaller, 0).astype(np.float32)
+        return _safe_ratio(inter, smaller).astype(np.float32)
 
 
 def _score_tiebreak_order(
@@ -264,7 +265,9 @@ def nmm_from_matrix(
         matched = np.where(candidates_of[current_idx])[0]
 
         if merge_to_keep[current_idx] < 0:
-            # current_idx is a keeper
+            # current_idx is a keeper. Point it at itself so that a later box
+            # cannot claim it: keepers are never merged into anything.
+            merge_to_keep[current_idx] = current_idx
             keep_to_merge_list[current_idx] = []
             for m in matched:
                 m_int = int(m)

--- a/sahi/postprocess/_sparse_backend.py
+++ b/sahi/postprocess/_sparse_backend.py
@@ -35,6 +35,21 @@ def should_use_sparse(n: int, match_threshold: float) -> bool:
     return n >= SPARSE_MIN_BOXES and match_threshold > 0
 
 
+def _safe_ratio(numerator: np.ndarray, denominator: np.ndarray) -> np.ndarray:
+    """Divide where the denominator is positive, yielding zero elsewhere.
+
+    Degenerate boxes have zero area, so the denominator can be zero. Masking the
+    division rather than the result keeps numpy from evaluating ``0 / 0`` and
+    warning about it.
+    """
+    return np.divide(
+        numerator,
+        denominator,
+        out=np.zeros(np.broadcast(numerator, denominator).shape, dtype=np.result_type(numerator, denominator)),
+        where=denominator > 0,
+    )
+
+
 def build_sparse_matches(
     boxes: np.ndarray,
     areas: np.ndarray,
@@ -76,7 +91,7 @@ def build_sparse_matches(
         denom = areas[rows] + areas[cols] - inter
     else:  # IOS
         denom = np.minimum(areas[rows], areas[cols])
-    metric = np.where(denom > 0, inter / denom, 0)
+    metric = _safe_ratio(inter, denom)
 
     matched = metric >= match_threshold
     rows, cols = rows[matched], cols[matched]
@@ -220,6 +235,9 @@ def nmm_sparse(
         matched = indices[start:end][dominates[start:end]]
 
         if merge_to_keep[current_idx] < 0:
+            # current_idx is a keeper. Point it at itself so that a later box
+            # cannot claim it: keepers are never merged into anything.
+            merge_to_keep[current_idx] = current_idx
             keep_to_merge_list[current_idx] = []
             for m in matched:
                 m_int = int(m)

--- a/tests/test_sparse_backend.py
+++ b/tests/test_sparse_backend.py
@@ -99,3 +99,59 @@ def test_large_input_takes_sparse_path_and_matches_dense() -> None:
     assert nms_numpy(predictions, "IOS", 0.3) == nms_from_matrix(matrix, sorted_idxs, 0.3)
     assert greedy_nmm_numpy(predictions, "IOS", 0.3) == greedy_nmm_from_matrix(matrix, sorted_idxs, 0.3)
     assert nmm_numpy(predictions, "IOS", 0.3) == nmm_from_matrix(matrix, sorted_idxs, scores, boxes, 0.3)
+
+
+@pytest.mark.parametrize("match_threshold", [0.1, 0.3, 0.5, 0.7])
+@pytest.mark.parametrize("match_metric", ["IOU", "IOS"])
+def test_nmm_never_merges_a_keeper_into_itself(match_metric: str, match_threshold: float) -> None:
+    """Tied scores on duplicate boxes used to let a later box claim an earlier keeper.
+
+    A keeper is never merged into anything, no index lands in two merge lists,
+    and every index is either a keeper or merged exactly once.
+    """
+    rng = np.random.default_rng(11)
+    n = 80
+    x1 = np.round(rng.uniform(0, 200, n) / 25) * 25
+    y1 = np.round(rng.uniform(0, 200, n) / 25) * 25
+    w = np.round(rng.uniform(1, 40, n) / 25) * 25
+    h = np.round(rng.uniform(1, 40, n) / 25) * 25
+    scores = np.round(rng.uniform(0, 1, n), 1)
+    predictions = np.stack([x1, y1, x1 + w, y1 + h, scores, rng.integers(0, 3, n)], axis=1)
+
+    boxes = predictions[:, :4]
+    areas = (boxes[:, 2] - boxes[:, 0]) * (boxes[:, 3] - boxes[:, 1])
+    matrix, sorted_idxs = _prepare_matrix(predictions, match_metric)
+    indptr, indices = build_sparse_matches(boxes, areas, match_metric, match_threshold)
+
+    dense = nmm_from_matrix(matrix, sorted_idxs, predictions[:, 4], boxes, match_threshold)
+    csr = nmm_sparse(indptr, indices, sorted_idxs, predictions[:, 4], boxes)
+    assert dense == csr
+
+    for name, result in (("dense", dense), ("csr", csr)):
+        merged_by: dict[int, int] = {}
+        for keeper, merged in result.items():
+            assert keeper not in merged, f"{name}: keeper {keeper} merged into itself"
+            for m in merged:
+                assert m not in merged_by, f"{name}: {m} merged into {merged_by[m]} and {keeper}"
+                merged_by[m] = keeper
+        assert not set(result) & set(merged_by), f"{name}: an index is both keeper and merged"
+        assert set(result) | set(merged_by) == set(range(n)), f"{name}: some index is in no group"
+
+
+def test_metric_does_not_warn_on_zero_area_boxes() -> None:
+    """Degenerate boxes make the denominator zero; that must not divide by zero."""
+    import warnings
+
+    from sahi.postprocess._numpy_backend import compute_metric_matrix
+
+    predictions = _make_predictions(300, spread=200.0, seed=12)
+    predictions[::7, 2] = predictions[::7, 0]  # zero width
+    predictions[::11, 3] = predictions[::11, 1]  # zero height
+    boxes = predictions[:, :4]
+    areas = (boxes[:, 2] - boxes[:, 0]) * (boxes[:, 3] - boxes[:, 1])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        for metric in ("IOU", "IOS"):
+            compute_metric_matrix(boxes, areas, metric)
+            build_sparse_matches(boxes, areas, metric, 0.3)


### PR DESCRIPTION
The NMM merge loop marked a keeper by leaving its `merge_to_keep` entry at `-1`, which is the same value that marks a box as unclaimed, so a box processed later could claim a keeper and append it to a merge list. With tied scores on duplicate boxes this produced a keeper listed inside its own merge list, and the same index reachable as both a keeper and a merged box. Keepers now point at themselves, which makes them unclaimable without changing any other outcome. The metric division is also masked rather than computed and discarded, because zero-area boxes made it evaluate `0 / 0` and emit a `RuntimeWarning`.

| behaviour | before | after |
| --- | --- | --- |
| keeper inside its own merge list | reachable at thresholds 0.1 to 0.7 | never |
| index in two merge lists | reachable | never |
| zero-area box metric | `RuntimeWarning` | no warning |
| dense and CSR agreement | held | held |