### PR TITLE
docs: replace em dashes with the repo's ASCII convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,8 +175,8 @@ path where it is faster.
 
 ## 🚀 SAHI v0.12.0 Release Notes
 
-One of the largest SAHI releases to date — **95 commits** since `0.11.34`
-(rolling in the `0.11.35`/`0.11.36` hotfixes) — featuring a re-architected
+One of the largest SAHI releases to date -- **95 commits** since `0.11.34`
+(rolling in the `0.11.35`/`0.11.36` hotfixes) -- featuring a re-architected
 postprocessing engine, true batch inference, a torch-free core, new
 open-vocabulary and segmentation models, and a full documentation overhaul.
 
@@ -184,19 +184,19 @@ open-vocabulary and segmentation models, and a full documentation overhaul.
 
 #### ⚡ Batch inference, torch-free core & accelerated postprocessing backends
 
-- **Batch inference** — slices are processed in batches end-to-end for major
+- **Batch inference** -- slices are processed in batches end-to-end for major
   GPU throughput gains ([#1336](https://github.com/obss/sahi/pull/1336)).
-- **Torch-free core** — the core slicing/postprocessing path no longer
+- **Torch-free core** -- the core slicing/postprocessing path no longer
   hard-depends on PyTorch; install only what your backend needs
   ([#1336](https://github.com/obss/sahi/pull/1336)).
-- **Pluggable postprocessing backends** — NMS/NMM run on a selectable backend:
+- **Pluggable postprocessing backends** -- NMS/NMM run on a selectable backend:
   **NumPy** (zero heavy deps), **Numba** (JIT-accelerated CPU), or
   **TorchVision** (GPU), auto-selected for your environment
   ([#1336](https://github.com/obss/sahi/pull/1336)).
 
 #### 🧠 New model support
 
-- **GroundingDINO (HuggingFace)** — zero-shot, text-prompted open-vocabulary
+- **GroundingDINO (HuggingFace)** -- zero-shot, text-prompted open-vocabulary
   detection through SAHI's sliced pipeline, with a dedicated demo notebook
   ([#1361](https://github.com/obss/sahi/pull/1361)).
 - **Universal segmentation from HuggingFace**
@@ -235,7 +235,7 @@ open-vocabulary and segmentation models, and a full documentation overhaul.
 
 ### ✨ Performance & Improvements
 
-- **Significantly faster post-processing** — NMS, NMM, and GREEDYNMM now use a
+- **Significantly faster post-processing** -- NMS, NMM, and GREEDYNMM now use a
   shapely `STRtree` spatial index, dramatically speeding up merging on images
   with many slices/detections ([#1248](https://github.com/obss/sahi/pull/1248)).
 - Faster `read_image_as_pil` for quicker slicing throughput

--- a/demo/inference_for_roboflow.ipynb
+++ b/demo/inference_for_roboflow.ipynb
@@ -26,7 +26,7 @@
    "source": [
     "# SAHI + Roboflow\n",
     "\n",
-    "This notebook demonstrates how to run object detection using Roboflow's [RF-DETR](https://github.com/roboflow/rfdetr) models in combination with [SAHI (Slicing Aided Hyper Inference)](https://github.com/obss/sahi) for improved detection performance—particularly on small objects. \n",
+    "This notebook demonstrates how to run object detection using Roboflow's [RF-DETR](https://github.com/roboflow/rfdetr) models in combination with [SAHI (Slicing Aided Hyper Inference)](https://github.com/obss/sahi) for improved detection performance, particularly on small objects. \n",
     "\n",
     "You can set the `model` parameter in one of **three ways**, depending on whether you're using a model from [Roboflow Universe](https://universe.roboflow.com/search?q=object%20detection) or a custom-trained RF-DETR model."
    ]

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,4 +1,4 @@
-/* Light theme: deep blue header — logo (#2B57E0) reads as a brighter highlight */
+/* Light theme: deep blue header -- logo (#2B57E0) reads as a brighter highlight */
 [data-md-color-primary=custom] {
   --md-primary-fg-color: #162d8a;
   --md-primary-fg-color--light: #1e3fa8;

--- a/docs/tr/postprocess/backends.md
+++ b/docs/tr/postprocess/backends.md
@@ -23,10 +23,10 @@ SAHI'nin postprocessing (NMS, NMM) işlemleri üç değiştirilebilir backend ü
 
 SAHI varsayılan olarak çalışma anında (runtime) mevcut en iyi backend'i otomatik olarak seçer:
 
-1. **torchvision** — `torchvision` yüklüyse _ve_ bir GPU mevcutsa
+1. **torchvision**: `torchvision` yüklüyse _ve_ bir GPU mevcutsa
    (CUDA veya Apple Silicon üzerinde Apple MPS).
-2. **numba** — `numba` paketi yüklüyse.
-3. **numpy** — son çare (fallback) olarak her zaman mevcuttur.
+2. **numba**: `numba` paketi yüklüyse.
+3. **numpy**: son çare (fallback) olarak her zaman mevcuttur.
 
 ```python
 from sahi.postprocess.backends import get_postprocess_backend
@@ -100,11 +100,11 @@ predictions = np.array([
     [300, 300, 400, 400, 0.90, 1],
 ])
 
-# Global NMS — all categories compete together
+# Global NMS, tüm kategoriler birlikte yarışır
 keep = nms(predictions, match_metric="IOU", match_threshold=0.5)
 print(predictions[keep])
 
-# Per-category NMS — class 0 and class 1 are treated independently
+# Kategori bazında NMS, sınıf 0 ve sınıf 1 bağımsız değerlendirilir
 keep = batched_nms(predictions, match_metric="IOU", match_threshold=0.5)
 print(predictions[keep])
 ```
@@ -142,19 +142,19 @@ Yüksek seviyeli sınıflar, SAHI'nin `ObjectPrediction` listeleriyle entegre ol
 ```python
 from sahi.postprocess.combine import NMSPostprocess, NMMPostprocess, GreedyNMMPostprocess
 
-# NMS — keep the best box, discard the rest
+# NMS, en iyi kutuyu tutar, geri kalanını atar
 postprocessor = NMSPostprocess(
     match_threshold=0.5,
     match_metric="IOU",
-    class_agnostic=True,   # False → per-category
+    class_agnostic=True,   # False → kategori bazında
 )
 filtered = postprocessor(object_prediction_list)
 
-# Greedy NMM — merge overlapping boxes (fast)
+# Greedy NMM, örtüşen kutuları birleştirir (hızlı)
 postprocessor = GreedyNMMPostprocess(match_threshold=0.5)
 merged = postprocessor(object_prediction_list)
 
-# Full NMM — transitive merging
+# Full NMM, geçişli birleştirme
 postprocessor = NMMPostprocess(match_threshold=0.5)
 merged = postprocessor(object_prediction_list)
 ```

--- a/docs/tr/stylesheets/extra.css
+++ b/docs/tr/stylesheets/extra.css
@@ -1,4 +1,4 @@
-/* Light theme: deep blue header — logo (#2B57E0) reads as a brighter highlight */
+/* Light theme: deep blue header -- logo (#2B57E0) reads as a brighter highlight */
 [data-md-color-primary=custom] {
   --md-primary-fg-color: #162d8a;
   --md-primary-fg-color--light: #1e3fa8;

--- a/docs/zh/stylesheets/extra.css
+++ b/docs/zh/stylesheets/extra.css
@@ -1,4 +1,4 @@
-/* Light theme: deep blue header — logo (#2B57E0) reads as a brighter highlight */
+/* Light theme: deep blue header -- logo (#2B57E0) reads as a brighter highlight */
 [data-md-color-primary=custom] {
   --md-primary-fg-color: #162d8a;
   --md-primary-fg-color--light: #1e3fa8;

--- a/sahi/__init__.py
+++ b/sahi/__init__.py
@@ -22,7 +22,7 @@ try:
 except importlib_metadata.PackageNotFoundError:
     __version__ = "development"
 
-# Lazy imports — heavy modules (cv2, shapely, requests, tqdm) are only
+# Lazy imports -- heavy modules (cv2, shapely, requests, tqdm) are only
 # loaded when the user actually accesses one of these names.
 _LAZY_IMPORTS = {
     "BoundingBox": "sahi.annotation",

--- a/sahi/models/huggingface.py
+++ b/sahi/models/huggingface.py
@@ -241,7 +241,7 @@ class HuggingfaceDetectionModel(DetectionModel):
         import torch
 
         if self._uses_sigmoid_cls:
-            # RT-DETR family: per-class sigmoid, logits shape (Q, num_classes) — no background class
+            # RT-DETR family: per-class sigmoid, logits shape (Q, num_classes) -- no background class
             probs = logits.sigmoid()
             scores, cat_ids = probs.max(-1)
             valid_mask = scores >= self.confidence_threshold

--- a/sahi/models/huggingface_segmentation.py
+++ b/sahi/models/huggingface_segmentation.py
@@ -17,7 +17,7 @@ from sahi.prediction import ObjectPrediction
 from sahi.utils.compatibility import fix_full_shape_list, fix_shift_amount_list
 from sahi.utils.cv import get_coco_segmentation_from_bool_mask
 
-# {model_class_name: processor_class_name} — strings to avoid eager transformers import
+# {model_class_name: processor_class_name} -- strings to avoid eager transformers import
 _SUPPORTED_MODELS: dict[str, str] = {
     "Mask2FormerForUniversalSegmentation": "Mask2FormerImageProcessor",
     "MaskFormerForInstanceSegmentation": "MaskFormerImageProcessor",

--- a/sahi/models/ultralytics.py
+++ b/sahi/models/ultralytics.py
@@ -153,7 +153,7 @@ class UltralyticsDetectionModel(DetectionModel):
         if self.image_size is not None:
             kwargs = {"imgsz": self.image_size, **kwargs}
 
-        # YOLO expects BGR — convert each image and pass the list for native batch inference
+        # YOLO expects BGR -- convert each image and pass the list for native batch inference
         images_bgr = [img[:, :, ::-1] for img in images]
         prediction_result = self.model(images_bgr, **kwargs)
 

--- a/sahi/postprocess/_numba_backend.py
+++ b/sahi/postprocess/_numba_backend.py
@@ -105,7 +105,7 @@ def _nms_numba_inner(
     match_threshold: float,
     use_iou: bool,
 ) -> list[int]:
-    """Core NMS loop — fully JIT-compiled."""
+    """Core NMS loop -- fully JIT-compiled."""
     n = len(scores)
     suppressed = np.zeros(n, dtype=numba.boolean)
     keep = []
@@ -151,7 +151,7 @@ def _greedy_nmm_numba_inner(
     match_threshold: float,
     use_iou: bool,
 ) -> tuple[list[int], NDArray, NDArray]:
-    """Core greedy NMM loop — fully JIT-compiled.
+    """Core greedy NMM loop -- fully JIT-compiled.
 
     Returns (keep_order, keeper_of, sorted_idxs) where keeper_of[i] = keeper index for box i, or -1 if keeper.
     """
@@ -192,7 +192,7 @@ def _greedy_nmm_numba_inner(
 
 @numba.njit(cache=True)
 def _compute_metric_matrix_numba(boxes: NDArray, areas: NDArray, use_iou: bool) -> NDArray:
-    """Compute full metric matrix with numba — symmetric, only compute upper triangle."""
+    """Compute full metric matrix with numba -- symmetric, only compute upper triangle."""
     n = len(boxes)
     matrix = np.zeros((n, n), dtype=np.float64)
     for i in range(n):

--- a/sahi/postprocess/_numpy_backend.py
+++ b/sahi/postprocess/_numpy_backend.py
@@ -26,7 +26,7 @@ _MAX_FULL_MATRIX = 8000
 
 
 # ---------------------------------------------------------------------------
-# Shared utilities — used by all backends via precomputed metric matrix
+# Shared utilities -- used by all backends via precomputed metric matrix
 # ---------------------------------------------------------------------------
 
 
@@ -217,7 +217,7 @@ def _prepare_matrix(predictions: np.ndarray, match_metric: str) -> tuple[np.ndar
 
 
 # ---------------------------------------------------------------------------
-# Shared greedy loop functions — operate on precomputed matrix
+# Shared greedy loop functions -- operate on precomputed matrix
 # ---------------------------------------------------------------------------
 
 

--- a/sahi/postprocess/combine.py
+++ b/sahi/postprocess/combine.py
@@ -62,7 +62,7 @@ def _dispatch(func_type: str) -> Callable[..., Any]:
 
 
 # ---------------------------------------------------------------------------
-# Batched (per-category) wrapper — shared logic for all batched_* functions
+# Batched (per-category) wrapper -- shared logic for all batched_* functions
 # ---------------------------------------------------------------------------
 
 
@@ -126,7 +126,7 @@ def _batched_apply(
 
 
 # ---------------------------------------------------------------------------
-# Public API — unchanged signatures
+# Public API -- unchanged signatures
 # ---------------------------------------------------------------------------
 
 

--- a/sahi/utils/cv.py
+++ b/sahi/utils/cv.py
@@ -185,7 +185,7 @@ def _to_hwc(arr: np.ndarray) -> np.ndarray:
 
     Uses channel-count heuristic (1, 3, or 4) instead of a size threshold so
     small images (height < 5 px) are handled correctly. Channel order is NOT
-    changed — callers are responsible for BGR/RGB correctness before passing in.
+    changed -- callers are responsible for BGR/RGB correctness before passing in.
 
     Args:
         arr (numpy.ndarray): The input array to be converted to HWC format.

--- a/scripts/detect_batch.py
+++ b/scripts/detect_batch.py
@@ -1,4 +1,4 @@
-"""Batch inference detection script — multiple HuggingFace architectures.
+"""Batch inference detection script -- multiple HuggingFace architectures.
 
 Tests sigmoid (RT-DETRv2, Conditional DETR) and softmax+background (DETR, YOLOS)
 classification heads. Runs single-image and batch inference, saves annotated
@@ -93,7 +93,7 @@ def run(cfg: dict, img1: np.ndarray, img2: np.ndarray) -> bool:
             device="cpu",
         )
     except Exception as e:
-        print(f"  SKIP — {e}")
+        print(f"  SKIP -- {e}")
         return True
 
     detected = "sigmoid" if model._uses_sigmoid_cls else "softmax"

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -109,7 +109,7 @@ class TestEdgeCases:
             dtype=np.float32,
         )
         keep = nms(preds, match_threshold=0.5)
-        assert len(keep) == 3  # all kept — no overlap
+        assert len(keep) == 3  # all kept -- no overlap
 
     def test_nms_equal_scores_deterministic(self) -> None:
         """Test NMS determinism with equal scores."""


### PR DESCRIPTION
Removes the last 31 em dashes so the whole repo uses the ASCII convention already used elsewhere.