### PR TITLE
perf: prune claimed boxes from streaming NMM queries

### DIFF
--- a/sahi/postprocess/_sparse_backend.py
+++ b/sahi/postprocess/_sparse_backend.py
@@ -24,8 +24,7 @@ from shapely import box as shapely_box
 # the N x N matrix it saves.
 SPARSE_MIN_BOXES = 2000
 
-# NMM reads a row per box rather than per survivor, so answering its rows from
-# the tree costs it roughly an order of magnitude in time. It keeps the stored
+# NMM can read many more rows than NMS and greedy NMM, so it keeps the stored
 # pair list until that list would get large, measured at about 110 bytes per
 # pair once the intermediates are counted.
 NMM_MAX_PAIRS = 2_000_000
@@ -98,7 +97,7 @@ class MatchQuery:
 
         Equivalent to one row of the CSR ``build_sparse_matches`` would build.
         """
-        candidates = self.tree.query(self.geoms[i], predicate="intersects")
+        candidates = self._candidate_indices(i)
         candidates = candidates[candidates != i]
         if len(candidates) == 0:
             return candidates.astype(np.intp)
@@ -117,6 +116,49 @@ class MatchQuery:
         metric = _safe_ratio(inter, denom)
 
         return np.sort(candidates[metric >= self.match_threshold]).astype(np.intp)
+
+    def _candidate_indices(self, i: int) -> np.ndarray:
+        """Return box indices whose envelopes intersect box ``i``."""
+        # STRtree's envelope query is already an exact intersection prefilter
+        # for axis-aligned rectangles.  The metric calculation in ``row``
+        # remains the source of truth, so asking GEOS to run ``intersects`` as
+        # well only repeats work for every candidate pair.
+        return self.tree.query(self.geoms[i])
+
+
+class ActiveMatchQuery(MatchQuery):
+    """Match query that periodically drops boxes NMM has already claimed.
+
+    STRtree is immutable, so claimed boxes are filtered by a boolean mask until
+    only half of the indexed boxes remain.  The tree is then rebuilt over the
+    survivors.  A claimed box may still be used as the query geometry when its
+    turn arrives; it just cannot be returned as a candidate and claimed again.
+    """
+
+    def __init__(self, boxes: np.ndarray, areas: np.ndarray, match_metric: str, match_threshold: float) -> None:
+        super().__init__(boxes, areas, match_metric, match_threshold)
+        self.active = np.ones(len(boxes), dtype=bool)
+        self.active_count = len(boxes)
+        self.tree_indices = np.arange(len(boxes), dtype=np.intp)
+
+    def deactivate(self, indices: int | np.ndarray) -> None:
+        """Remove newly claimed indices from future candidate rows."""
+        indices_array = np.atleast_1d(indices).astype(np.intp, copy=False)
+        newly_inactive = indices_array[self.active[indices_array]]
+        self.active[newly_inactive] = False
+        self.active_count -= len(newly_inactive)
+
+    def _candidate_indices(self, i: int) -> np.ndarray:
+        if self.active_count == 0:
+            return np.empty(0, dtype=np.intp)
+
+        if self.active_count * 2 <= len(self.tree_indices):
+            self.tree_indices = np.flatnonzero(self.active)
+            self.tree = STRtree(self.geoms[self.tree_indices])
+
+        local_indices = self.tree.query(self.geoms[i])
+        candidates = self.tree_indices[local_indices]
+        return candidates[self.active[candidates]]
 
 
 def nms_streaming(
@@ -217,7 +259,10 @@ def estimate_mean_degree(boxes: np.ndarray, sample: int = 512) -> float:
 
     k = min(n, sample)
     probe = geoms[np.linspace(0, n - 1, k).astype(np.intp)]
-    rows, _ = tree.query(probe, predicate="intersects")
+    # The indexed geometries are axis-aligned rectangles, so their envelopes
+    # intersect exactly when the rectangles do.  Avoid a duplicate GEOS
+    # predicate evaluation for every candidate pair.
+    rows, _ = tree.query(probe)
     return max(0.0, len(rows) / k - 1.0)
 
 
@@ -246,7 +291,7 @@ def build_sparse_matches(
     # Only intersecting pairs can clear a positive threshold. Returns both
     # (i, j) and (j, i), so the resulting adjacency is symmetric like the
     # dense matrix. Both IOU and IOS are symmetric metrics.
-    rows, cols = tree.query(geoms, predicate="intersects")
+    rows, cols = tree.query(geoms)
 
     self_pair = rows == cols
     if self_pair.any():
@@ -437,9 +482,11 @@ def nmm_streaming(
 ) -> dict[int, list[int]]:
     """NMM reading match rows on demand. Same result as ``nmm_sparse``.
 
-    Unlike NMS and greedy NMM this visits every box, not just the survivors, so
-    it issues one tree query per box and is markedly slower than the stored-pair
-    version. It exists for inputs whose pair list does not fit in memory.
+    NMM propagates group labels through claimed boxes, but only unclaimed boxes
+    can change groups. The candidate tree is therefore rebuilt over unclaimed
+    boxes whenever its live population halves. This keeps memory bounded while
+    avoiding queries and metric calculations for edges whose destination has
+    already been assigned.
 
     Args:
         boxes: Array of shape (N, 4) with columns [x1, y1, x2, y2].
@@ -453,14 +500,16 @@ def nmm_streaming(
         Dict mapping each kept index to a list of indices merged into it.
     """
     n = len(boxes)
-    matches = MatchQuery(boxes, areas, match_metric, match_threshold)
+    matches = ActiveMatchQuery(boxes, areas, match_metric, match_threshold)
 
     keep_to_merge_list: dict[int, list[int]] = {}
     merge_to_keep = np.full(n, -1, dtype=np.intp)
 
     for idx_pos in range(n):
+        if matches.active_count == 0:
+            break
+
         current_idx = int(sorted_idxs[idx_pos])
-        matched = _dominated_row(matches.row(current_idx), current_idx, scores, boxes)
 
         if merge_to_keep[current_idx] < 0:
             # current_idx is a keeper. Point it at itself so that a later box
@@ -473,13 +522,14 @@ def nmm_streaming(
             keep_idx = int(merge_to_keep[current_idx])
             merge_list = keep_to_merge_list[keep_idx]
 
-        # A claimed box always has a non-negative merge_to_keep entry, so that
-        # test alone decides membership; scanning merge_list would repeat it.
-        for m in matched:
-            m_int = int(m)
-            if merge_to_keep[m_int] < 0:
-                merge_list.append(m_int)
-                merge_to_keep[m_int] = keep_idx
+        # The current box and every returned candidate are now assigned.  They
+        # remain valid query geometries when their turns arrive, but cannot be
+        # claimed by a second group, so remove them from future candidate rows.
+        matches.deactivate(current_idx)
+        matched = _dominated_row(matches.row(current_idx), current_idx, scores, boxes)
+        merge_list.extend(matched.tolist())
+        merge_to_keep[matched] = keep_idx
+        matches.deactivate(matched)
 
     return keep_to_merge_list
 

--- a/sahi/postprocess/_sparse_backend.py
+++ b/sahi/postprocess/_sparse_backend.py
@@ -25,10 +25,12 @@ from shapely import box as shapely_box
 # the N x N matrix it saves.
 SPARSE_MIN_BOXES = 2000
 
-# NMM reads a row for every box, not just for the survivors, so it keeps the
-# stored pair list until that list would get large, measured at about 110 bytes
-# per pair once the intermediates are counted.
-NMM_MAX_PAIRS = 2_000_000
+# NMM reads a row for every box, not just for the survivors, so answering its
+# rows from a stored pair list is worth the memory while boxes have few
+# neighbours. Past this many the list costs more to build than the queries it
+# saves, and keeps growing with the square of the crowding. The measured
+# crossover barely moves with N, so it is a degree and not a pair budget.
+NMM_MAX_DEGREE = 40.0
 
 # Probing the tree in one call would return sample x degree pairs at once, which
 # on crowded boxes dwarfs everything the path being chosen goes on to allocate.
@@ -58,9 +60,10 @@ def should_stream_nmm(boxes: np.ndarray) -> bool:
         boxes: Array of shape (N, 4) with columns [x1, y1, x2, y2].
 
     Returns:
-        True when the pair list is projected to exceed ``NMM_MAX_PAIRS``.
+        True when the boxes intersect each other often enough that reading rows
+        from the tree beats storing them.
     """
-    return estimate_mean_degree(boxes) * len(boxes) > NMM_MAX_PAIRS
+    return estimate_mean_degree(boxes) > NMM_MAX_DEGREE
 
 
 def should_use_sparse(n: int, match_threshold: float) -> bool:

--- a/sahi/postprocess/_sparse_backend.py
+++ b/sahi/postprocess/_sparse_backend.py
@@ -210,7 +210,7 @@ def nms_streaming(
     match_threshold: float,
     sorted_idxs: np.ndarray,
 ) -> list[int]:
-    """NMS reading match rows on demand. Same result as ``nms_sparse``.
+    """NMS reading match rows on demand. Same result as ``nms_from_matrix``.
 
     Only boxes that survive are ever queried, and suppressed boxes leave the
     query, so on crowded inputs this touches a small fraction of the pairs the
@@ -253,7 +253,7 @@ def greedy_nmm_streaming(
     match_threshold: float,
     sorted_idxs: np.ndarray,
 ) -> dict[int, list[int]]:
-    """Greedy NMM reading match rows on demand. Same result as ``greedy_nmm_sparse``.
+    """Greedy NMM reading match rows on demand. Same result as ``greedy_nmm_from_matrix``.
 
     Args:
         boxes: Array of shape (N, 4) with columns [x1, y1, x2, y2].
@@ -361,67 +361,6 @@ def build_sparse_matches(
     indptr = np.zeros(n + 1, dtype=np.intp)
     np.cumsum(np.bincount(rows, minlength=n), out=indptr[1:])
     return indptr, cols.astype(np.intp)
-
-
-def nms_sparse(indptr: np.ndarray, indices: np.ndarray, sorted_idxs: np.ndarray) -> list[int]:
-    """NMS over a CSR match adjacency. Mirrors ``nms_from_matrix``.
-
-    Args:
-        indptr: CSR row pointers of length N + 1.
-        indices: CSR column indices.
-        sorted_idxs: Indices sorted by score descending.
-
-    Returns:
-        List of kept indices sorted by score descending.
-    """
-    keep: list[int] = []
-    suppressed = np.zeros(len(indptr) - 1, dtype=bool)
-
-    for idx in sorted_idxs:
-        if suppressed[idx]:
-            continue
-        keep.append(int(idx))
-        suppressed[indices[indptr[idx] : indptr[idx + 1]]] = True
-
-    return keep
-
-
-def greedy_nmm_sparse(
-    indptr: np.ndarray,
-    indices: np.ndarray,
-    sorted_idxs: np.ndarray,
-) -> dict[int, list[int]]:
-    """Greedy NMM over a CSR match adjacency. Mirrors ``greedy_nmm_from_matrix``.
-
-    Args:
-        indptr: CSR row pointers of length N + 1.
-        indices: CSR column indices.
-        sorted_idxs: Indices sorted by score descending.
-
-    Returns:
-        Dict mapping each kept index to a list of indices merged into it.
-    """
-    n = len(indptr) - 1
-    suppressed = np.zeros(n, dtype=bool)
-
-    # The dense loop only considers candidates that come later in score order,
-    # and emits them in that order.
-    rank = np.empty(n, dtype=np.intp)
-    rank[sorted_idxs] = np.arange(n)
-
-    keep_to_merge_list: dict[int, list[int]] = {}
-    for position, idx in enumerate(sorted_idxs):
-        if suppressed[idx]:
-            continue
-
-        neighbours = indices[indptr[idx] : indptr[idx + 1]]
-        merge_indices = neighbours[(rank[neighbours] > position) & ~suppressed[neighbours]]
-        merge_indices = merge_indices[np.argsort(rank[merge_indices])]
-
-        suppressed[merge_indices] = True
-        keep_to_merge_list[int(idx)] = merge_indices.tolist()
-
-    return keep_to_merge_list
 
 
 def _dominates_all(indptr: np.ndarray, indices: np.ndarray, scores: np.ndarray, boxes: np.ndarray) -> np.ndarray:

--- a/sahi/postprocess/_sparse_backend.py
+++ b/sahi/postprocess/_sparse_backend.py
@@ -9,9 +9,10 @@ intersecting. The adjacency is CSR: row ``i`` is
 Storing every pair is only a saving while boxes are spread out. Boxes piled on
 top of each other intersect nearly everything, so the pair count approaches
 ``N ^ 2`` and the CSR gets as expensive as the matrix it replaced. The loops
-read one row at a time and NMS and greedy NMM only ever read rows of boxes that
-survived, so ``MatchQuery`` answers rows from the tree on demand instead, which
-holds peak memory at ``O(N + max_degree)`` whatever the layout.
+read one row at a time, so ``MatchQuery`` answers rows from the tree on demand
+instead, which holds peak memory at ``O(N + max_degree)`` whatever the layout.
+Each loop also hands boxes back to the query as it finishes with them, so a
+crowded input shrinks the tree it is querying as it goes.
 """
 
 from __future__ import annotations
@@ -24,10 +25,15 @@ from shapely import box as shapely_box
 # the N x N matrix it saves.
 SPARSE_MIN_BOXES = 2000
 
-# NMM can read many more rows than NMS and greedy NMM, so it keeps the stored
-# pair list until that list would get large, measured at about 110 bytes per
-# pair once the intermediates are counted.
+# NMM reads a row for every box, not just for the survivors, so it keeps the
+# stored pair list until that list would get large, measured at about 110 bytes
+# per pair once the intermediates are counted.
 NMM_MAX_PAIRS = 2_000_000
+
+# Probing the tree in one call would return sample x degree pairs at once, which
+# on crowded boxes dwarfs everything the path being chosen goes on to allocate.
+# Only the count is wanted, so the probe is spent a chunk at a time.
+DEGREE_PROBE_CHUNK = 32
 
 
 def _safe_ratio(numerator: np.ndarray, denominator: np.ndarray) -> np.ndarray:
@@ -77,6 +83,13 @@ def should_use_sparse(n: int, match_threshold: float) -> bool:
 class MatchQuery:
     """Answers 'which boxes match box i' from an STRtree, without storing pairs.
 
+    Every loop below settles each box exactly once, as a keeper or into a group,
+    and never revisits that decision, so a settled box is dropped from later
+    rows. It stays available as a query geometry for when its own turn arrives;
+    it just cannot be returned as a candidate again. STRtree is immutable, so
+    settled boxes are masked out and the tree is rebuilt once the live
+    population has halved, which is O(N log N) of rebuilding over a whole run.
+
     Args:
         boxes: Array of shape (N, 4) with columns [x1, y1, x2, y2].
         areas: Precomputed areas of shape (N,).
@@ -91,11 +104,30 @@ class MatchQuery:
         self.match_threshold = match_threshold
         self.geoms = shapely_box(boxes[:, 0], boxes[:, 1], boxes[:, 2], boxes[:, 3])
         self.tree = STRtree(self.geoms)
+        self.active = np.ones(len(boxes), dtype=bool)
+        self.active_count = len(boxes)
+        self.tree_indices = np.arange(len(boxes), dtype=np.intp)
+        # Until the first rebuild the tree holds every box, so its own indices
+        # are the box indices and the remap in ``_candidate_indices`` is a no-op.
+        self.tree_is_whole = True
+
+    def deactivate(self, index: int) -> None:
+        """Drop one settled box from every later row."""
+        if self.active[index]:
+            self.active[index] = False
+            self.active_count -= 1
+
+    def deactivate_row(self, indices: np.ndarray) -> None:
+        """Drop a whole settled row. Its entries are active by construction."""
+        if len(indices):
+            self.active[indices] = False
+            self.active_count -= len(indices)
 
     def row(self, i: int) -> np.ndarray:
-        """Return the matches of box ``i``, ascending, excluding ``i`` itself.
+        """Return the unsettled matches of box ``i``, ascending, excluding ``i``.
 
-        Equivalent to one row of the CSR ``build_sparse_matches`` would build.
+        With nothing deactivated yet this is one row of the CSR
+        ``build_sparse_matches`` would build.
         """
         candidates = self._candidate_indices(i)
         candidates = candidates[candidates != i]
@@ -118,46 +150,22 @@ class MatchQuery:
         return np.sort(candidates[metric >= self.match_threshold]).astype(np.intp)
 
     def _candidate_indices(self, i: int) -> np.ndarray:
-        """Return box indices whose envelopes intersect box ``i``."""
-        # STRtree's envelope query is already an exact intersection prefilter
-        # for axis-aligned rectangles.  The metric calculation in ``row``
-        # remains the source of truth, so asking GEOS to run ``intersects`` as
-        # well only repeats work for every candidate pair.
-        return self.tree.query(self.geoms[i])
-
-
-class ActiveMatchQuery(MatchQuery):
-    """Match query that periodically drops boxes NMM has already claimed.
-
-    STRtree is immutable, so claimed boxes are filtered by a boolean mask until
-    only half of the indexed boxes remain.  The tree is then rebuilt over the
-    survivors.  A claimed box may still be used as the query geometry when its
-    turn arrives; it just cannot be returned as a candidate and claimed again.
-    """
-
-    def __init__(self, boxes: np.ndarray, areas: np.ndarray, match_metric: str, match_threshold: float) -> None:
-        super().__init__(boxes, areas, match_metric, match_threshold)
-        self.active = np.ones(len(boxes), dtype=bool)
-        self.active_count = len(boxes)
-        self.tree_indices = np.arange(len(boxes), dtype=np.intp)
-
-    def deactivate(self, indices: int | np.ndarray) -> None:
-        """Remove newly claimed indices from future candidate rows."""
-        indices_array = np.atleast_1d(indices).astype(np.intp, copy=False)
-        newly_inactive = indices_array[self.active[indices_array]]
-        self.active[newly_inactive] = False
-        self.active_count -= len(newly_inactive)
-
-    def _candidate_indices(self, i: int) -> np.ndarray:
+        """Return the active box indices whose envelopes intersect box ``i``."""
         if self.active_count == 0:
             return np.empty(0, dtype=np.intp)
 
         if self.active_count * 2 <= len(self.tree_indices):
             self.tree_indices = np.flatnonzero(self.active)
             self.tree = STRtree(self.geoms[self.tree_indices])
+            self.tree_is_whole = False
 
-        local_indices = self.tree.query(self.geoms[i])
-        candidates = self.tree_indices[local_indices]
+        # Every indexed geometry is an axis-aligned rectangle, so it is its own
+        # envelope and the tree's envelope query is already exact. Asking GEOS
+        # for "intersects" as well would repeat that test for every pair, and
+        # the metric above is the real filter regardless.
+        candidates = self.tree.query(self.geoms[i])
+        if not self.tree_is_whole:
+            candidates = self.tree_indices[candidates]
         return candidates[self.active[candidates]]
 
 
@@ -170,9 +178,9 @@ def nms_streaming(
 ) -> list[int]:
     """NMS reading match rows on demand. Same result as ``nms_sparse``.
 
-    Only boxes that survive are ever queried, so on crowded inputs, where almost
-    everything is suppressed, this touches a small fraction of the pairs the CSR
-    would have stored.
+    Only boxes that survive are ever queried, and suppressed boxes leave the
+    query, so on crowded inputs this touches a small fraction of the pairs the
+    CSR would have stored.
 
     Args:
         boxes: Array of shape (N, 4) with columns [x1, y1, x2, y2].
@@ -185,14 +193,21 @@ def nms_streaming(
         List of kept indices sorted by score descending.
     """
     matches = MatchQuery(boxes, areas, match_metric, match_threshold)
-    suppressed = np.zeros(len(boxes), dtype=bool)
     keep: list[int] = []
 
     for idx in sorted_idxs:
-        if suppressed[idx]:
+        if matches.active_count == 0:
+            break
+
+        current_idx = int(idx)
+        if not matches.active[current_idx]:
             continue
-        keep.append(int(idx))
-        suppressed[matches.row(int(idx))] = True
+        keep.append(current_idx)
+
+        # A survivor can never be suppressed afterwards. The metrics are
+        # symmetric, so any box able to suppress it was suppressed by it first.
+        matches.deactivate(current_idx)
+        matches.deactivate_row(matches.row(current_idx))
 
     return keep
 
@@ -218,24 +233,28 @@ def greedy_nmm_streaming(
     """
     n = len(boxes)
     matches = MatchQuery(boxes, areas, match_metric, match_threshold)
-    suppressed = np.zeros(n, dtype=bool)
 
     # The dense loop only considers candidates that come later in score order,
-    # and emits them in that order.
+    # and emits them in that order. A row cannot return an earlier one, since
+    # every box before this position has been settled and left the query, so
+    # only that order is left to reproduce.
     rank = np.empty(n, dtype=np.intp)
     rank[sorted_idxs] = np.arange(n)
 
     keep_to_merge_list: dict[int, list[int]] = {}
-    for position, idx in enumerate(sorted_idxs):
-        if suppressed[idx]:
+    for idx in sorted_idxs:
+        if matches.active_count == 0:
+            break
+
+        current_idx = int(idx)
+        if not matches.active[current_idx]:
             continue
 
-        neighbours = matches.row(int(idx))
-        merge_indices = neighbours[(rank[neighbours] > position) & ~suppressed[neighbours]]
+        matches.deactivate(current_idx)
+        merge_indices = matches.row(current_idx)
         merge_indices = merge_indices[np.argsort(rank[merge_indices])]
-
-        suppressed[merge_indices] = True
-        keep_to_merge_list[int(idx)] = merge_indices.tolist()
+        matches.deactivate_row(merge_indices)
+        keep_to_merge_list[current_idx] = merge_indices.tolist()
 
     return keep_to_merge_list
 
@@ -260,10 +279,12 @@ def estimate_mean_degree(boxes: np.ndarray, sample: int = 512) -> float:
     k = min(n, sample)
     probe = geoms[np.linspace(0, n - 1, k).astype(np.intp)]
     # The indexed geometries are axis-aligned rectangles, so their envelopes
-    # intersect exactly when the rectangles do.  Avoid a duplicate GEOS
-    # predicate evaluation for every candidate pair.
-    rows, _ = tree.query(probe)
-    return max(0.0, len(rows) / k - 1.0)
+    # intersect exactly when the rectangles do. Avoid a duplicate GEOS predicate
+    # evaluation for every candidate pair.
+    matches = sum(
+        len(tree.query(probe[start : start + DEGREE_PROBE_CHUNK])[0]) for start in range(0, k, DEGREE_PROBE_CHUNK)
+    )
+    return max(0.0, matches / k - 1.0)
 
 
 def build_sparse_matches(
@@ -482,11 +503,10 @@ def nmm_streaming(
 ) -> dict[int, list[int]]:
     """NMM reading match rows on demand. Same result as ``nmm_sparse``.
 
-    NMM propagates group labels through claimed boxes, but only unclaimed boxes
-    can change groups. The candidate tree is therefore rebuilt over unclaimed
-    boxes whenever its live population halves. This keeps memory bounded while
-    avoiding queries and metric calculations for edges whose destination has
-    already been assigned.
+    Unlike NMS and greedy NMM this reads a row for every box, not just for the
+    survivors, since a claimed box still propagates its keeper's label. Only
+    unclaimed boxes can change groups, so claimed ones leave the query and the
+    run stops early once every box has been assigned.
 
     Args:
         boxes: Array of shape (N, 4) with columns [x1, y1, x2, y2].
@@ -500,7 +520,7 @@ def nmm_streaming(
         Dict mapping each kept index to a list of indices merged into it.
     """
     n = len(boxes)
-    matches = ActiveMatchQuery(boxes, areas, match_metric, match_threshold)
+    matches = MatchQuery(boxes, areas, match_metric, match_threshold)
 
     keep_to_merge_list: dict[int, list[int]] = {}
     merge_to_keep = np.full(n, -1, dtype=np.intp)
@@ -522,14 +542,14 @@ def nmm_streaming(
             keep_idx = int(merge_to_keep[current_idx])
             merge_list = keep_to_merge_list[keep_idx]
 
-        # The current box and every returned candidate are now assigned.  They
-        # remain valid query geometries when their turns arrive, but cannot be
-        # claimed by a second group, so remove them from future candidate rows.
+        # The current box and every returned candidate are now assigned. They
+        # stay valid query geometries for when their turns arrive, but cannot be
+        # claimed by a second group, so they leave the candidate rows.
         matches.deactivate(current_idx)
         matched = _dominated_row(matches.row(current_idx), current_idx, scores, boxes)
         merge_list.extend(matched.tolist())
         merge_to_keep[matched] = keep_idx
-        matches.deactivate(matched)
+        matches.deactivate_row(matched)
 
     return keep_to_merge_list
 

--- a/sahi/postprocess/_sparse_backend.py
+++ b/sahi/postprocess/_sparse_backend.py
@@ -53,6 +53,49 @@ def _safe_ratio(numerator: np.ndarray, denominator: np.ndarray) -> np.ndarray:
     )
 
 
+def _overlap_metric(
+    boxes: np.ndarray, areas: np.ndarray, left: int | np.ndarray, right: np.ndarray, match_metric: str
+) -> np.ndarray:
+    """Overlap of each ``left`` box against the ``right`` box paired with it.
+
+    ``left`` may be a single index, which broadcasts against ``right``. Holding the
+    IOU and IOS rule in one place keeps a row read on demand and a stored pair from
+    drifting apart.
+    """
+    inter_x1 = np.maximum(boxes[left, 0], boxes[right, 0])
+    inter_y1 = np.maximum(boxes[left, 1], boxes[right, 1])
+    inter_x2 = np.minimum(boxes[left, 2], boxes[right, 2])
+    inter_y2 = np.minimum(boxes[left, 3], boxes[right, 3])
+    inter = np.maximum(0, inter_x2 - inter_x1) * np.maximum(0, inter_y2 - inter_y1)
+
+    if match_metric == "IOU":
+        denom = areas[left] + areas[right] - inter
+    else:  # IOS
+        denom = np.minimum(areas[left], areas[right])
+    return _safe_ratio(inter, denom)
+
+
+def _dominates(left: int | np.ndarray, right: np.ndarray, scores: np.ndarray, boxes: np.ndarray) -> np.ndarray:
+    """Whether each ``left`` box may claim the ``right`` box paired with it.
+
+    A box claims another when the other scores lower, or scores equal and does not
+    sort before it lexicographically by coordinates. ``left`` may be a single index,
+    which broadcasts against ``right``. Same rule as the dense ``dominates`` matrix.
+    """
+    lower_score = scores[left] > scores[right]
+    score_equal = scores[left] == scores[right]
+
+    left_lt = np.zeros(len(right), dtype=bool)
+    still_equal = np.ones(len(right), dtype=bool)
+    for col in range(4):
+        col_lt = boxes[left, col] < boxes[right, col]
+        col_eq = boxes[left, col] == boxes[right, col]
+        left_lt |= still_equal & col_lt
+        still_equal &= col_eq
+
+    return lower_score | (score_equal & ~left_lt)
+
+
 def should_stream_nmm(boxes: np.ndarray) -> bool:
     """Return whether NMM should answer rows from the tree instead of storing pairs.
 
@@ -137,19 +180,7 @@ class MatchQuery:
         if len(candidates) == 0:
             return candidates.astype(np.intp)
 
-        boxes, areas = self.boxes, self.areas
-        inter_x1 = np.maximum(boxes[i, 0], boxes[candidates, 0])
-        inter_y1 = np.maximum(boxes[i, 1], boxes[candidates, 1])
-        inter_x2 = np.minimum(boxes[i, 2], boxes[candidates, 2])
-        inter_y2 = np.minimum(boxes[i, 3], boxes[candidates, 3])
-        inter = np.maximum(0, inter_x2 - inter_x1) * np.maximum(0, inter_y2 - inter_y1)
-
-        if self.match_metric == "IOU":
-            denom = areas[i] + areas[candidates] - inter
-        else:  # IOS
-            denom = np.minimum(areas[i], areas[candidates])
-        metric = _safe_ratio(inter, denom)
-
+        metric = _overlap_metric(self.boxes, self.areas, i, candidates, self.match_metric)
         return np.sort(candidates[metric >= self.match_threshold]).astype(np.intp)
 
     def _candidate_indices(self, i: int) -> np.ndarray:
@@ -321,19 +352,7 @@ def build_sparse_matches(
     if self_pair.any():
         rows, cols = rows[~self_pair], cols[~self_pair]
 
-    inter_x1 = np.maximum(boxes[rows, 0], boxes[cols, 0])
-    inter_y1 = np.maximum(boxes[rows, 1], boxes[cols, 1])
-    inter_x2 = np.minimum(boxes[rows, 2], boxes[cols, 2])
-    inter_y2 = np.minimum(boxes[rows, 3], boxes[cols, 3])
-    inter = np.maximum(0, inter_x2 - inter_x1) * np.maximum(0, inter_y2 - inter_y1)
-
-    if match_metric == "IOU":
-        denom = areas[rows] + areas[cols] - inter
-    else:  # IOS
-        denom = np.minimum(areas[rows], areas[cols])
-    metric = _safe_ratio(inter, denom)
-
-    matched = metric >= match_threshold
+    matched = _overlap_metric(boxes, areas, rows, cols, match_metric) >= match_threshold
     rows, cols = rows[matched], cols[matched]
 
     order = np.lexsort((cols, rows))
@@ -408,10 +427,8 @@ def greedy_nmm_sparse(
 def _dominates_all(indptr: np.ndarray, indices: np.ndarray, scores: np.ndarray, boxes: np.ndarray) -> np.ndarray:
     """Return, for every CSR entry, whether its row may claim its column.
 
-    A box claims another when the other scores lower, or scores equal and does
-    not sort before it lexicographically by coordinates. Same rule as the dense
-    ``dominates`` matrix, evaluated for all stored pairs at once so the merge
-    loop below does no per-row numpy work.
+    Evaluated for all stored pairs at once so the merge loop does no per-row
+    numpy work.
 
     Args:
         indptr: CSR row pointers of length N + 1.
@@ -424,19 +441,7 @@ def _dominates_all(indptr: np.ndarray, indices: np.ndarray, scores: np.ndarray, 
     """
     n = len(indptr) - 1
     rows = np.repeat(np.arange(n, dtype=np.intp), np.diff(indptr))
-
-    lower_score = scores[rows] > scores[indices]
-    score_equal = scores[rows] == scores[indices]
-
-    row_lt = np.zeros(len(indices), dtype=bool)
-    still_equal = np.ones(len(indices), dtype=bool)
-    for col in range(4):
-        col_lt = boxes[rows, col] < boxes[indices, col]
-        col_eq = boxes[rows, col] == boxes[indices, col]
-        row_lt |= still_equal & col_lt
-        still_equal &= col_eq
-
-    return lower_score | (score_equal & ~row_lt)
+    return _dominates(rows, indices, scores, boxes)
 
 
 def nmm_sparse(
@@ -564,16 +569,4 @@ def _dominated_row(candidates: np.ndarray, i: int, scores: np.ndarray, boxes: np
     """
     if len(candidates) == 0:
         return candidates
-
-    lower_score = scores[i] > scores[candidates]
-    score_equal = scores[i] == scores[candidates]
-
-    row_lt = np.zeros(len(candidates), dtype=bool)
-    still_equal = np.ones(len(candidates), dtype=bool)
-    for col in range(4):
-        col_lt = boxes[i, col] < boxes[candidates, col]
-        col_eq = boxes[i, col] == boxes[candidates, col]
-        row_lt |= still_equal & col_lt
-        still_equal &= col_eq
-
-    return candidates[lower_score | (score_equal & ~row_lt)]
+    return candidates[_dominates(i, candidates, scores, boxes)]

--- a/tests/test_sparse_backend.py
+++ b/tests/test_sparse_backend.py
@@ -19,11 +19,9 @@ from sahi.postprocess._sparse_backend import (
     SPARSE_MIN_BOXES,
     MatchQuery,
     build_sparse_matches,
-    greedy_nmm_sparse,
     greedy_nmm_streaming,
     nmm_sparse,
     nmm_streaming,
-    nms_sparse,
     nms_streaming,
     should_stream_nmm,
     should_use_sparse,
@@ -106,18 +104,15 @@ def test_sparse_adjacency_matches_dense(match_metric: str, match_threshold: floa
 
 @PARITY_GRID
 def test_dense_csr_and_streaming_agree(match_metric: str, match_threshold: float, spread: float) -> None:
-    """NMS, greedy NMM and NMM return identical results on all three paths."""
+    """NMS, greedy NMM and NMM return identical results on every path that exists for them."""
     predictions = _make_predictions(400, spread, seed=2)
     case = _case(predictions, match_metric, match_threshold)
     streaming_args = (case.boxes, case.areas, match_metric, match_threshold, case.sorted_idxs)
 
-    dense_nms = nms_from_matrix(case.matrix, case.sorted_idxs, match_threshold)
-    assert nms_sparse(case.indptr, case.indices, case.sorted_idxs) == dense_nms
-    assert nms_streaming(*streaming_args) == dense_nms
-
-    dense_greedy = greedy_nmm_from_matrix(case.matrix, case.sorted_idxs, match_threshold)
-    assert greedy_nmm_sparse(case.indptr, case.indices, case.sorted_idxs) == dense_greedy
-    assert greedy_nmm_streaming(*streaming_args) == dense_greedy
+    assert nms_streaming(*streaming_args) == nms_from_matrix(case.matrix, case.sorted_idxs, match_threshold)
+    assert greedy_nmm_streaming(*streaming_args) == greedy_nmm_from_matrix(
+        case.matrix, case.sorted_idxs, match_threshold
+    )
 
     dense_nmm = nmm_from_matrix(case.matrix, case.sorted_idxs, case.scores, case.boxes, match_threshold)
     assert nmm_sparse(case.indptr, case.indices, case.sorted_idxs, case.scores, case.boxes) == dense_nmm

--- a/tests/test_sparse_backend.py
+++ b/tests/test_sparse_backend.py
@@ -174,7 +174,7 @@ def test_settled_boxes_leave_later_rows() -> None:
     assert query.row(0).tolist() == []
 
 
-def test_nmm_streams_only_when_pair_list_would_be_large() -> None:
+def test_nmm_streams_only_when_boxes_are_crowded() -> None:
     """Scattered boxes keep the stored-pair path; crowded ones switch to streaming."""
     scattered = _make_predictions(4000, spread=30000.0, seed=7)
     crowded = _make_predictions(4000, spread=80.0, seed=7)

--- a/tests/test_sparse_backend.py
+++ b/tests/test_sparse_backend.py
@@ -135,6 +135,45 @@ def test_match_query_row_equals_csr_row(match_metric: str, match_threshold: floa
         assert query.row(i).tolist() == case.indices[case.indptr[i] : case.indptr[i + 1]].tolist()
 
 
+@pytest.mark.parametrize("match_metric", ["IOU", "IOS"])
+def test_streaming_agrees_with_dense_once_the_tree_is_rebuilt(match_metric: str) -> None:
+    """Crowded boxes settle early, so every loop rebuilds its query and exits before the end."""
+    predictions = _make_predictions(1200, spread=80.0, seed=8)
+    case = _case(predictions, match_metric, 0.3)
+    streaming_args = (case.boxes, case.areas, match_metric, 0.3, case.sorted_idxs)
+
+    assert nms_streaming(*streaming_args) == nms_from_matrix(case.matrix, case.sorted_idxs, 0.3)
+    assert greedy_nmm_streaming(*streaming_args) == greedy_nmm_from_matrix(case.matrix, case.sorted_idxs, 0.3)
+
+    result = nmm_streaming(*streaming_args, case.scores)
+    assert result == nmm_from_matrix(case.matrix, case.sorted_idxs, case.scores, case.boxes, 0.3)
+    _assert_partition(result, len(predictions), "rebuilt")
+
+
+def test_settled_boxes_leave_later_rows() -> None:
+    """Deactivating a box drops it from every later row, but it stays queryable itself."""
+    case = _case(_make_predictions(300, spread=200.0, seed=9), "IOU", 0.1)
+    n = len(case.boxes)
+    query = MatchQuery(case.boxes, case.areas, "IOU", 0.1)
+    full_rows = [query.row(i).tolist() for i in range(n)]
+    assert any(full_rows), "fixture must produce some matches"
+
+    # Settling every second box halves the population, which rebuilds the tree.
+    query.deactivate_row(np.arange(0, n, 2))
+    assert query.active_count == n // 2
+    for i in range(n):
+        assert query.row(i).tolist() == [m for m in full_rows[i] if m % 2]
+
+    query.deactivate(1)
+    assert query.active_count == n // 2 - 1
+    query.deactivate(1)  # settling twice must not double count
+    assert query.active_count == n // 2 - 1
+
+    query.deactivate_row(np.arange(3, n, 2))
+    assert query.active_count == 0
+    assert query.row(0).tolist() == []
+
+
 def test_nmm_streams_only_when_pair_list_would_be_large() -> None:
     """Scattered boxes keep the stored-pair path; crowded ones switch to streaming."""
     scattered = _make_predictions(4000, spread=30000.0, seed=7)
@@ -175,6 +214,7 @@ def test_crowded_input_stays_within_memory() -> None:
     tracemalloc.start()
     nms_numpy(predictions, "IOS", 0.3)
     greedy_nmm_numpy(predictions, "IOS", 0.3)
+    nmm_numpy(predictions, "IOS", 0.3)
     _, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()
 


### PR DESCRIPTION
Hi, @onuralpszr 

After 2 weeks of investigating and benchmarking, I developed an optimization for the streaming NMM path.  It removes already-claimed boxes from future candidate queries and periodically rebuilds the STRtree over the remaining active boxes, substantially reducing redundant overlap computations on crowded inputs.

## Summary

This PR speeds up the crowded streaming NMM path by:

- removing already claimed boxes from future candidate rows;
- rebuilding the STRtree whenever the active candidate population halves;
- stopping once every box has been assigned to a group;
- using envelope-only STRtree queries for axis-aligned boxes.

## Why this is safe

NMM never reassigns a box after its `merge_to_keep` entry becomes non-negative. Therefore, a claimed box no longer needs to remain in the candidate index.

Claimed boxes can still propagate their keeper label when their turn arrives because their geometries remain available as query sources. The STRtree only needs to contain boxes that are still valid assignment targets.

The envelope-only query is also sufficient here because every indexed geometry is an axis-aligned rectangle created by `shapely.box`. Its envelope is the rectangle itself, and the IOU/IOS calculation remains the final match filter.

## Benchmark

on M4 Pro, Python 3.11.14, NumPy 2.4.6, Shapely 2.1.2.

Same crowded fixture as the previous benchmark: IOS, threshold 0.3, spread 80, seed 7.

| Boxes | Before | After | Speedup |
|---:|---:|---:|---:|
| 10,000 | 2.749 s | 0.029 s | 94.8x |
| 33,337 | 37.349 s | 0.098 s | 381.1x |

At 33,337 boxes, the active candidate set becomes empty after 504 processed rows, so the remaining rows cannot change the result and are skipped.

A less favorable case with IOU 0.9, where only 105 of 10,000 boxes are merged, completes in 0.401 s.