### PR TITLE
perf: decode the source image once per sliced prediction

### DIFF
--- a/sahi/predict.py
+++ b/sahi/predict.py
@@ -397,7 +397,9 @@ def get_sliced_prediction(
 
         if num_slices > 1 and perform_standard_pred:
             prediction_result = get_prediction(
-                image=image,
+                # the slicing pass already decoded this, and every slice is a view
+                # into it, so reusing it costs nothing and saves a second decode
+                image=slice_image_result.original_image if slice_image_result.original_image is not None else image,
                 detection_model=detection_model,
                 shift_amount=[0, 0],
                 full_shape=[

--- a/sahi/prediction.py
+++ b/sahi/prediction.py
@@ -10,7 +10,7 @@ from PIL import Image
 
 from sahi.annotation import ObjectAnnotation
 from sahi.utils.coco import CocoPrediction
-from sahi.utils.cv import read_image_as_pil, visualize_object_predictions
+from sahi.utils.cv import read_image_as_pil, read_image_size, visualize_object_predictions
 from sahi.utils.file import Path
 
 
@@ -202,10 +202,21 @@ class PredictionResult:
             durations_in_seconds: dict[str, Any]
                 Elapsed times for profiling (e.g. inference, postprocess).
         """
-        self.image: Image.Image = read_image_as_pil(image)
-        self.image_width, self.image_height = self.image.size
+        # Only the size is needed to build a result, and a path can give that from
+        # its header. Decoding is deferred to the callers that want the pixels,
+        # which for a sliced run over a large image is usually none of them.
+        self._image_source = image
+        self._image: Image.Image | None = None
+        self.image_width, self.image_height = read_image_size(image)
         self.object_prediction_list: list[ObjectPrediction] = object_prediction_list
         self.durations_in_seconds = durations_in_seconds
+
+    @property
+    def image(self) -> Image.Image:
+        """The source image, decoded on first access and kept thereafter."""
+        if self._image is None:
+            self._image = read_image_as_pil(self._image_source)
+        return self._image
 
     def export_visuals(
         self,

--- a/sahi/slicing.py
+++ b/sahi/slicing.py
@@ -170,7 +170,12 @@ class SlicedImage:
 class SliceImageResult:
     """Container for sliced image results."""
 
-    def __init__(self, original_image_size: list[int], image_dir: str | None = None) -> None:
+    def __init__(
+        self,
+        original_image_size: list[int],
+        image_dir: str | None = None,
+        original_image: np.ndarray | None = None,
+    ) -> None:
         """Initialize SliceImageResult.
 
         Args:
@@ -178,10 +183,15 @@ class SliceImageResult:
                 Directory of the sliced image exports.
             original_image_size: list of int
                 Size of the unsliced original image in [height, width].
+            original_image: np.ndarray, optional
+                The decoded source image. Every slice is a view into it, so it is
+                alive for as long as this result is; holding it lets callers reuse
+                the decode instead of reading the file again.
         """
         self.original_image_height = original_image_size[0]
         self.original_image_width = original_image_size[1]
         self.image_dir = image_dir
+        self.original_image = original_image
 
         self._sliced_image_list: list[SlicedImage] = []
 
@@ -376,7 +386,9 @@ def slice_image(
     n_ims = 0
 
     # init images and annotations lists
-    sliced_image_result = SliceImageResult(original_image_size=[image_height, image_width], image_dir=output_dir)
+    sliced_image_result = SliceImageResult(
+        original_image_size=[image_height, image_width], image_dir=output_dir, original_image=image_arr
+    )
 
     suffix = _slice_file_suffix(image, out_ext)
 

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -688,3 +688,39 @@ def test_video_prediction() -> None:
         name="exp",
         verbose=1,
     )
+
+
+def test_source_image_is_decoded_once_per_sliced_prediction(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A sliced run decodes the source file once, not once per result it builds.
+
+    Slicing already holds the decoded array and every slice is a view into it,
+    so the standard pass and both PredictionResults reuse it. Decoding a
+    gigapixel source four times is the cost this guards against.
+    """
+    import sahi.predict
+    import sahi.prediction
+    import sahi.slicing
+    from sahi.utils.cv import read_image_as_pil
+
+    decodes = []
+
+    def counting_read(image: Any, *args: Any, **kwargs: Any) -> Any:
+        # only a path or URL costs a decode; an array or PIL image is already open
+        if isinstance(image, str):
+            decodes.append(image)
+        return read_image_as_pil(image, *args, **kwargs)
+
+    for module in (sahi.slicing, sahi.predict, sahi.prediction):
+        monkeypatch.setattr(module, "read_image_as_pil", counting_read, raising=False)
+
+    model = UltralyticsDetectionModel(
+        model_path=UltralyticsConstants.YOLO11N_MODEL_PATH,
+        confidence_threshold=CONFIDENCE_THRESHOLD,
+        device=MODEL_DEVICE,
+        image_size=IMAGE_SIZE,
+    )
+    result = get_sliced_prediction("tests/data/small-vehicles1.jpeg", model, slice_height=256, slice_width=256)
+
+    assert len(decodes) == 1, f"expected a single decode, got {len(decodes)}: {decodes}"
+    # the size still comes back, and the pixels are still reachable on demand
+    assert (result.image_width, result.image_height) == result.image.size


### PR DESCRIPTION
A sliced run decoded the source file four times; reusing the decode slicing already holds cuts get_sliced_prediction roughly in half.