### PR TITLE
Keep postprocess memory independent of how crowded the boxes are

### DIFF
--- a/sahi/postprocess/_numba_backend.py
+++ b/sahi/postprocess/_numba_backend.py
@@ -17,8 +17,12 @@ from numpy.typing import NDArray
 
 from sahi.postprocess._numpy_backend import (
     _score_tiebreak_order,
+    greedy_nmm_match_all,
+    matches_all_pairs,
     nmm_from_matrix,
+    nmm_match_all,
     nmm_numpy,
+    nms_match_all,
 )
 from sahi.postprocess._sparse_backend import should_use_sparse
 
@@ -225,6 +229,9 @@ def nms_numba(
     if len(predictions) == 0:
         return []
 
+    if matches_all_pairs(match_threshold):
+        return nms_match_all(predictions)
+
     preds = predictions.astype(np.float64)
     x1, y1, x2, y2 = preds[:, 0], preds[:, 1], preds[:, 2], preds[:, 3]
     scores = preds[:, 4]
@@ -239,6 +246,9 @@ def greedy_nmm_numba(
     match_threshold: float = 0.5,
 ) -> dict[int, list[int]]:
     """Greedy non-maximum merging using numba JIT compilation."""
+    if matches_all_pairs(match_threshold):
+        return greedy_nmm_match_all(predictions)
+
     preds = predictions.astype(np.float64)
     x1, y1, x2, y2 = preds[:, 0], preds[:, 1], preds[:, 2], preds[:, 3]
     scores = preds[:, 4]
@@ -265,6 +275,8 @@ def nmm_numba(
     match_threshold: float = 0.5,
 ) -> dict[int, list[int]]:
     """NMM using numba-computed metric matrix + shared Python merge logic."""
+    if matches_all_pairs(match_threshold):
+        return nmm_match_all(predictions)
     if should_use_sparse(len(predictions), match_threshold):
         return nmm_numpy(predictions, match_metric, match_threshold)
 

--- a/sahi/postprocess/_numpy_backend.py
+++ b/sahi/postprocess/_numpy_backend.py
@@ -12,9 +12,11 @@ import numpy as np
 from sahi.postprocess._sparse_backend import (
     _safe_ratio,
     build_sparse_matches,
-    greedy_nmm_sparse,
+    greedy_nmm_streaming,
     nmm_sparse,
-    nms_sparse,
+    nmm_streaming,
+    nms_streaming,
+    should_stream_nmm,
     should_use_sparse,
 )
 
@@ -114,6 +116,81 @@ def _score_tiebreak_order(
     """
     order = np.lexsort((y2, x2, y1, x1, -scores))
     return order
+
+
+def matches_all_pairs(match_threshold: float) -> bool:
+    """Return whether every pair counts as a match at this threshold.
+
+    Both metrics divide a non-negative intersection by a positive denominator,
+    or yield zero, so a metric value is never negative. Once the threshold
+    reaches zero the ``metric >= match_threshold`` test holds for every pair
+    including disjoint ones, and the adjacency is the complete graph.
+
+    Args:
+        match_threshold: Overlap threshold used for matching.
+
+    Returns:
+        True when the threshold admits every pair.
+    """
+    return match_threshold <= 0
+
+
+def _match_all_order(predictions: np.ndarray) -> np.ndarray:
+    """Score order for the complete-graph case, where no metric is needed."""
+    boxes = predictions[:, :4]
+    return _score_tiebreak_order(boxes[:, 0], boxes[:, 1], boxes[:, 2], boxes[:, 3], predictions[:, 4])
+
+
+def nms_match_all(predictions: np.ndarray) -> list[int]:
+    """NMS when every pair matches: the top-scoring box suppresses the rest."""
+    if len(predictions) == 0:
+        return []
+    return [int(_match_all_order(predictions)[0])]
+
+
+def greedy_nmm_match_all(predictions: np.ndarray) -> dict[int, list[int]]:
+    """Greedy NMM when every pair matches: one keeper absorbs the rest.
+
+    The dense loop emits candidates in score order, so this does too.
+    """
+    if len(predictions) == 0:
+        return {}
+    order = _match_all_order(predictions)
+    return {int(order[0]): [int(i) for i in order[1:]]}
+
+
+def nmm_match_all(predictions: np.ndarray) -> dict[int, list[int]]:
+    """NMM when every pair matches: the top-scoring box absorbs what it dominates.
+
+    A box only claims another that scores lower, or that scores equal without
+    sorting before it by coordinates. The top-scoring box sorts first among its
+    own score, so it claims every lower-scored box plus any exact coordinate
+    duplicate of itself, and nothing else. Boxes sharing the top score are left
+    as keepers with nothing merged into them, which is what the dense loop
+    produces once every pair is a match.
+
+    The merged indices come out in ascending index order, matching the
+    ``np.where`` the dense loop collects them with.
+    """
+    n = len(predictions)
+    if n == 0:
+        return {}
+
+    boxes, scores = predictions[:, :4], predictions[:, 4]
+    order = _match_all_order(predictions)
+    top = int(order[0])
+
+    tied = scores == scores[top]
+    duplicate = tied & np.all(boxes == boxes[top], axis=1)
+
+    claimed = ~tied | duplicate
+    claimed[top] = False
+
+    result: dict[int, list[int]] = {top: np.flatnonzero(claimed).tolist()}
+    for idx in order:
+        if tied[idx] and not duplicate[idx]:
+            result[int(idx)] = []
+    return result
 
 
 def _prepare_matrix(predictions: np.ndarray, match_metric: str) -> tuple[np.ndarray, np.ndarray]:
@@ -294,6 +371,14 @@ def nmm_from_matrix(
 # ---------------------------------------------------------------------------
 
 
+def _prepare_streaming(predictions: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Extract boxes, areas and the score order, computing no overlaps at all."""
+    boxes = predictions[:, :4]
+    areas = (boxes[:, 2] - boxes[:, 0]) * (boxes[:, 3] - boxes[:, 1])
+    sorted_idxs = _score_tiebreak_order(boxes[:, 0], boxes[:, 1], boxes[:, 2], boxes[:, 3], predictions[:, 4])
+    return boxes, areas, sorted_idxs
+
+
 def _prepare_sparse(
     predictions: np.ndarray, match_metric: str, match_threshold: float
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
@@ -314,9 +399,11 @@ def nms_numpy(
     """Non-maximum suppression using vectorized numpy metric matrix."""
     if len(predictions) == 0:
         return []
+    if matches_all_pairs(match_threshold):
+        return nms_match_all(predictions)
     if should_use_sparse(len(predictions), match_threshold):
-        indptr, indices, sorted_idxs = _prepare_sparse(predictions, match_metric, match_threshold)
-        return nms_sparse(indptr, indices, sorted_idxs)
+        boxes, areas, sorted_idxs = _prepare_streaming(predictions)
+        return nms_streaming(boxes, areas, match_metric, match_threshold, sorted_idxs)
     matrix, sorted_idxs = _prepare_matrix(predictions, match_metric)
     return nms_from_matrix(matrix, sorted_idxs, match_threshold)
 
@@ -327,9 +414,11 @@ def greedy_nmm_numpy(
     match_threshold: float = 0.5,
 ) -> dict[int, list[int]]:
     """Greedy non-maximum merging using vectorized numpy metric matrix."""
+    if matches_all_pairs(match_threshold):
+        return greedy_nmm_match_all(predictions)
     if should_use_sparse(len(predictions), match_threshold):
-        indptr, indices, sorted_idxs = _prepare_sparse(predictions, match_metric, match_threshold)
-        return greedy_nmm_sparse(indptr, indices, sorted_idxs)
+        boxes, areas, sorted_idxs = _prepare_streaming(predictions)
+        return greedy_nmm_streaming(boxes, areas, match_metric, match_threshold, sorted_idxs)
     matrix, sorted_idxs = _prepare_matrix(predictions, match_metric)
     return greedy_nmm_from_matrix(matrix, sorted_idxs, match_threshold)
 
@@ -340,7 +429,12 @@ def nmm_numpy(
     match_threshold: float = 0.5,
 ) -> dict[int, list[int]]:
     """Non-maximum merging using vectorized numpy metric matrix."""
+    if matches_all_pairs(match_threshold):
+        return nmm_match_all(predictions)
     if should_use_sparse(len(predictions), match_threshold):
+        if should_stream_nmm(predictions[:, :4]):
+            boxes, areas, sorted_idxs = _prepare_streaming(predictions)
+            return nmm_streaming(boxes, areas, match_metric, match_threshold, sorted_idxs, predictions[:, 4])
         indptr, indices, sorted_idxs = _prepare_sparse(predictions, match_metric, match_threshold)
         return nmm_sparse(indptr, indices, sorted_idxs, predictions[:, 4], predictions[:, :4])
     matrix, sorted_idxs = _prepare_matrix(predictions, match_metric)

--- a/sahi/postprocess/_sparse_backend.py
+++ b/sahi/postprocess/_sparse_backend.py
@@ -5,6 +5,13 @@ this module skips the dense ``N x N`` matrix and builds the thresholded
 adjacency directly from the box pairs a shapely STRtree reports as
 intersecting. The adjacency is CSR: row ``i`` is
 ``indices[indptr[i]:indptr[i + 1]]``, sorted ascending.
+
+Storing every pair is only a saving while boxes are spread out. Boxes piled on
+top of each other intersect nearly everything, so the pair count approaches
+``N ^ 2`` and the CSR gets as expensive as the matrix it replaced. The loops
+read one row at a time and NMS and greedy NMM only ever read rows of boxes that
+survived, so ``MatchQuery`` answers rows from the tree on demand instead, which
+holds peak memory at ``O(N + max_degree)`` whatever the layout.
 """
 
 from __future__ import annotations
@@ -16,6 +23,39 @@ from shapely import box as shapely_box
 # Below this many boxes the dense path wins: the STRtree build costs more than
 # the N x N matrix it saves.
 SPARSE_MIN_BOXES = 2000
+
+# NMM reads a row per box rather than per survivor, so answering its rows from
+# the tree costs it roughly an order of magnitude in time. It keeps the stored
+# pair list until that list would get large, measured at about 110 bytes per
+# pair once the intermediates are counted.
+NMM_MAX_PAIRS = 2_000_000
+
+
+def _safe_ratio(numerator: np.ndarray, denominator: np.ndarray) -> np.ndarray:
+    """Divide where the denominator is positive, yielding zero elsewhere.
+
+    Degenerate boxes have zero area, so the denominator can be zero. Masking the
+    division rather than the result keeps numpy from evaluating ``0 / 0`` and
+    warning about it.
+    """
+    return np.divide(
+        numerator,
+        denominator,
+        out=np.zeros(np.broadcast(numerator, denominator).shape, dtype=np.result_type(numerator, denominator)),
+        where=denominator > 0,
+    )
+
+
+def should_stream_nmm(boxes: np.ndarray) -> bool:
+    """Return whether NMM should answer rows from the tree instead of storing pairs.
+
+    Args:
+        boxes: Array of shape (N, 4) with columns [x1, y1, x2, y2].
+
+    Returns:
+        True when the pair list is projected to exceed ``NMM_MAX_PAIRS``.
+    """
+    return estimate_mean_degree(boxes) * len(boxes) > NMM_MAX_PAIRS
 
 
 def should_use_sparse(n: int, match_threshold: float) -> bool:
@@ -35,19 +75,150 @@ def should_use_sparse(n: int, match_threshold: float) -> bool:
     return n >= SPARSE_MIN_BOXES and match_threshold > 0
 
 
-def _safe_ratio(numerator: np.ndarray, denominator: np.ndarray) -> np.ndarray:
-    """Divide where the denominator is positive, yielding zero elsewhere.
+class MatchQuery:
+    """Answers 'which boxes match box i' from an STRtree, without storing pairs.
 
-    Degenerate boxes have zero area, so the denominator can be zero. Masking the
-    division rather than the result keeps numpy from evaluating ``0 / 0`` and
-    warning about it.
+    Args:
+        boxes: Array of shape (N, 4) with columns [x1, y1, x2, y2].
+        areas: Precomputed areas of shape (N,).
+        match_metric: Overlap metric, "IOU" or "IOS".
+        match_threshold: Minimum metric value counted as a match.
     """
-    return np.divide(
-        numerator,
-        denominator,
-        out=np.zeros(np.broadcast(numerator, denominator).shape, dtype=np.result_type(numerator, denominator)),
-        where=denominator > 0,
-    )
+
+    def __init__(self, boxes: np.ndarray, areas: np.ndarray, match_metric: str, match_threshold: float) -> None:
+        self.boxes = boxes
+        self.areas = areas
+        self.match_metric = match_metric
+        self.match_threshold = match_threshold
+        self.geoms = shapely_box(boxes[:, 0], boxes[:, 1], boxes[:, 2], boxes[:, 3])
+        self.tree = STRtree(self.geoms)
+
+    def row(self, i: int) -> np.ndarray:
+        """Return the matches of box ``i``, ascending, excluding ``i`` itself.
+
+        Equivalent to one row of the CSR ``build_sparse_matches`` would build.
+        """
+        candidates = self.tree.query(self.geoms[i], predicate="intersects")
+        candidates = candidates[candidates != i]
+        if len(candidates) == 0:
+            return candidates.astype(np.intp)
+
+        boxes, areas = self.boxes, self.areas
+        inter_x1 = np.maximum(boxes[i, 0], boxes[candidates, 0])
+        inter_y1 = np.maximum(boxes[i, 1], boxes[candidates, 1])
+        inter_x2 = np.minimum(boxes[i, 2], boxes[candidates, 2])
+        inter_y2 = np.minimum(boxes[i, 3], boxes[candidates, 3])
+        inter = np.maximum(0, inter_x2 - inter_x1) * np.maximum(0, inter_y2 - inter_y1)
+
+        if self.match_metric == "IOU":
+            denom = areas[i] + areas[candidates] - inter
+        else:  # IOS
+            denom = np.minimum(areas[i], areas[candidates])
+        metric = _safe_ratio(inter, denom)
+
+        return np.sort(candidates[metric >= self.match_threshold]).astype(np.intp)
+
+
+def nms_streaming(
+    boxes: np.ndarray,
+    areas: np.ndarray,
+    match_metric: str,
+    match_threshold: float,
+    sorted_idxs: np.ndarray,
+) -> list[int]:
+    """NMS reading match rows on demand. Same result as ``nms_sparse``.
+
+    Only boxes that survive are ever queried, so on crowded inputs, where almost
+    everything is suppressed, this touches a small fraction of the pairs the CSR
+    would have stored.
+
+    Args:
+        boxes: Array of shape (N, 4) with columns [x1, y1, x2, y2].
+        areas: Precomputed areas of shape (N,).
+        match_metric: Overlap metric, "IOU" or "IOS".
+        match_threshold: Minimum metric value counted as a match.
+        sorted_idxs: Indices sorted by score descending.
+
+    Returns:
+        List of kept indices sorted by score descending.
+    """
+    matches = MatchQuery(boxes, areas, match_metric, match_threshold)
+    suppressed = np.zeros(len(boxes), dtype=bool)
+    keep: list[int] = []
+
+    for idx in sorted_idxs:
+        if suppressed[idx]:
+            continue
+        keep.append(int(idx))
+        suppressed[matches.row(int(idx))] = True
+
+    return keep
+
+
+def greedy_nmm_streaming(
+    boxes: np.ndarray,
+    areas: np.ndarray,
+    match_metric: str,
+    match_threshold: float,
+    sorted_idxs: np.ndarray,
+) -> dict[int, list[int]]:
+    """Greedy NMM reading match rows on demand. Same result as ``greedy_nmm_sparse``.
+
+    Args:
+        boxes: Array of shape (N, 4) with columns [x1, y1, x2, y2].
+        areas: Precomputed areas of shape (N,).
+        match_metric: Overlap metric, "IOU" or "IOS".
+        match_threshold: Minimum metric value counted as a match.
+        sorted_idxs: Indices sorted by score descending.
+
+    Returns:
+        Dict mapping each kept index to a list of indices merged into it.
+    """
+    n = len(boxes)
+    matches = MatchQuery(boxes, areas, match_metric, match_threshold)
+    suppressed = np.zeros(n, dtype=bool)
+
+    # The dense loop only considers candidates that come later in score order,
+    # and emits them in that order.
+    rank = np.empty(n, dtype=np.intp)
+    rank[sorted_idxs] = np.arange(n)
+
+    keep_to_merge_list: dict[int, list[int]] = {}
+    for position, idx in enumerate(sorted_idxs):
+        if suppressed[idx]:
+            continue
+
+        neighbours = matches.row(int(idx))
+        merge_indices = neighbours[(rank[neighbours] > position) & ~suppressed[neighbours]]
+        merge_indices = merge_indices[np.argsort(rank[merge_indices])]
+
+        suppressed[merge_indices] = True
+        keep_to_merge_list[int(idx)] = merge_indices.tolist()
+
+    return keep_to_merge_list
+
+
+def estimate_mean_degree(boxes: np.ndarray, sample: int = 512) -> float:
+    """Estimate how many other boxes an average box intersects.
+
+    Queries the tree with an evenly spaced subset instead of every box, so the
+    cost is a small fraction of the full query the sparse path would run.
+
+    Args:
+        boxes: Array of shape (N, 4) with columns [x1, y1, x2, y2].
+        sample: Number of boxes to probe with.
+
+    Returns:
+        Mean number of intersecting neighbours, self-pair excluded.
+    """
+    n = len(boxes)
+    geoms = shapely_box(boxes[:, 0], boxes[:, 1], boxes[:, 2], boxes[:, 3])
+    tree = STRtree(geoms)
+
+    k = min(n, sample)
+    probe = geoms[np.linspace(0, n - 1, k).astype(np.intp)]
+    rows, _ = tree.query(probe, predicate="intersects")
+    return max(0.0, len(rows) / k - 1.0)
 
 
 def build_sparse_matches(
@@ -256,3 +427,84 @@ def nmm_sparse(
                     merge_to_keep[m_int] = keep_idx
 
     return keep_to_merge_list
+
+
+def nmm_streaming(
+    boxes: np.ndarray,
+    areas: np.ndarray,
+    match_metric: str,
+    match_threshold: float,
+    sorted_idxs: np.ndarray,
+    scores: np.ndarray,
+) -> dict[int, list[int]]:
+    """NMM reading match rows on demand. Same result as ``nmm_sparse``.
+
+    Unlike NMS and greedy NMM this visits every box, not just the survivors, so
+    it issues one tree query per box and is markedly slower than the stored-pair
+    version. It exists for inputs whose pair list does not fit in memory.
+
+    Args:
+        boxes: Array of shape (N, 4) with columns [x1, y1, x2, y2].
+        areas: Precomputed areas of shape (N,).
+        match_metric: Overlap metric, "IOU" or "IOS".
+        match_threshold: Minimum metric value counted as a match.
+        sorted_idxs: Indices sorted by score descending.
+        scores: Prediction scores of shape (N,).
+
+    Returns:
+        Dict mapping each kept index to a list of indices merged into it.
+    """
+    n = len(boxes)
+    matches = MatchQuery(boxes, areas, match_metric, match_threshold)
+
+    keep_to_merge_list: dict[int, list[int]] = {}
+    merge_to_keep = np.full(n, -1, dtype=np.intp)
+
+    for idx_pos in range(n):
+        current_idx = int(sorted_idxs[idx_pos])
+        matched = _dominated_row(matches.row(current_idx), current_idx, scores, boxes)
+
+        if merge_to_keep[current_idx] < 0:
+            # current_idx is a keeper. Point it at itself so that a later box
+            # cannot claim it: keepers are never merged into anything.
+            merge_to_keep[current_idx] = current_idx
+            keep_to_merge_list[current_idx] = []
+            for m in matched:
+                m_int = int(m)
+                if merge_to_keep[m_int] < 0:
+                    keep_to_merge_list[current_idx].append(m_int)
+                    merge_to_keep[m_int] = current_idx
+        else:
+            keep_idx = int(merge_to_keep[current_idx])
+            merge_list = keep_to_merge_list.get(keep_idx, [])
+            if keep_idx not in keep_to_merge_list:
+                keep_to_merge_list[keep_idx] = merge_list
+            for m in matched:
+                m_int = int(m)
+                if m_int not in merge_list and merge_to_keep[m_int] < 0:
+                    merge_list.append(m_int)
+                    merge_to_keep[m_int] = keep_idx
+
+    return keep_to_merge_list
+
+
+def _dominated_row(candidates: np.ndarray, i: int, scores: np.ndarray, boxes: np.ndarray) -> np.ndarray:
+    """Restrict one match row to the columns its row may claim.
+
+    Single-row form of ``_dominates_all``.
+    """
+    if len(candidates) == 0:
+        return candidates
+
+    lower_score = scores[i] > scores[candidates]
+    score_equal = scores[i] == scores[candidates]
+
+    row_lt = np.zeros(len(candidates), dtype=bool)
+    still_equal = np.ones(len(candidates), dtype=bool)
+    for col in range(4):
+        col_lt = boxes[i, col] < boxes[candidates, col]
+        col_eq = boxes[i, col] == boxes[candidates, col]
+        row_lt |= still_equal & col_lt
+        still_equal &= col_eq
+
+    return candidates[lower_score | (score_equal & ~row_lt)]

--- a/sahi/postprocess/_torchvision_backend.py
+++ b/sahi/postprocess/_torchvision_backend.py
@@ -14,10 +14,14 @@ import torchvision
 from sahi.postprocess._numpy_backend import (
     _score_tiebreak_order,
     greedy_nmm_from_matrix,
+    greedy_nmm_match_all,
     greedy_nmm_numpy,
+    matches_all_pairs,
     nmm_from_matrix,
+    nmm_match_all,
     nmm_numpy,
     nms_from_matrix,
+    nms_match_all,
     nms_numpy,
 )
 from sahi.postprocess._sparse_backend import should_use_sparse
@@ -76,6 +80,9 @@ def nms_torchvision(
     if len(predictions) == 0:
         return []
 
+    if matches_all_pairs(match_threshold):
+        return nms_match_all(predictions)
+
     if match_metric == "IOU":
         # Use torchvision's native CUDA NMS kernel
         device = _get_device()
@@ -97,6 +104,8 @@ def greedy_nmm_torchvision(
     match_threshold: float = 0.5,
 ) -> dict[int, list[int]]:
     """Greedy NMM: compute metric matrix on GPU, merge logic on CPU."""
+    if matches_all_pairs(match_threshold):
+        return greedy_nmm_match_all(predictions)
     if should_use_sparse(len(predictions), match_threshold):
         return greedy_nmm_numpy(predictions, match_metric, match_threshold)
     matrix, sorted_idxs = _prepare_matrix_torch(predictions, match_metric)
@@ -109,6 +118,8 @@ def nmm_torchvision(
     match_threshold: float = 0.5,
 ) -> dict[int, list[int]]:
     """NMM: compute metric matrix on GPU, transitive merge logic on CPU."""
+    if matches_all_pairs(match_threshold):
+        return nmm_match_all(predictions)
     if should_use_sparse(len(predictions), match_threshold):
         return nmm_numpy(predictions, match_metric, match_threshold)
     matrix, sorted_idxs = _prepare_matrix_torch(predictions, match_metric)

--- a/tests/test_match_all_threshold.py
+++ b/tests/test_match_all_threshold.py
@@ -1,0 +1,163 @@
+"""Tests for the degenerate ``match_threshold <= 0`` path.
+
+Both metrics are non-negative, so such a threshold matches every pair including
+disjoint ones. The dense path answered that by building an N x N matrix, which
+made the one configuration that needs no metric at all the most expensive one,
+and reintroduced the out-of-memory failure from issue #1374 at large N.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from sahi.postprocess._numpy_backend import (
+    _prepare_matrix,
+    _score_tiebreak_order,
+    greedy_nmm_from_matrix,
+    greedy_nmm_numpy,
+    matches_all_pairs,
+    nmm_from_matrix,
+    nmm_numpy,
+    nms_from_matrix,
+    nms_numpy,
+)
+
+BACKENDS: list[tuple[str, tuple]] = [("numpy", (nms_numpy, greedy_nmm_numpy, nmm_numpy))]
+
+try:
+    from sahi.postprocess._numba_backend import greedy_nmm_numba, nmm_numba, nms_numba
+
+    BACKENDS.append(("numba", (nms_numba, greedy_nmm_numba, nmm_numba)))
+except ImportError:  # pragma: no cover - numba is optional
+    pass
+
+try:
+    from sahi.postprocess._torchvision_backend import (
+        greedy_nmm_torchvision,
+        nmm_torchvision,
+        nms_torchvision,
+    )
+
+    BACKENDS.append(("torchvision", (nms_torchvision, greedy_nmm_torchvision, nmm_torchvision)))
+except ImportError:  # pragma: no cover - torchvision is optional
+    pass
+
+BACKEND_IDS = [name for name, _ in BACKENDS]
+BACKEND_FUNCS = [funcs for _, funcs in BACKENDS]
+
+
+def _predictions(n: int, spread: float, seed: int, score_decimals: int | None = None) -> np.ndarray:
+    """Build (N, 6) predictions; round the scores to force ties when asked."""
+    rng = np.random.default_rng(seed)
+    x1 = rng.uniform(0, spread, n)
+    y1 = rng.uniform(0, spread, n)
+    w = rng.uniform(1, 40, n)
+    h = rng.uniform(1, 40, n)
+    scores = rng.uniform(0, 1, n)
+    if score_decimals is not None:
+        scores = np.round(scores, score_decimals)
+    categories = rng.integers(0, 3, n)
+    return np.stack([x1, y1, x1 + w, y1 + h, scores, categories], axis=1).astype(np.float32)
+
+
+def _top_index(predictions: np.ndarray) -> int:
+    boxes = predictions[:, :4]
+    order = _score_tiebreak_order(boxes[:, 0], boxes[:, 1], boxes[:, 2], boxes[:, 3], predictions[:, 4])
+    return int(order[0])
+
+
+def test_matches_all_pairs_boundary() -> None:
+    """Only non-positive thresholds admit every pair."""
+    assert matches_all_pairs(0.0) is True
+    assert matches_all_pairs(-0.5) is True
+    assert matches_all_pairs(1e-9) is False
+    assert matches_all_pairs(0.5) is False
+
+
+@pytest.mark.parametrize("funcs", BACKEND_FUNCS, ids=BACKEND_IDS)
+@pytest.mark.parametrize("match_metric", ["IOU", "IOS"])
+@pytest.mark.parametrize("match_threshold", [0.0, -0.5])
+@pytest.mark.parametrize("spread", [200.0, 20000.0])
+def test_matches_dense_path(funcs: tuple, match_metric: str, match_threshold: float, spread: float) -> None:
+    """With a unique top score every backend reproduces the dense matrix result."""
+    f_nms, f_greedy, f_nmm = funcs
+    predictions = _predictions(120, spread, seed=1)
+    matrix, sorted_idxs = _prepare_matrix(predictions, match_metric)
+    boxes, scores = predictions[:, :4], predictions[:, 4]
+
+    assert f_nms(predictions, match_metric, match_threshold) == nms_from_matrix(matrix, sorted_idxs, match_threshold)
+    assert f_greedy(predictions, match_metric, match_threshold) == greedy_nmm_from_matrix(
+        matrix, sorted_idxs, match_threshold
+    )
+    assert f_nmm(predictions, match_metric, match_threshold) == nmm_from_matrix(
+        matrix, sorted_idxs, scores, boxes, match_threshold
+    )
+
+
+@pytest.mark.parametrize("funcs", BACKEND_FUNCS, ids=BACKEND_IDS)
+@pytest.mark.parametrize("match_metric", ["IOU", "IOS"])
+def test_collapses_to_single_keeper(funcs: tuple, match_metric: str) -> None:
+    """Everything merges into the top-scoring box."""
+    f_nms, f_greedy, f_nmm = funcs
+    predictions = _predictions(120, 200.0, seed=2)
+    boxes = predictions[:, :4]
+    order = _score_tiebreak_order(boxes[:, 0], boxes[:, 1], boxes[:, 2], boxes[:, 3], predictions[:, 4])
+    top = int(order[0])
+    rest = [i for i in range(len(predictions)) if i != top]
+
+    assert f_nms(predictions, match_metric, 0.0) == [top]
+    # greedy emits merged indices in score order, nmm in ascending index order
+    assert f_greedy(predictions, match_metric, 0.0) == {top: [int(i) for i in order[1:]]}
+    assert f_nmm(predictions, match_metric, 0.0) == {top: rest}
+
+
+@pytest.mark.parametrize("funcs", BACKEND_FUNCS, ids=BACKEND_IDS)
+@pytest.mark.parametrize("match_metric", ["IOU", "IOS"])
+def test_tied_top_score_matches_dense_path(funcs: tuple, match_metric: str) -> None:
+    """A tie for the top score is handled exactly as the dense loop handles it.
+
+    Boxes sharing the top score are keepers with nothing merged into them, and
+    no keeper ever appears inside a merge list.
+    """
+    f_nms, f_greedy, f_nmm = funcs
+    predictions = _predictions(120, 200.0, seed=3, score_decimals=1)
+    top_score = predictions[:, 4].max()
+    assert (predictions[:, 4] == top_score).sum() > 1, "fixture must tie at the top"
+
+    matrix, sorted_idxs = _prepare_matrix(predictions, match_metric)
+    boxes, scores = predictions[:, :4], predictions[:, 4]
+
+    assert f_nms(predictions, match_metric, 0.0) == nms_from_matrix(matrix, sorted_idxs, 0.0)
+    assert f_greedy(predictions, match_metric, 0.0) == greedy_nmm_from_matrix(matrix, sorted_idxs, 0.0)
+
+    result = f_nmm(predictions, match_metric, 0.0)
+    assert result == nmm_from_matrix(matrix, sorted_idxs, scores, boxes, 0.0)
+    for keeper, merged in result.items():
+        assert keeper not in merged
+
+
+@pytest.mark.parametrize("funcs", BACKEND_FUNCS, ids=BACKEND_IDS)
+def test_empty_input(funcs: tuple) -> None:
+    """Empty predictions stay empty."""
+    f_nms, f_greedy, f_nmm = funcs
+    empty = np.zeros((0, 6), dtype=np.float32)
+    assert f_nms(empty, "IOU", 0.0) == []
+    assert f_greedy(empty, "IOU", 0.0) == {}
+    assert f_nmm(empty, "IOU", 0.0) == {}
+
+
+@pytest.mark.parametrize("funcs", BACKEND_FUNCS, ids=BACKEND_IDS)
+def test_large_input_allocates_no_matrix(funcs: tuple) -> None:
+    """Regression guard for #1374.
+
+    40000 boxes would need a 6.4 GiB float32 matrix, so reaching the dense path
+    here fails with MemoryError or a CUDA OOM rather than returning.
+    """
+    f_nms, f_greedy, f_nmm = funcs
+    predictions = _predictions(40000, 30000.0, seed=4)
+    top = _top_index(predictions)
+
+    assert f_nms(predictions, "IOS", 0.0) == [top]
+    assert list(f_greedy(predictions, "IOS", 0.0)) == [top]
+    assert list(f_nmm(predictions, "IOS", 0.0)) == [top]

--- a/tests/test_sparse_backend.py
+++ b/tests/test_sparse_backend.py
@@ -9,14 +9,20 @@ from sahi.postprocess._numpy_backend import (
     _prepare_matrix,
     greedy_nmm_from_matrix,
     nmm_from_matrix,
+    nmm_numpy,
     nms_from_matrix,
 )
 from sahi.postprocess._sparse_backend import (
     SPARSE_MIN_BOXES,
+    MatchQuery,
     build_sparse_matches,
     greedy_nmm_sparse,
+    greedy_nmm_streaming,
     nmm_sparse,
+    nmm_streaming,
     nms_sparse,
+    nms_streaming,
+    should_stream_nmm,
     should_use_sparse,
 )
 
@@ -85,6 +91,87 @@ def test_sparse_algorithms_match_dense(match_metric: str, match_threshold: float
     )
 
 
+@pytest.mark.parametrize("match_metric", ["IOU", "IOS"])
+@pytest.mark.parametrize("match_threshold", [0.1, 0.5, 0.9])
+@pytest.mark.parametrize("spread", [200.0, 20000.0])
+def test_match_query_row_equals_csr_row(match_metric: str, match_threshold: float, spread: float) -> None:
+    """A row read on demand is the row the CSR builder would have stored."""
+    predictions = _make_predictions(300, spread, seed=4)
+    boxes = predictions[:, :4]
+    areas = (boxes[:, 2] - boxes[:, 0]) * (boxes[:, 3] - boxes[:, 1])
+
+    indptr, indices = build_sparse_matches(boxes, areas, match_metric, match_threshold)
+    query = MatchQuery(boxes, areas, match_metric, match_threshold)
+
+    for i in range(len(boxes)):
+        assert query.row(i).tolist() == indices[indptr[i] : indptr[i + 1]].tolist()
+
+
+@pytest.mark.parametrize("match_metric", ["IOU", "IOS"])
+@pytest.mark.parametrize("match_threshold", [0.1, 0.5, 0.9])
+@pytest.mark.parametrize("spread", [200.0, 20000.0])
+def test_streaming_matches_pair_list(match_metric: str, match_threshold: float, spread: float) -> None:
+    """Streaming NMS and greedy NMM agree with the stored-pair versions."""
+    predictions = _make_predictions(400, spread, seed=5)
+    boxes = predictions[:, :4]
+    areas = (boxes[:, 2] - boxes[:, 0]) * (boxes[:, 3] - boxes[:, 1])
+
+    _, sorted_idxs = _prepare_matrix(predictions, match_metric)
+    indptr, indices = build_sparse_matches(boxes, areas, match_metric, match_threshold)
+
+    assert nms_streaming(boxes, areas, match_metric, match_threshold, sorted_idxs) == nms_sparse(
+        indptr, indices, sorted_idxs
+    )
+    assert greedy_nmm_streaming(boxes, areas, match_metric, match_threshold, sorted_idxs) == greedy_nmm_sparse(
+        indptr, indices, sorted_idxs
+    )
+    assert nmm_streaming(boxes, areas, match_metric, match_threshold, sorted_idxs, predictions[:, 4]) == nmm_sparse(
+        indptr, indices, sorted_idxs, predictions[:, 4], boxes
+    )
+
+
+def test_nmm_streams_only_when_pair_list_would_be_large() -> None:
+    """Scattered boxes keep the stored-pair path; crowded ones switch to streaming."""
+    scattered = _make_predictions(4000, spread=30000.0, seed=7)
+    crowded = _make_predictions(4000, spread=80.0, seed=7)
+
+    assert should_stream_nmm(scattered[:, :4]) is False
+    assert should_stream_nmm(crowded[:, :4]) is True
+
+    # both routes must still agree with the stored-pair result
+    for predictions in (scattered, crowded):
+        boxes = predictions[:, :4]
+        areas = (boxes[:, 2] - boxes[:, 0]) * (boxes[:, 3] - boxes[:, 1])
+        _, sorted_idxs = _prepare_matrix(predictions, "IOS")
+        indptr, indices = build_sparse_matches(boxes, areas, "IOS", 0.3)
+        assert nmm_numpy(predictions, "IOS", 0.3) == nmm_sparse(indptr, indices, sorted_idxs, predictions[:, 4], boxes)
+
+
+def test_crowded_input_stays_within_memory() -> None:
+    """Regression guard for #1374 on layouts where storing every pair is not sparse.
+
+    These boxes all sit on top of each other, so the pair count is close to
+    N squared and the stored-pair path needs hundreds of MB for it.
+    """
+    import tracemalloc
+
+    from sahi.postprocess._numpy_backend import greedy_nmm_numpy, nms_numpy
+
+    predictions = _make_predictions(8000, spread=80.0, seed=6)
+    boxes = predictions[:, :4]
+    areas = (boxes[:, 2] - boxes[:, 0]) * (boxes[:, 3] - boxes[:, 1])
+    indptr, _ = build_sparse_matches(boxes, areas, "IOS", 0.3)
+    assert indptr[-1] > 5_000_000, "fixture must be crowded enough to matter"
+
+    tracemalloc.start()
+    nms_numpy(predictions, "IOS", 0.3)
+    greedy_nmm_numpy(predictions, "IOS", 0.3)
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    assert peak < 32 * 2**20, f"peak {peak / 2**20:.0f} MB suggests the pair list was materialized"
+
+
 def test_large_input_takes_sparse_path_and_matches_dense() -> None:
     """Above the cutoff the public numpy functions still agree with the dense path."""
     from sahi.postprocess._numpy_backend import greedy_nmm_numpy, nmm_numpy, nms_numpy
@@ -123,12 +210,15 @@ def test_nmm_never_merges_a_keeper_into_itself(match_metric: str, match_threshol
     matrix, sorted_idxs = _prepare_matrix(predictions, match_metric)
     indptr, indices = build_sparse_matches(boxes, areas, match_metric, match_threshold)
 
-    dense = nmm_from_matrix(matrix, sorted_idxs, predictions[:, 4], boxes, match_threshold)
-    csr = nmm_sparse(indptr, indices, sorted_idxs, predictions[:, 4], boxes)
-    assert dense == csr
+    results = {
+        "dense": nmm_from_matrix(matrix, sorted_idxs, predictions[:, 4], boxes, match_threshold),
+        "csr": nmm_sparse(indptr, indices, sorted_idxs, predictions[:, 4], boxes),
+        "streaming": nmm_streaming(boxes, areas, match_metric, match_threshold, sorted_idxs, predictions[:, 4]),
+    }
+    assert results["dense"] == results["csr"] == results["streaming"]
 
-    for name, result in (("dense", dense), ("csr", csr)):
-        merged_by: dict[int, int] = {}
+    for name, result in results.items():
+        merged_by = {}
         for keeper, merged in result.items():
             assert keeper not in merged, f"{name}: keeper {keeper} merged into itself"
             for m in merged:
@@ -155,3 +245,4 @@ def test_metric_does_not_warn_on_zero_area_boxes() -> None:
         for metric in ("IOU", "IOS"):
             compute_metric_matrix(boxes, areas, metric)
             build_sparse_matches(boxes, areas, metric, 0.3)
+            MatchQuery(boxes, areas, metric, 0.3).row(0)


### PR DESCRIPTION
The CSR adjacency introduced for large inputs stores one entry per intersecting pair, which is only a saving while boxes are spread out; boxes piled on top of each other intersect nearly everything, so the pair count approaches `N squared` and the CSR costs about as much as the matrix it replaced. The merge loops read one row at a time, and NMS and greedy NMM only ever read rows of boxes that survived, so match rows are now answered from the STRtree on demand and peak memory no longer depends on the layout. NMM reads a row per box rather than per survivor, so it keeps the stored pair list until that list is projected to be large. A non-positive threshold also no longer builds a matrix at all: both metrics are non-negative, so every pair matches and the answer follows from the score order, which previously made the one configuration needing no overlap computation the most expensive one and reintroduced the reported out-of-memory failure.

| case | before | after |
| --- | --- | --- |
| crowded 33337 boxes, NMS | 47180 ms, 3416 MB | 135 ms, 4 MB |
| crowded 33337 boxes, greedy NMM | 41545 ms, 3416 MB | 118 ms, 4 MB |
| crowded 20000 boxes, NMS | 15931 ms, 1232 MB | 57 ms, 2 MB |
| scattered 33336 boxes, NMS | 539 ms, 65 MB | 188 ms, 4 MB |
| 25000 boxes at threshold 0 | out of memory, 2.33 GiB | 7 ms |
| 100000 boxes at threshold 0 | out of memory, 37 GiB | 33 ms |