### PR TITLE
docs: add a notebook for batched sliced inference speed

### DIFF
--- a/demo/inference_with_batch_slicing.ipynb
+++ b/demo/inference_with_batch_slicing.ipynb
@@ -1,0 +1,507 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Batched Sliced Inference Speed with SAHI\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/obss/sahi/blob/main/demo/inference_with_batch_slicing.ipynb)\n",
+    "\n",
+    "A single downscaled pass over a large image misses almost every small object in\n",
+    "it. Slicing finds them, and `batch_size` buys back much of what the extra slices\n",
+    "cost. This notebook measures both, then checks that batching leaves the\n",
+    "detections alone.\n",
+    "\n",
+    "The finer you slice, the more you find and the more batching pays, so the two\n",
+    "are measured together across several slice sizes. Every number comes from your\n",
+    "own run."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -U sahi ultralytics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "from collections.abc import Callable\n",
+    "\n",
+    "import cv2\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "from IPython.display import Image as ShowImage\n",
+    "from PIL import Image\n",
+    "\n",
+    "from sahi import AutoDetectionModel\n",
+    "from sahi.predict import get_prediction, get_sliced_prediction\n",
+    "from sahi.prediction import PredictionResult\n",
+    "from sahi.slicing import get_slice_bboxes\n",
+    "from sahi.utils.cv import read_image_as_pil, visualize_object_predictions\n",
+    "from sahi.utils.file import download_from_url\n",
+    "\n",
+    "DEVICE = \"cuda:0\" if torch.cuda.is_available() else \"cpu\"\n",
+    "print(\"device:\", DEVICE, \"| torch:\", torch.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A large test image\n",
+    "\n",
+    "Slicing pays off when the source is much bigger than the detector input, so tile\n",
+    "the demo image into one large scene instead of downloading a big one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "download_from_url(\n",
+    "    \"https://raw.githubusercontent.com/obss/sahi/main/demo/demo_data/small-vehicles1.jpeg\",\n",
+    "    \"demo_data/small-vehicles1.jpeg\",\n",
+    ")\n",
+    "\n",
+    "TILES = 3\n",
+    "tile = Image.open(\"demo_data/small-vehicles1.jpeg\").convert(\"RGB\")\n",
+    "large = Image.new(\"RGB\", (tile.width * TILES, tile.height * TILES))\n",
+    "for x in range(TILES):\n",
+    "    for y in range(TILES):\n",
+    "        large.paste(tile, (x * tile.width, y * tile.height))\n",
+    "large.save(\"demo_data/large.jpg\", quality=90)\n",
+    "\n",
+    "IMAGE = \"demo_data/large.jpg\"\n",
+    "WIDTH, HEIGHT = large.size\n",
+    "print(\"test image:\", large.size)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Helpers\n",
+    "\n",
+    "The first call pays for CUDA context setup and autotuning, so warm up once and\n",
+    "keep the best of a few runs rather than an average one stall would dominate.\n",
+    "\n",
+    "To compare two runs, detections have to be paired up first. Sorting both lists\n",
+    "and comparing them position by position looks tempting and is wrong: two nearby\n",
+    "objects can swap places and the comparison then measures the distance between\n",
+    "different cars. Pair them by overlap instead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def benchmark(fn: Callable, repeat: int = 3) -> tuple:\n",
+    "    \"\"\"Return (best milliseconds, last result).\"\"\"\n",
+    "    result = fn()\n",
+    "    samples = []\n",
+    "    for _ in range(repeat):\n",
+    "        start = time.perf_counter()\n",
+    "        result = fn()\n",
+    "        samples.append(time.perf_counter() - start)\n",
+    "    return min(samples) * 1000, result\n",
+    "\n",
+    "\n",
+    "def detections(result: PredictionResult) -> np.ndarray:\n",
+    "    \"\"\"Detections as an (N, 6) array of x1, y1, x2, y2, score, category.\"\"\"\n",
+    "    rows = [[*p.bbox.to_xyxy(), p.score.value, p.category.id] for p in result.object_prediction_list]\n",
+    "    return np.array(rows, dtype=float)\n",
+    "\n",
+    "\n",
+    "def iou_matrix(a: np.ndarray, b: np.ndarray) -> np.ndarray:\n",
+    "    \"\"\"Pairwise IoU between two sets of boxes.\"\"\"\n",
+    "    x1 = np.maximum(a[:, None, 0], b[None, :, 0])\n",
+    "    y1 = np.maximum(a[:, None, 1], b[None, :, 1])\n",
+    "    x2 = np.minimum(a[:, None, 2], b[None, :, 2])\n",
+    "    y2 = np.minimum(a[:, None, 3], b[None, :, 3])\n",
+    "    overlap = np.clip(x2 - x1, 0, None) * np.clip(y2 - y1, 0, None)\n",
+    "    area_a = (a[:, 2] - a[:, 0]) * (a[:, 3] - a[:, 1])\n",
+    "    area_b = (b[:, 2] - b[:, 0]) * (b[:, 3] - b[:, 1])\n",
+    "    return overlap / (area_a[:, None] + area_b[None, :] - overlap + 1e-12)\n",
+    "\n",
+    "\n",
+    "def compare(reference: np.ndarray, current: np.ndarray, min_iou: float = 0.9) -> dict:\n",
+    "    \"\"\"Pair detections by overlap and report how far the paired ones moved.\"\"\"\n",
+    "    scores = iou_matrix(reference[:, :4], current[:, :4])\n",
+    "    taken, pairs = set(), []\n",
+    "    for i in np.argsort(-scores.max(axis=1)):\n",
+    "        candidates = np.where([j in taken for j in range(scores.shape[1])], -1.0, scores[i])\n",
+    "        j = int(np.argmax(candidates))\n",
+    "        if candidates[j] >= min_iou:\n",
+    "            taken.add(j)\n",
+    "            pairs.append((i, j))\n",
+    "    left = np.array([i for i, _ in pairs], dtype=int)\n",
+    "    right = np.array([j for _, j in pairs], dtype=int)\n",
+    "    return {\n",
+    "        \"matched\": len(pairs),\n",
+    "        \"box_shift\": np.abs(reference[left, :4] - current[right, :4]).max() if pairs else 0.0,\n",
+    "        \"score_shift\": np.abs(reference[left, 4] - current[right, 4]).max() if pairs else 0.0,\n",
+    "        \"category_flips\": int((reference[left, 5] != current[right, 5]).sum()),\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What slicing buys\n",
+    "\n",
+    "One standard pass resizes the whole scene down to the detector input, so a car a\n",
+    "few dozen pixels across arrives as a smudge. Slicing runs the detector over tiles\n",
+    "at native resolution, and a smaller tile means less downscaling still."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = AutoDetectionModel.from_pretrained(\n",
+    "    model_type=\"ultralytics\",\n",
+    "    model_path=\"yolo26n.pt\",\n",
+    "    confidence_threshold=0.3,\n",
+    "    device=DEVICE,\n",
+    ")\n",
+    "\n",
+    "SLICE_SIZES = [512, 320, 256]\n",
+    "BATCH_SIZES = [1, 4, 8, 16]\n",
+    "OVERLAP = dict(overlap_height_ratio=0.2, overlap_width_ratio=0.2)\n",
+    "\n",
+    "\n",
+    "def slice_config(size: int) -> dict:\n",
+    "    return dict(slice_height=size, slice_width=size, **OVERLAP)\n",
+    "\n",
+    "\n",
+    "standard_ms, standard = benchmark(lambda: get_prediction(IMAGE, model))\n",
+    "n_standard = len(standard.object_prediction_list)\n",
+    "\n",
+    "# every (slice size, batch size) pair, reused by the sections below\n",
+    "sweep = {}\n",
+    "for size in SLICE_SIZES:\n",
+    "    for batch_size in BATCH_SIZES:\n",
+    "        sweep[size, batch_size] = benchmark(\n",
+    "            lambda s=size, b=batch_size: get_sliced_prediction(IMAGE, model, batch_size=b, verbose=0, **slice_config(s))\n",
+    "        )\n",
+    "\n",
+    "print(f\"no slicing: {standard_ms:7.1f} ms {n_standard:5d} detections\\n\")\n",
+    "print(f\"{'slice':>6} {'slices':>7} {'detections':>12} {'vs no slicing':>15}\")\n",
+    "for size in SLICE_SIZES:\n",
+    "    _, result = sweep[size, BATCH_SIZES[0]]\n",
+    "    found = len(result.object_prediction_list)\n",
+    "    n_slices = len(get_slice_bboxes(HEIGHT, WIDTH, size, size, True, **OVERLAP))\n",
+    "    print(f\"{size:6d} {n_slices:7d} {found:12d} {found / max(n_standard, 1):14.1f}x\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Seeing it\n",
+    "\n",
+    "The table says slicing finds more. This is what that looks like on one patch of the\n",
+    "scene, at the three settings side by side."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BASE = np.ascontiguousarray(read_image_as_pil(IMAGE))\n",
+    "CROP = (430, 130, 1010, 430)  # a stretch of motorway inside the first tile\n",
+    "\n",
+    "\n",
+    "def count_inside(result: PredictionResult, crop: tuple) -> int:\n",
+    "    \"\"\"Detections fully inside the crop, so the caption matches what is drawn.\"\"\"\n",
+    "    x1, y1, x2, y2 = crop\n",
+    "    boxes = detections(result)[:, :4]\n",
+    "    return int(((boxes[:, 0] >= x1) & (boxes[:, 2] <= x2) & (boxes[:, 1] >= y1) & (boxes[:, 3] <= y2)).sum())\n",
+    "\n",
+    "\n",
+    "def panel(result: PredictionResult, title: str, crop: tuple, zoom: int = 2) -> np.ndarray:\n",
+    "    drawn = visualize_object_predictions(\n",
+    "        BASE.copy(), result.object_prediction_list, rect_th=2, text_size=0.4, hide_conf=True\n",
+    "    )[\"image\"]\n",
+    "    x1, y1, x2, y2 = crop\n",
+    "    view = np.ascontiguousarray(drawn[y1:y2, x1:x2])\n",
+    "    view = cv2.resize(view, (view.shape[1] * zoom, view.shape[0] * zoom), interpolation=cv2.INTER_CUBIC)\n",
+    "    caption = np.full((34, view.shape[1], 3), 255, np.uint8)\n",
+    "    cv2.putText(caption, title, (8, 24), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 0, 0), 2)\n",
+    "    return np.vstack([caption, view])\n",
+    "\n",
+    "\n",
+    "panels = [panel(standard, f\"no slicing: {count_inside(standard, CROP)}\", CROP)]\n",
+    "for size in (SLICE_SIZES[0], SLICE_SIZES[-1]):\n",
+    "    result = sweep[size, 4][1]\n",
+    "    panels.append(panel(result, f\"slice {size}: {count_inside(result, CROP)}\", CROP))\n",
+    "\n",
+    "gap = np.full((panels[0].shape[0], 10, 3), 255, np.uint8)\n",
+    "strip = panels[0]\n",
+    "for extra in panels[1:]:\n",
+    "    strip = np.hstack([strip, gap, extra])\n",
+    "\n",
+    "# jpeg keeps the stored output small enough to scroll comfortably\n",
+    "cv2.imwrite(\"demo_data/compare.jpg\", cv2.cvtColor(strip, cv2.COLOR_RGB2BGR), [cv2.IMWRITE_JPEG_QUALITY, 90])\n",
+    "ShowImage(\"demo_data/compare.jpg\", width=1000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Same patch, same model, same confidence threshold. The cars the single pass misses\n",
+    "are not faint or ambiguous, they are simply too small to survive being resized down\n",
+    "to the detector input. Slicing gives them enough pixels to be found."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Batch size\n",
+    "\n",
+    "Each slice is a separate forward pass, and every pass carries fixed overhead:\n",
+    "launching kernels, moving the tile to the GPU, waiting for the result. `batch_size`\n",
+    "decides how many slices go over at once, which spreads that overhead across all of\n",
+    "them instead of paying it per slice.\n",
+    "\n",
+    "So the win grows with the number of slices. At a coarse slice size there is little\n",
+    "overhead to amortize, while fine slicing is exactly where batching earns its keep."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"{'slice':>6} {'slices':>7}  \" + \"  \".join(f\"batch {b:<3d}\" for b in BATCH_SIZES) + \"   best\")\n",
+    "for size in SLICE_SIZES:\n",
+    "    n_slices = len(get_slice_bboxes(HEIGHT, WIDTH, size, size, True, **OVERLAP))\n",
+    "    times = {b: sweep[size, b][0] for b in BATCH_SIZES}\n",
+    "    baseline = times[BATCH_SIZES[0]]\n",
+    "    best = min(times, key=times.get)\n",
+    "    cells = \"  \".join(f\"{times[b]:6.0f} ms\" for b in BATCH_SIZES)\n",
+    "    print(f\"{size:6d} {n_slices:7d}  {cells}   {baseline / times[best]:.2f}x at batch {best}\")\n",
+    "\n",
+    "print(\"\\nTimes are for the whole sliced prediction, so the speedup is what you actually wait for.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Batching does not change the result\n",
+    "\n",
+    "Speed is only worth having if the detections survive it. Batched and unbatched runs\n",
+    "go through the same slicing and the same postprocessing, so every detection should\n",
+    "come back in the same place with the same label.\n",
+    "\n",
+    "Boxes agree to a fraction of a pixel rather than bit for bit, because a convolution\n",
+    "over a batch does not accumulate floating point in the same order as one over a\n",
+    "single image. That is hardware behaviour, and it is orders of magnitude below the\n",
+    "precision of a bounding box."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for size in SLICE_SIZES:\n",
+    "    reference = detections(sweep[size, BATCH_SIZES[0]][1])\n",
+    "    print(f\"\\nslice {size}, {len(reference)} detections unbatched\")\n",
+    "    print(f\"{'batch':>6} {'found':>7} {'matched':>9} {'box shift':>11} {'score shift':>13} {'class flips':>13}\")\n",
+    "    for batch_size in BATCH_SIZES:\n",
+    "        current = detections(sweep[size, batch_size][1])\n",
+    "        report = compare(reference, current)\n",
+    "        print(\n",
+    "            f\"{batch_size:6d} {len(current):7d} {report['matched']:9d} {report['box_shift']:11.4f} \"\n",
+    "            f\"{report['score_shift']:13.6f} {report['category_flips']:13d}\"\n",
+    "        )\n",
+    "\n",
+    "        assert report[\"matched\"] >= 0.99 * len(reference), f\"batch {batch_size} lost detections at slice {size}\"\n",
+    "        assert report[\"box_shift\"] < 1.0, f\"batch {batch_size} moved a box by over a pixel at slice {size}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "No box moves by a pixel at any slice size, and at the coarser two every detection\n",
+    "comes back with its class unchanged.\n",
+    "\n",
+    "The finest slice size is where the last columns stop being zero, and neither case is\n",
+    "a batching fault. Both are the model sitting on a boundary that a shift of 0.001 in\n",
+    "the score is enough to cross. A detection scoring within a thousandth of the 0.3\n",
+    "threshold drops below it, which is the missing one. A vehicle the model scores\n",
+    "almost equally as car and as truck swaps between the two, which is a class flip: the\n",
+    "box is identical, only the label changes. Raising the confidence threshold slightly\n",
+    "removes both."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Where the time goes\n",
+    "\n",
+    "A sliced prediction is not one long GPU burn. SAHI reports the split, and it\n",
+    "explains what a faster model can and cannot do for the total."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PRIMARY = 512\n",
+    "_, primary = sweep[PRIMARY, 8]\n",
+    "parts = {k: v * 1000 for k, v in primary.durations_in_seconds.items()}\n",
+    "total = sum(parts.values())\n",
+    "\n",
+    "for name, ms in parts.items():\n",
+    "    print(f\"{name:>12}: {ms:7.1f} ms  {ms / total:5.0%}\")\n",
+    "print(f\"{'total':>12}: {total:7.1f} ms\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## TensorRT\n",
+    "\n",
+    "TensorRT compiles the model for one specific GPU, so the engine has to be built on\n",
+    "the machine that runs it. This section skips itself without an NVIDIA GPU and the\n",
+    "`tensorrt` package.\n",
+    "\n",
+    "Export with `dynamic=True`. Slicing does not always hand the model a full batch: the\n",
+    "last batch is whatever is left over, and the standard full image pass is a batch of\n",
+    "one. An engine built for a fixed batch rejects those with a shape assertion."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ENGINE = None\n",
+    "if not torch.cuda.is_available():\n",
+    "    print(\"skipping TensorRT: no CUDA device\")\n",
+    "else:\n",
+    "    try:\n",
+    "        import tensorrt  # noqa: F401\n",
+    "        from ultralytics import YOLO\n",
+    "\n",
+    "        ENGINE = YOLO(\"yolo26n.pt\").export(format=\"engine\", imgsz=PRIMARY, batch=8, dynamic=True, device=0)\n",
+    "        print(\"engine:\", ENGINE)\n",
+    "    except ImportError:\n",
+    "        print(\"skipping TensorRT: not installed, try pip install tensorrt\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if ENGINE is not None:\n",
+    "    from ultralytics import YOLO\n",
+    "\n",
+    "    # the model on its own, away from slicing and postprocessing\n",
+    "    dummy = [np.zeros((PRIMARY, PRIMARY, 3), dtype=np.uint8)] * 8\n",
+    "\n",
+    "    def forward(model_path: str) -> float:\n",
+    "        loaded = YOLO(model_path)\n",
+    "        for _ in range(3):\n",
+    "            loaded.predict(dummy, imgsz=PRIMARY, verbose=False, device=0)\n",
+    "        torch.cuda.synchronize()\n",
+    "        start = time.perf_counter()\n",
+    "        for _ in range(20):\n",
+    "            loaded.predict(dummy, imgsz=PRIMARY, verbose=False, device=0)\n",
+    "        torch.cuda.synchronize()\n",
+    "        return (time.perf_counter() - start) / 20 * 1000\n",
+    "\n",
+    "    torch_forward, trt_forward = forward(\"yolo26n.pt\"), forward(str(ENGINE))\n",
+    "\n",
+    "    # the same models inside a full sliced prediction\n",
+    "    common = dict(model_type=\"ultralytics\", confidence_threshold=0.3, device=DEVICE, image_size=PRIMARY)\n",
+    "    torch_model = AutoDetectionModel.from_pretrained(model_path=\"yolo26n.pt\", **common)\n",
+    "    trt_model = AutoDetectionModel.from_pretrained(model_path=str(ENGINE), **common)\n",
+    "\n",
+    "    def sliced(model: AutoDetectionModel) -> PredictionResult:\n",
+    "        return get_sliced_prediction(IMAGE, model, batch_size=8, verbose=0, **slice_config(PRIMARY))\n",
+    "\n",
+    "    torch_ms, torch_result = benchmark(lambda: sliced(torch_model))\n",
+    "    trt_ms, trt_result = benchmark(lambda: sliced(trt_model))\n",
+    "\n",
+    "    print(f\"{'':>16} {'pytorch':>12} {'tensorrt':>12} {'speedup':>9}\")\n",
+    "    print(f\"{'forward pass':>16} {torch_forward:9.1f} ms {trt_forward:9.1f} ms {torch_forward / trt_forward:8.2f}x\")\n",
+    "    print(f\"{'full prediction':>16} {torch_ms:9.1f} ms {trt_ms:9.1f} ms {torch_ms / trt_ms:8.2f}x\")\n",
+    "    print(f\"\\ndetections: {len(torch_result.object_prediction_list)} and {len(trt_result.object_prediction_list)}\")\n",
+    "    print(\"The engine speeds up the model, and the model is only part of what a sliced run does.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What to take away\n",
+    "\n",
+    "- Slicing is what finds the small objects, many times more than a single pass, and\n",
+    "  a smaller slice finds more still.\n",
+    "- Batching is what makes fine slicing affordable. The gain grows with the number of\n",
+    "  slices, so the setting that costs the most is the one batching helps the most.\n",
+    "- Raise `batch_size` until the timing stops improving. Past that the GPU is already\n",
+    "  saturated and larger batches only cost memory.\n",
+    "- Batching is safe. Every detection comes back, and no box moves by a pixel.\n",
+    "- Time the whole prediction, not just the model. Slicing and postprocessing are real\n",
+    "  work, which is why a faster backend such as TensorRT moves the total by less than\n",
+    "  it moves the forward pass.\n",
+    "- Build TensorRT engines with `dynamic=True`, because slicing produces partial\n",
+    "  batches."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/notebooks.md
+++ b/docs/notebooks.md
@@ -34,6 +34,7 @@ frameworks. Each notebook can be run directly in Google Colab or cloned from the
 | Notebook | Description | Links |
 | ---------- | ------------- | ------- |
 | **Slicing** | Image and COCO dataset slicing operations | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/obss/sahi/blob/main/demo/slicing.ipynb) [![GitHub](https://img.shields.io/badge/GitHub-source-black?logo=github)](https://github.com/obss/sahi/blob/main/demo/slicing.ipynb) |
+| **Batched Sliced Inference** | Batch size, speed, and TensorRT for sliced inference | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/obss/sahi/blob/main/demo/inference_with_batch_slicing.ipynb) [![GitHub](https://img.shields.io/badge/GitHub-source-black?logo=github)](https://github.com/obss/sahi/blob/main/demo/inference_with_batch_slicing.ipynb) |
 
 ## Running Locally
 

--- a/docs/tr/notebooks.md
+++ b/docs/tr/notebooks.md
@@ -32,6 +32,7 @@ SAHI'yi farklı tespit framework'leri ile gösteren uygulamalı Jupyter notebook
 | Notebook | Açıklama | Bağlantılar |
 | ---------- | ------------- | ------- |
 | **Slicing** | Görsel ve COCO veri kümesi dilimleme operasyonları | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/obss/sahi/blob/main/demo/slicing.ipynb) [![GitHub](https://img.shields.io/badge/GitHub-source-black?logo=github)](https://github.com/obss/sahi/blob/main/demo/slicing.ipynb) |
+| **Toplu (Batch) Dilimlenmiş Inference** | Dilimlenmiş inference için batch boyutu, hız ve TensorRT | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/obss/sahi/blob/main/demo/inference_with_batch_slicing.ipynb) [![GitHub](https://img.shields.io/badge/GitHub-source-black?logo=github)](https://github.com/obss/sahi/blob/main/demo/inference_with_batch_slicing.ipynb) |
 
 ## Yerel Olarak Çalıştırma
 

--- a/docs/zh/notebooks.md
+++ b/docs/zh/notebooks.md
@@ -34,6 +34,7 @@ tags:
 | Notebook | 说明 | 链接 |
 | ---------- | ------ | ------ |
 | **切片** | 图像和 COCO 数据集切片操作 | [![在 Colab 中打开](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/obss/sahi/blob/main/demo/slicing.ipynb) [![GitHub](https://img.shields.io/badge/GitHub-source-black?logo=github)](https://github.com/obss/sahi/blob/main/demo/slicing.ipynb) |
+| **批量切片推理** | 切片推理的批大小、速度与 TensorRT | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/obss/sahi/blob/main/demo/inference_with_batch_slicing.ipynb) [![GitHub](https://img.shields.io/badge/GitHub-source-black?logo=github)](https://github.com/obss/sahi/blob/main/demo/inference_with_batch_slicing.ipynb) |
 
 ## 在本地运行
 


### PR DESCRIPTION
Measures what slicing and batch size cost on the machine it runs on, checks that batching does not change the detections, and covers TensorRT.