### PR TITLE
Point the demo links at the repository so they resolve off GitHub too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -672,7 +672,7 @@ and @fcakyon!
 #### 📓 Interactive Examples
 
 All documentation files are complemented by interactive Jupyter notebooks in the
-[demo directory](../demo/):
+[demo directory](https://github.com/obss/sahi/tree/main/demo):
 
 - `slicing.ipynb` - Slicing operations demonstration
 - `inference_for_ultralytics.ipynb` - YOLOv8/YOLO11/YOLO12 integration
@@ -693,7 +693,7 @@ If you're new to SAHI:
    images
 3. Check out the [CLI commands](cli.md) for command-line usage
 4. Dive into [COCO utilities](coco.md) for dataset operations
-5. Try the interactive notebooks in the [demo directory](../demo/) for hands-on
+5. Try the interactive notebooks in the [demo directory](https://github.com/obss/sahi/tree/main/demo) for hands-on
    experience
 
 ## 🚀 SAHI v0.11.21 Release Notes

--- a/docs/tr/README.md
+++ b/docs/tr/README.md
@@ -147,7 +147,7 @@ pip install inference>=0.51.5 rfdetr>=1.6.2
 | [Hata Analizi Grafikleri & Değerlendirme](https://github.com/obss/sahi/discussions/622) ⭐                                                   | Tartışma    |
 | [Etkileşimli Sonuç Görselleştirme ve İnceleme](https://github.com/obss/sahi/discussions/624) ⭐                                              | Tartışma    |
 | [Video Inference Desteği](https://github.com/obss/sahi/discussions/626)                                                                      | Tartışma    |
-| [Dilimleme Operasyonları Notebook'u](demo/slicing.ipynb)                                                                                     | Notebook    |
+| [Dilimleme Operasyonları Notebook'u](https://github.com/obss/sahi/blob/main/demo/slicing.ipynb)                                              | Notebook    |
 | [Tam Dokümantasyon](index.md)                                                                                                                | Doküman     |
 
 ### Notebook'lar & Demolar

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -151,7 +151,7 @@ pip install inference>=0.51.5 rfdetr>=1.6.2
 | [误差分析绘图 & 评估](https://github.com/obss/sahi/discussions/622) ⭐                                                                   | 讨论     |
 | [交互式结果可视化与检查](https://github.com/obss/sahi/discussions/624) ⭐                                                                | 讨论     |
 | [视频推理支持](https://github.com/obss/sahi/discussions/626)                                                                             | 讨论     |
-| [切片操作 Notebook](../../demo/slicing.ipynb)                                                                                            | Notebook |
+| [切片操作 Notebook](https://github.com/obss/sahi/blob/main/demo/slicing.ipynb)                                                           | Notebook |
 | [完整文档](index.md)                                                                                                                     | 文档     |
 
 ### Notebooks & 示例

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -681,7 +681,7 @@ CUDA（RTX 4000 Ada Laptop，12 GB）：
 
 #### 📓 交互式示例
 
-所有文档文件都配有 [demo 目录](../../demo/) 中的交互式 Jupyter notebook：
+所有文档文件都配有 [demo 目录](https://github.com/obss/sahi/tree/main/demo) 中的交互式 Jupyter notebook：
 
 - `slicing.ipynb` - 切片操作演示
 - `inference_for_ultralytics.ipynb` - YOLOv8/YOLO11/YOLO26 集成
@@ -703,7 +703,7 @@ CUDA（RTX 4000 Ada Laptop，12 GB）：
 2. 探索[切片工具](slicing.md)，学习处理大图像
 3. 查看 [CLI 命令](cli.md)，了解命令行用法
 4. 深入 [COCO 工具](coco.md)，学习数据集操作
-5. 尝试 [demo 目录](../../demo/) 中的交互式 notebook，获取实践经验
+5. 尝试 [demo 目录](https://github.com/obss/sahi/tree/main/demo) 中的交互式 notebook，获取实践经验
 
 ## 🚀 SAHI v0.11.21 发布说明
 


### PR DESCRIPTION
Replaces relative links to the demo directory with absolute repository URLs, which resolved neither on the docs site nor from the repository root.