### PR TITLE
Make the quick start end in a prediction and stop listing pages twice

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,153 +1,85 @@
 ---
-hide:
-  - navigation
 tags:
   - getting-started
   - installation
   - inference
   - slicing
-  - postprocessing
 ---
 
 # Quick Start
 
-SAHI (Slicing Aided Hyper Inference) detects small objects in large images by
-slicing them into overlapping tiles, running your detector on each tile, and
-merging the results. It works with any detection model no retraining needed.
+SAHI cuts a large image into overlapping slices, runs your detector on each slice, and merges the detections back onto the full image. Small objects stay big enough to detect, and no retraining is needed.
 
-<div align="center">
-  <img width="700" alt="sliced inference" src="https://raw.githubusercontent.com/obss/sahi/main/resources/sliced_inference.gif">
-</div>
-
-## Installation
-
-[![PyPI - Version](https://img.shields.io/pypi/v/sahi?logo=pypi&logoColor=white)](https://pypi.org/project/sahi/)
-[![Conda Version](https://img.shields.io/conda/vn/conda-forge/sahi?logo=condaforge)](https://anaconda.org/conda-forge/sahi)
-[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/sahi?logo=python&logoColor=gold)](https://pypi.org/project/sahi/)
+## 1. Install
 
 ```bash
-pip install sahi
+pip install "sahi[ultralytics]"
 ```
 
-For object detection you also need a framework. The most common choice is
-Ultralytics:
+`sahi` on its own ships no detector, so pick the extra for the framework you want: `ultralytics`, `transformers`, `yolov5`, `roboflow`, `torchvision`, `torch`, `onnx`, `numba`, or `all`. Conda users can run `conda install -c conda-forge sahi` and install the framework separately.
 
-```bash
-pip install ultralytics
-```
+## 2. Get a prediction
 
-??? note "Other install methods"
-
-    **Conda:**
-
-    [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/sahi.svg)](https://anaconda.org/conda-forge/sahi)
-    [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/sahi.svg)](https://anaconda.org/conda-forge/sahi)
-
-    ```bash
-    conda install -c conda-forge sahi
-    ```
-
-    !!! note
-        If you are installing in a CUDA environment, it is best practice to install
-        `ultralytics`, `pytorch`, and `pytorch-cuda` in the same command:
-        ```bash
-        conda install -c pytorch -c nvidia -c conda-forge pytorch torchvision pytorch-cuda=11.8 ultralytics
-        ```
-
-    **From source:**
-    ```bash
-    pip install git+https://github.com/obss/sahi.git@main
-    ```
-
-    **Development (editable):**
-    ```bash
-    git clone https://github.com/obss/sahi
-    cd sahi
-    pip install -e .
-    ```
-
-See the
-[pyproject.toml](https://github.com/obss/sahi/blob/main/pyproject.toml) for the
-full list of dependencies.
-
-## Sliced Prediction with Python
+This runs end to end on CPU. It downloads a sample image, and Ultralytics downloads `yolo26n.pt` on first use.
 
 ```python
 from sahi import AutoDetectionModel
 from sahi.predict import get_sliced_prediction
+from sahi.utils.file import download_from_url
 
-# Load a model (works with any supported framework)
+download_from_url(
+    "https://raw.githubusercontent.com/obss/sahi/main/demo/demo_data/small-vehicles1.jpeg",
+    "demo_data/small-vehicles1.jpeg",
+)
+
 detection_model = AutoDetectionModel.from_pretrained(
     model_type="ultralytics",
     model_path="yolo26n.pt",
     confidence_threshold=0.25,
-    device="cuda:0",  # or "cpu"
+    device="cpu",  # or "cuda:0"
 )
 
-# Run sliced prediction
 result = get_sliced_prediction(
-    "path/to/your/image.jpg",
+    "demo_data/small-vehicles1.jpeg",
     detection_model,
     slice_height=512,
     slice_width=512,
     overlap_height_ratio=0.2,
     overlap_width_ratio=0.2,
 )
-
-# Export visualizations
-result.export_visuals(export_dir="demo_data/")
-
-# Access individual predictions
-for pred in result.object_prediction_list:
-    print(pred.category.name, pred.score.value, pred.bbox.to_xyxy())
 ```
 
-## Prediction with the CLI
+Swap `model_type` and `model_path` for any other framework. See [Model Integrations](guides/models.md) for the full list.
 
-Run sliced inference without writing Python code:
+## 3. Read the result
 
-```bash
-sahi predict \
-  --model_path yolo26n.pt \
-  --model_type ultralytics \
-  --source /path/to/images/ \
-  --slice_height 512 \
-  --slice_width 512
-```
-
-Results are saved to `runs/predict/exp` by default.
-
-## Choosing a Postprocessing Backend
-
-After slicing, SAHI merges overlapping predictions with NMS or NMM. The best
-available backend is selected automatically:
-
-| Backend | When selected | Install |
-| --------- | -------------- | --------- |
-| **torchvision** | CUDA or Apple MPS GPU + torchvision available | `pip install torch torchvision` |
-| **numba** | numba installed, no GPU | `pip install numba` |
-| **numpy** | Always available (fallback) | -- |
-
-Override the choice manually:
+`result` is a `PredictionResult`. Every detection lives in `result.object_prediction_list`.
 
 ```python
-from sahi.postprocess.backends import set_postprocess_backend
+for pred in result.object_prediction_list:
+    print(pred.category.name, pred.score.value, pred.bbox.to_xyxy())
 
-set_postprocess_backend("numpy")       # always available
-set_postprocess_backend("numba")       # JIT-compiled
-set_postprocess_backend("torchvision") # GPU-accelerated
-set_postprocess_backend("auto")        # restore auto-detection
+# Writes demo_data/prediction_visual.png
+result.export_visuals(export_dir="demo_data/")
+
+# COCO-format dicts, ready to dump as JSON
+coco_predictions = result.to_coco_predictions(image_id=1)
 ```
 
-## Next Steps
+If your image is already close to the model input size, use `get_prediction` instead and skip slicing entirely.
 
-- [How Sliced Inference Works](guides/sliced-inference.md) -- Understand the
-  algorithm, tuning tips, and when to use it
-- [Model Integrations](guides/models.md) -- Use SAHI with Ultralytics, HuggingFace,
-  MMDetection, TorchVision, Detectron2, and more
-- [Prediction Utilities](predict.md) -- Batch inference, progress tracking,
-  visualization options
-- [COCO Utilities](coco.md) -- Create, slice, merge, and convert COCO datasets
-- [CLI Commands](cli.md) -- Full CLI reference
-- [Interactive Notebooks](notebooks.md) -- Hands-on Colab notebooks for every
-  framework
+## 4. The same run from the CLI
+
+```bash
+sahi predict --model_type ultralytics --model_path yolo26n.pt --source demo_data/ --slice_height 512 --slice_width 512
+```
+
+Visuals are written to `runs/predict/exp`. Add `--dataset_json_path dataset.json` to also export a COCO `result.json` for evaluation.
+
+## Next steps
+
+- [How Sliced Inference Works](guides/sliced-inference.md) for choosing slice size, overlap, and the merge strategy.
+- [Model Integrations](guides/models.md) for HuggingFace, MMDetection, Detectron2, TorchVision, RT-DETR, RF-DETR, and the rest.
+- [Prediction Utilities](predict.md) for batch inference, progress bars, and export options.
+- [CLI Commands](cli.md) for every command and flag.
+- [Interactive Notebooks](notebooks.md) for runnable Colab examples.

--- a/zensical.toml
+++ b/zensical.toml
@@ -15,18 +15,14 @@ nav = [
     {"How Sliced Inference Works" = "guides/sliced-inference.md"},
     {"Model Integrations" = "guides/models.md"},
     {"Prediction Utilities" = "predict.md"},
-    {"COCO Dataset Operations" = "coco.md"},
     {"Slicing Utilities" = "slicing.md"},
     {"Postprocessing Backends" = "postprocess/backends.md"},
-    {"FiftyOne Visualization" = "fiftyone.md"},
     {"CLI Commands" = "cli.md"},
+    {"COCO Dataset Operations" = "coco.md"},
+    {"FiftyOne Visualization" = "fiftyone.md"},
   ]},
   {Notebooks = "notebooks.md"},
   {"Code Reference" = [
-    {"High-level API" = [
-      "predict.md",
-      "slicing.md",
-    ]},
     {Core = [
       "annotation.md",
       "prediction.md",
@@ -47,7 +43,6 @@ nav = [
       "models/roboflow.md",
     ]},
     {"Post-processing" = [
-      "postprocess/backends.md",
       "postprocess/combine.md",
       "postprocess/utils.md",
     ]},


### PR DESCRIPTION
Rewrites the quick start so the example runs as written, and removes three duplicate navigation entries.