### PR TITLE
Point the docs at the site they are actually published on and serve their markdown

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -66,6 +66,8 @@ jobs:
           # Rebuild /tr as a standalone localized site (own nav, links stay inside /tr/)
           rm -rf site/tr
           uv run zensical build -f zensical.tr.toml
+          # Publish each page's markdown source beside its HTML, plus llms.txt
+          uv run python scripts/docs/export_markdown_sources.py
 
       - name: 🚀 Deploy to GitHub Pages
         if:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <a href="https://pepy.tech/project/sahi"><img src="https://pepy.tech/badge/sahi/month" alt="Monthly Downloads"></a>
   <a href="https://badge.fury.io/py/sahi"><img src="https://badge.fury.io/py/sahi.svg" alt="PyPI Version"></a>
   <a href="https://anaconda.org/conda-forge/sahi"><img src="https://anaconda.org/conda-forge/sahi/badges/version.svg" alt="Conda Version"></a>
-  <a href="https://github.com/obss/sahi/blob/main/LICENSE.md"><img src="https://img.shields.io/pypi/l/sahi" alt="License"></a>
+  <a href="https://github.com/obss/sahi/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/sahi" alt="License"></a>
 </div>
 
 <!-- CI & Quality -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ tags:
 <div>
     <a href="https://pepy.tech/project/sahi"><img src="https://pepy.tech/badge/sahi" alt="downloads"></a>
     <a href="https://pepy.tech/project/sahi"><img src="https://pepy.tech/badge/sahi/month" alt="downloads"></a>
-    <a href="https://github.com/obss/sahi/blob/main/LICENSE.md"><img src="https://img.shields.io/pypi/l/sahi" alt="License"></a>
+    <a href="https://github.com/obss/sahi/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/sahi" alt="License"></a>
     <a href="https://badge.fury.io/py/sahi"><img src="https://badge.fury.io/py/sahi.svg" alt="pypi version"></a>
     <a href="https://anaconda.org/conda-forge/sahi"><img src="https://anaconda.org/conda-forge/sahi/badges/version.svg" alt="conda version"></a>
     <a href="https://github.com/obss/sahi/actions/workflows/ci.yml"><img src="https://github.com/obss/sahi/actions/workflows/ci.yml/badge.svg" alt="Continuous Integration"></a>

--- a/docs/tr/README.md
+++ b/docs/tr/README.md
@@ -18,7 +18,7 @@
   <a href="https://pepy.tech/project/sahi"><img src="https://pepy.tech/badge/sahi/month" alt="Aylık İndirme"></a>
   <a href="https://badge.fury.io/py/sahi"><img src="https://badge.fury.io/py/sahi.svg" alt="PyPI Sürümü"></a>
   <a href="https://anaconda.org/conda-forge/sahi"><img src="https://anaconda.org/conda-forge/sahi/badges/version.svg" alt="Conda Sürümü"></a>
-  <a href="https://github.com/obss/sahi/blob/main/LICENSE.md"><img src="https://img.shields.io/pypi/l/sahi" alt="Lisans"></a>
+  <a href="https://github.com/obss/sahi/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/sahi" alt="Lisans"></a>
 </div>
 
 <!-- CI & Quality -->

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -18,7 +18,7 @@
   <a href="https://pepy.tech/project/sahi"><img src="https://pepy.tech/badge/sahi/month" alt="月下载量"></a>
   <a href="https://badge.fury.io/py/sahi"><img src="https://badge.fury.io/py/sahi.svg" alt="PyPI 版本"></a>
   <a href="https://anaconda.org/conda-forge/sahi"><img src="https://anaconda.org/conda-forge/sahi/badges/version.svg" alt="Conda 版本"></a>
-  <a href="https://github.com/obss/sahi/blob/main/LICENSE.md"><img src="https://img.shields.io/pypi/l/sahi" alt="许可证"></a>
+  <a href="https://github.com/obss/sahi/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/sahi" alt="许可证"></a>
 </div>
 
 <!-- CI & 质量 -->

--- a/scripts/docs/export_markdown_sources.py
+++ b/scripts/docs/export_markdown_sources.py
@@ -1,0 +1,109 @@
+"""Publish the markdown source of every docs page next to its built HTML.
+
+Adding `.md` to any page URL then returns the source, so `/guides/sliced-inference/`
+and `/guides/sliced-inference.md` are the same page in two formats. That is convenient
+for reading a page in a terminal, and it gives crawlers and language models the prose
+without the site chrome around it.
+
+Also writes `llms.txt` at the site root, the conventional index that points at those
+markdown files.
+
+Run after `zensical build`, from the repository root.
+"""
+
+import pathlib
+import re
+import sys
+from pathlib import Path
+
+import tomllib
+
+DOCS = Path("docs")
+SITE = Path("site")
+SNIPPET = re.compile(r'^(\s*)--8<--\s+"([^"]+)"\s*$', re.M)
+FRONT_MATTER = re.compile(r"\A---\n.*?\n---\n", re.S)
+TITLE = re.compile(r"^#\s+(.+)$", re.M)
+
+
+def resolve_snippets(text: str, depth: int = 0) -> str:
+    """Inline `--8<-- "file"` includes so the published source is the real content."""
+    if depth > 5:
+        return text
+
+    def replace(match: re.Match) -> str:
+        indent, target = match.group(1), match.group(2)
+        for base in (Path("."), DOCS):
+            candidate = base / target
+            if candidate.is_file():
+                body = resolve_snippets(candidate.read_text(encoding="utf-8"), depth + 1)
+                return "\n".join(indent + line for line in body.splitlines())
+        return match.group(0)
+
+    return SNIPPET.sub(replace, text)
+
+
+def nav_titles(nav: object, into: dict) -> dict:
+    """Collect {path: title} from the nested nav, which names pages a heading may not."""
+    if isinstance(nav, dict):
+        for title, value in nav.items():
+            if isinstance(value, str):
+                into[value] = title
+            else:
+                nav_titles(value, into)
+    elif isinstance(nav, list):
+        for item in nav:
+            nav_titles(item, into)
+    return into
+
+
+def page_title(text: str, relative: str, from_nav: dict) -> str:
+    """Prefer the page heading, fall back to the nav label, then to the file name."""
+    found = TITLE.search(FRONT_MATTER.sub("", text))
+    if found:
+        return found.group(1).strip()
+    return from_nav.get(relative, pathlib.PurePosixPath(relative).stem)
+
+
+def main() -> int:
+    if not SITE.is_dir():
+        print("site/ not found, run zensical build first", file=sys.stderr)
+        return 1
+
+    site_url = "/"
+    from_nav: dict = {}
+    config = Path("zensical.toml")
+    if config.is_file():
+        project = tomllib.loads(config.read_text())["project"]
+        site_url = project.get("site_url", "/").rstrip("/") + "/"
+        nav_titles(project.get("nav", []), from_nav)
+
+    written: list[tuple[str, str]] = []
+    for source in sorted(DOCS.rglob("*.md")):
+        relative = source.relative_to(DOCS)
+        target = SITE / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        text = resolve_snippets(source.read_text(encoding="utf-8"))
+        target.write_text(text, encoding="utf-8")
+        written.append((relative.as_posix(), page_title(text, relative.as_posix(), from_nav)))
+
+    # English pages only: the translated trees have their own roots.
+    english = [(rel, title) for rel, title in written if not rel.startswith(("zh/", "tr/"))]
+    lines = [
+        "# SAHI",
+        "",
+        "> A vision library for performing sliced inference on large images and small objects.",
+        "",
+        "Every page below is the markdown source of the corresponding documentation page.",
+        "",
+        "## Documentation",
+        "",
+    ]
+    lines += [f"- [{title}]({site_url}{rel})" for rel, title in english]
+    (SITE / "llms.txt").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    print(f"published {len(written)} markdown sources and llms.txt with {len(english)} entries")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,6 +1,6 @@
 [project]
 site_name = "SAHI Documentation"
-site_url = "https://sahi.readthedocs.io/"
+site_url = "https://obss.github.io/sahi/"
 repo_url = "https://github.com/obss/sahi"
 repo_name = "obss/sahi"
 edit_uri = "https://github.com/obss/sahi/tree/main/docs"
@@ -149,6 +149,8 @@ permalink = true
 # --- PyMdown extensions ---
 
 [project.markdown_extensions.pymdownx.details]
+[project.markdown_extensions.abbr]
+
 [project.markdown_extensions.pymdownx.superfences]
 
 [project.markdown_extensions.pymdownx.tabbed]

--- a/zensical.tr.toml
+++ b/zensical.tr.toml
@@ -1,6 +1,6 @@
 [project]
 site_name = "SAHI Dokümantasyonu"
-site_url = "https://sahi.readthedocs.io/tr/"
+site_url = "https://obss.github.io/sahi/tr/"
 repo_url = "https://github.com/obss/sahi"
 repo_name = "obss/sahi"
 edit_uri = "https://github.com/obss/sahi/tree/main/docs/tr"

--- a/zensical.zh.toml
+++ b/zensical.zh.toml
@@ -1,6 +1,6 @@
 [project]
 site_name = "SAHI 文档"
-site_url = "https://sahi.readthedocs.io/zh/"
+site_url = "https://obss.github.io/sahi/zh/"
 repo_url = "https://github.com/obss/sahi"
 repo_name = "obss/sahi"
 edit_uri = "https://github.com/obss/sahi/tree/main/docs/zh"


### PR DESCRIPTION
Fixes site_url, which pointed at a host that 404s, and publishes each page's markdown source plus llms.txt alongside the built HTML.