### PR TITLE
docs: fix unresolved autoref warnings and drop dead mkdocs.yml refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,9 @@ on:
       - "docs/**"
       - "demo/**"
       - "context7.json"
-      - "mkdocs.yml"
       - "zensical.toml"
+      - "zensical.tr.toml"
+      - "zensical.zh.toml"
 
   pull_request:
     branches: [main]
@@ -21,8 +22,9 @@ on:
       - "docs/**"
       - "demo/**"
       - "context7.json"
-      - "mkdocs.yml"
       - "zensical.toml"
+      - "zensical.tr.toml"
+      - "zensical.zh.toml"
 
   schedule:
     - cron: "0 0 * * *" # Runs at 00:00 UTC every day

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,6 @@ repos:
       - id: trailing-whitespace
         exclude: test/.*\.py
       - id: check-yaml
-        exclude: mkdocs.yml
       - id: check-executables-have-shebangs
       - id: check-toml
       - id: check-case-conflict

--- a/sahi/utils/coco.py
+++ b/sahi/utils/coco.py
@@ -89,7 +89,7 @@ class CocoAnnotation:
 
         Args:
             segmentation: List[List]
-                [[1, 1, 325, 125, 250, 200, 5, 200]]
+                `[[1, 1, 325, 125, 250, 200, 5, 200]]`
             category_id: int
                 Category id of the annotation
             category_name: str
@@ -206,7 +206,7 @@ class CocoAnnotation:
 
         Args:
             segmentation: List[List]
-                [[1, 1, 325, 125, 250, 200, 5, 200]]
+                `[[1, 1, 325, 125, 250, 200, 5, 200]]`
             bbox: List
                 [xmin, ymin, width, height]
             category_id: int
@@ -265,7 +265,7 @@ class CocoAnnotation:
 
     @property
     def segmentation(self) -> list[list[int]]:
-        """Returns coco formatted segmentation of the annotation as [[1, 1, 325, 125, 250, 200, 5, 200]]."""
+        """Returns coco formatted segmentation of the annotation as `[[1, 1, 325, 125, 250, 200, 5, 200]]`."""
         if self._segmentation:
             return self._shapely_annotation.to_coco_segmentation()
         else:
@@ -350,7 +350,7 @@ class CocoPrediction(CocoAnnotation):
 
         Args:
             segmentation: List[List]
-                [[1, 1, 325, 125, 250, 200, 5, 200]]
+                `[[1, 1, 325, 125, 250, 200, 5, 200]]`
             category_id: int
                 Category id of the annotation
             category_name: str
@@ -456,7 +456,7 @@ class CocoPrediction(CocoAnnotation):
 
         Args:
             segmentation: List[List]
-                [[1, 1, 325, 125, 250, 200, 5, 200]]
+                `[[1, 1, 325, 125, 250, 200, 5, 200]]`
             bbox: List
                 [xmin, ymin, width, height]
             category_id: int

--- a/sahi/utils/shapely.py
+++ b/sahi/utils/shapely.py
@@ -90,7 +90,7 @@ class ShapelyAnnotation:
 
         Args:
             segmentation: COCO segmentation format,
-                e.g. [[1, 1, 325, 125, 250, 200, 5, 200]].
+                e.g. `[[1, 1, 325, 125, 250, 200, 5, 200]]`.
             slice_bbox: Bounding box as [xmin, ymin, width, height].
                 Should have the same format as the output of the get_bbox_from_shapely function.
                 Is used to calculate sliced coco coordinates.


### PR DESCRIPTION
Takes all three doc site builds from 6 warnings to zero.